### PR TITLE
Add tests to cover all scenarios between wa and de

### DIFF
--- a/bot/tests/simpleCalc/__snapshots__/de-vs-de.test.js.snap
+++ b/bot/tests/simpleCalc/__snapshots__/de-vs-de.test.js.snap
@@ -1,0 +1,55001 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`de b 1, de d 1 1`] = `
+{
+  "_cmd": "de b 1, de d 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b 1, de d 2 1`] = `
+{
+  "_cmd": "de b 1, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, de d 3 1`] = `
+{
+  "_cmd": "de b 1, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, de d 4 1`] = `
+{
+  "_cmd": "de b 1, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de d 5 1`] = `
+{
+  "_cmd": "de b 1, de d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de d 6 1`] = `
+{
+  "_cmd": "de b 1, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de d 7 1`] = `
+{
+  "_cmd": "de b 1, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de d 8 1`] = `
+{
+  "_cmd": "de b 1, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, de d 9 1`] = `
+{
+  "_cmd": "de b 1, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de d 10 1`] = `
+{
+  "_cmd": "de b 1, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de d 11 1`] = `
+{
+  "_cmd": "de b 1, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de d 12 1`] = `
+{
+  "_cmd": "de b 1, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de d 13 1`] = `
+{
+  "_cmd": "de b 1, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de d 14 1`] = `
+{
+  "_cmd": "de b 1, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de d 15 1`] = `
+{
+  "_cmd": "de b 1, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de d v 1 1`] = `
+{
+  "_cmd": "de b 1, de d v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b 1, de d v 2 1`] = `
+{
+  "_cmd": "de b 1, de d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, de d v 3 1`] = `
+{
+  "_cmd": "de b 1, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, de d v 4 1`] = `
+{
+  "_cmd": "de b 1, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de d v 5 1`] = `
+{
+  "_cmd": "de b 1, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de d v 6 1`] = `
+{
+  "_cmd": "de b 1, de d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de d v 7 1`] = `
+{
+  "_cmd": "de b 1, de d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de d v 8 1`] = `
+{
+  "_cmd": "de b 1, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, de d v 9 1`] = `
+{
+  "_cmd": "de b 1, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de d v 10 1`] = `
+{
+  "_cmd": "de b 1, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de d v 11 1`] = `
+{
+  "_cmd": "de b 1, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de d v 12 1`] = `
+{
+  "_cmd": "de b 1, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de d v 13 1`] = `
+{
+  "_cmd": "de b 1, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de d v 14 1`] = `
+{
+  "_cmd": "de b 1, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de d v 15 1`] = `
+{
+  "_cmd": "de b 1, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de d v 16 1`] = `
+{
+  "_cmd": "de b 1, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 1, de d v 17 1`] = `
+{
+  "_cmd": "de b 1, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 1, de d v 18 1`] = `
+{
+  "_cmd": "de b 1, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 1, de d v 19 1`] = `
+{
+  "_cmd": "de b 1, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 1, de d v 20 1`] = `
+{
+  "_cmd": "de b 1, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 1, de p 1 1`] = `
+{
+  "_cmd": "de b 1, de p 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, de p 2 1`] = `
+{
+  "_cmd": "de b 1, de p 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, de p 3 1`] = `
+{
+  "_cmd": "de b 1, de p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, de p 4 1`] = `
+{
+  "_cmd": "de b 1, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de p 5 1`] = `
+{
+  "_cmd": "de b 1, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de p 6 1`] = `
+{
+  "_cmd": "de b 1, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de p 7 1`] = `
+{
+  "_cmd": "de b 1, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de p 8 1`] = `
+{
+  "_cmd": "de b 1, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de p 9 1`] = `
+{
+  "_cmd": "de b 1, de p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de p 10 1`] = `
+{
+  "_cmd": "de b 1, de p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de p 11 1`] = `
+{
+  "_cmd": "de b 1, de p 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de p 12 1`] = `
+{
+  "_cmd": "de b 1, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de p 13 1`] = `
+{
+  "_cmd": "de b 1, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de p 14 1`] = `
+{
+  "_cmd": "de b 1, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de p 15 1`] = `
+{
+  "_cmd": "de b 1, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de p v 1 1`] = `
+{
+  "_cmd": "de b 1, de p v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, de p v 2 1`] = `
+{
+  "_cmd": "de b 1, de p v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, de p v 3 1`] = `
+{
+  "_cmd": "de b 1, de p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, de p v 4 1`] = `
+{
+  "_cmd": "de b 1, de p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de p v 5 1`] = `
+{
+  "_cmd": "de b 1, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de p v 6 1`] = `
+{
+  "_cmd": "de b 1, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de p v 7 1`] = `
+{
+  "_cmd": "de b 1, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de p v 8 1`] = `
+{
+  "_cmd": "de b 1, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de p v 9 1`] = `
+{
+  "_cmd": "de b 1, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, de p v 10 1`] = `
+{
+  "_cmd": "de b 1, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de p v 11 1`] = `
+{
+  "_cmd": "de b 1, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de p v 12 1`] = `
+{
+  "_cmd": "de b 1, de p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de p v 13 1`] = `
+{
+  "_cmd": "de b 1, de p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de p v 14 1`] = `
+{
+  "_cmd": "de b 1, de p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de p v 15 1`] = `
+{
+  "_cmd": "de b 1, de p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de p v 16 1`] = `
+{
+  "_cmd": "de b 1, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 1, de p v 17 1`] = `
+{
+  "_cmd": "de b 1, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 1, de p v 18 1`] = `
+{
+  "_cmd": "de b 1, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 1, de p v 19 1`] = `
+{
+  "_cmd": "de b 1, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 1, de p v 20 1`] = `
+{
+  "_cmd": "de b 1, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 1, de v 1 1`] = `
+{
+  "_cmd": "de b 1, de v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, de v 2 1`] = `
+{
+  "_cmd": "de b 1, de v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, de v 3 1`] = `
+{
+  "_cmd": "de b 1, de v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, de v 4 1`] = `
+{
+  "_cmd": "de b 1, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de v 5 1`] = `
+{
+  "_cmd": "de b 1, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de v 6 1`] = `
+{
+  "_cmd": "de b 1, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de v 7 1`] = `
+{
+  "_cmd": "de b 1, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de v 8 1`] = `
+{
+  "_cmd": "de b 1, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de v 9 1`] = `
+{
+  "_cmd": "de b 1, de v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de v 10 1`] = `
+{
+  "_cmd": "de b 1, de v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de v 11 1`] = `
+{
+  "_cmd": "de b 1, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de v 12 1`] = `
+{
+  "_cmd": "de b 1, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de v 13 1`] = `
+{
+  "_cmd": "de b 1, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de v 14 1`] = `
+{
+  "_cmd": "de b 1, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de v 15 1`] = `
+{
+  "_cmd": "de b 1, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de v 16 1`] = `
+{
+  "_cmd": "de b 1, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 1, de v 17 1`] = `
+{
+  "_cmd": "de b 1, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 1, de v 18 1`] = `
+{
+  "_cmd": "de b 1, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 1, de v 19 1`] = `
+{
+  "_cmd": "de b 1, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 1, de v 20 1`] = `
+{
+  "_cmd": "de b 1, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 1, de w 1 1`] = `
+{
+  "_cmd": "de b 1, de w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, de w 2 1`] = `
+{
+  "_cmd": "de b 1, de w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, de w 3 1`] = `
+{
+  "_cmd": "de b 1, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de w 4 1`] = `
+{
+  "_cmd": "de b 1, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de w 5 1`] = `
+{
+  "_cmd": "de b 1, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de w 6 1`] = `
+{
+  "_cmd": "de b 1, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de w 7 1`] = `
+{
+  "_cmd": "de b 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de w 8 1`] = `
+{
+  "_cmd": "de b 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, de w 9 1`] = `
+{
+  "_cmd": "de b 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de w 10 1`] = `
+{
+  "_cmd": "de b 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de w 11 1`] = `
+{
+  "_cmd": "de b 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de w 12 1`] = `
+{
+  "_cmd": "de b 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de w 13 1`] = `
+{
+  "_cmd": "de b 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de w 14 1`] = `
+{
+  "_cmd": "de b 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de w 15 1`] = `
+{
+  "_cmd": "de b 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de w v 1 1`] = `
+{
+  "_cmd": "de b 1, de w v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, de w v 2 1`] = `
+{
+  "_cmd": "de b 1, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, de w v 3 1`] = `
+{
+  "_cmd": "de b 1, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, de w v 4 1`] = `
+{
+  "_cmd": "de b 1, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, de w v 5 1`] = `
+{
+  "_cmd": "de b 1, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, de w v 6 1`] = `
+{
+  "_cmd": "de b 1, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, de w v 7 1`] = `
+{
+  "_cmd": "de b 1, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, de w v 8 1`] = `
+{
+  "_cmd": "de b 1, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, de w v 9 1`] = `
+{
+  "_cmd": "de b 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, de w v 10 1`] = `
+{
+  "_cmd": "de b 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, de w v 11 1`] = `
+{
+  "_cmd": "de b 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, de w v 12 1`] = `
+{
+  "_cmd": "de b 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, de w v 13 1`] = `
+{
+  "_cmd": "de b 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, de w v 14 1`] = `
+{
+  "_cmd": "de b 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, de w v 15 1`] = `
+{
+  "_cmd": "de b 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, de w v 16 1`] = `
+{
+  "_cmd": "de b 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 1, de w v 17 1`] = `
+{
+  "_cmd": "de b 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 1, de w v 18 1`] = `
+{
+  "_cmd": "de b 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 1, de w v 19 1`] = `
+{
+  "_cmd": "de b 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 1, de w v 20 1`] = `
+{
+  "_cmd": "de b 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 2, de d 1 1`] = `
+{
+  "_cmd": "de b 2, de d 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b 2, de d 2 1`] = `
+{
+  "_cmd": "de b 2, de d 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, de d 3 1`] = `
+{
+  "_cmd": "de b 2, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de d 4 1`] = `
+{
+  "_cmd": "de b 2, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, de d 5 1`] = `
+{
+  "_cmd": "de b 2, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, de d 6 1`] = `
+{
+  "_cmd": "de b 2, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de d 7 1`] = `
+{
+  "_cmd": "de b 2, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de d 8 1`] = `
+{
+  "_cmd": "de b 2, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de d 9 1`] = `
+{
+  "_cmd": "de b 2, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de d 10 1`] = `
+{
+  "_cmd": "de b 2, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de d 11 1`] = `
+{
+  "_cmd": "de b 2, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de d 12 1`] = `
+{
+  "_cmd": "de b 2, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de d 13 1`] = `
+{
+  "_cmd": "de b 2, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de d 14 1`] = `
+{
+  "_cmd": "de b 2, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de d 15 1`] = `
+{
+  "_cmd": "de b 2, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de d v 1 1`] = `
+{
+  "_cmd": "de b 2, de d v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b 2, de d v 2 1`] = `
+{
+  "_cmd": "de b 2, de d v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, de d v 3 1`] = `
+{
+  "_cmd": "de b 2, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, de d v 4 1`] = `
+{
+  "_cmd": "de b 2, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, de d v 5 1`] = `
+{
+  "_cmd": "de b 2, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, de d v 6 1`] = `
+{
+  "_cmd": "de b 2, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de d v 7 1`] = `
+{
+  "_cmd": "de b 2, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de d v 8 1`] = `
+{
+  "_cmd": "de b 2, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de d v 9 1`] = `
+{
+  "_cmd": "de b 2, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de d v 10 1`] = `
+{
+  "_cmd": "de b 2, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de d v 11 1`] = `
+{
+  "_cmd": "de b 2, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de d v 12 1`] = `
+{
+  "_cmd": "de b 2, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de d v 13 1`] = `
+{
+  "_cmd": "de b 2, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de d v 14 1`] = `
+{
+  "_cmd": "de b 2, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de d v 15 1`] = `
+{
+  "_cmd": "de b 2, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de d v 16 1`] = `
+{
+  "_cmd": "de b 2, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 2, de d v 17 1`] = `
+{
+  "_cmd": "de b 2, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 2, de d v 18 1`] = `
+{
+  "_cmd": "de b 2, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 2, de d v 19 1`] = `
+{
+  "_cmd": "de b 2, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 2, de d v 20 1`] = `
+{
+  "_cmd": "de b 2, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 2, de p 1 1`] = `
+{
+  "_cmd": "de b 2, de p 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b 2, de p 2 1`] = `
+{
+  "_cmd": "de b 2, de p 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, de p 3 1`] = `
+{
+  "_cmd": "de b 2, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, de p 4 1`] = `
+{
+  "_cmd": "de b 2, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de p 5 1`] = `
+{
+  "_cmd": "de b 2, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, de p 6 1`] = `
+{
+  "_cmd": "de b 2, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de p 7 1`] = `
+{
+  "_cmd": "de b 2, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de p 8 1`] = `
+{
+  "_cmd": "de b 2, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de p 9 1`] = `
+{
+  "_cmd": "de b 2, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de p 10 1`] = `
+{
+  "_cmd": "de b 2, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de p 11 1`] = `
+{
+  "_cmd": "de b 2, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de p 12 1`] = `
+{
+  "_cmd": "de b 2, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de p 13 1`] = `
+{
+  "_cmd": "de b 2, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de p 14 1`] = `
+{
+  "_cmd": "de b 2, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de p 15 1`] = `
+{
+  "_cmd": "de b 2, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de p v 1 1`] = `
+{
+  "_cmd": "de b 2, de p v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b 2, de p v 2 1`] = `
+{
+  "_cmd": "de b 2, de p v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, de p v 3 1`] = `
+{
+  "_cmd": "de b 2, de p v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, de p v 4 1`] = `
+{
+  "_cmd": "de b 2, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de p v 5 1`] = `
+{
+  "_cmd": "de b 2, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, de p v 6 1`] = `
+{
+  "_cmd": "de b 2, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, de p v 7 1`] = `
+{
+  "_cmd": "de b 2, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de p v 8 1`] = `
+{
+  "_cmd": "de b 2, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de p v 9 1`] = `
+{
+  "_cmd": "de b 2, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de p v 10 1`] = `
+{
+  "_cmd": "de b 2, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de p v 11 1`] = `
+{
+  "_cmd": "de b 2, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de p v 12 1`] = `
+{
+  "_cmd": "de b 2, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de p v 13 1`] = `
+{
+  "_cmd": "de b 2, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de p v 14 1`] = `
+{
+  "_cmd": "de b 2, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de p v 15 1`] = `
+{
+  "_cmd": "de b 2, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de p v 16 1`] = `
+{
+  "_cmd": "de b 2, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de p v 17 1`] = `
+{
+  "_cmd": "de b 2, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 2, de p v 18 1`] = `
+{
+  "_cmd": "de b 2, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 2, de p v 19 1`] = `
+{
+  "_cmd": "de b 2, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 2, de p v 20 1`] = `
+{
+  "_cmd": "de b 2, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 2, de v 1 1`] = `
+{
+  "_cmd": "de b 2, de v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b 2, de v 2 1`] = `
+{
+  "_cmd": "de b 2, de v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, de v 3 1`] = `
+{
+  "_cmd": "de b 2, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, de v 4 1`] = `
+{
+  "_cmd": "de b 2, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de v 5 1`] = `
+{
+  "_cmd": "de b 2, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, de v 6 1`] = `
+{
+  "_cmd": "de b 2, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de v 7 1`] = `
+{
+  "_cmd": "de b 2, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de v 8 1`] = `
+{
+  "_cmd": "de b 2, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de v 9 1`] = `
+{
+  "_cmd": "de b 2, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de v 10 1`] = `
+{
+  "_cmd": "de b 2, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de v 11 1`] = `
+{
+  "_cmd": "de b 2, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de v 12 1`] = `
+{
+  "_cmd": "de b 2, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de v 13 1`] = `
+{
+  "_cmd": "de b 2, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de v 14 1`] = `
+{
+  "_cmd": "de b 2, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de v 15 1`] = `
+{
+  "_cmd": "de b 2, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de v 16 1`] = `
+{
+  "_cmd": "de b 2, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de v 17 1`] = `
+{
+  "_cmd": "de b 2, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 2, de v 18 1`] = `
+{
+  "_cmd": "de b 2, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 2, de v 19 1`] = `
+{
+  "_cmd": "de b 2, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 2, de v 20 1`] = `
+{
+  "_cmd": "de b 2, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 2, de w 1 1`] = `
+{
+  "_cmd": "de b 2, de w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, de w 2 1`] = `
+{
+  "_cmd": "de b 2, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, de w 3 1`] = `
+{
+  "_cmd": "de b 2, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de w 4 1`] = `
+{
+  "_cmd": "de b 2, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, de w 5 1`] = `
+{
+  "_cmd": "de b 2, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de w 6 1`] = `
+{
+  "_cmd": "de b 2, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de w 7 1`] = `
+{
+  "_cmd": "de b 2, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de w 8 1`] = `
+{
+  "_cmd": "de b 2, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de w 9 1`] = `
+{
+  "_cmd": "de b 2, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de w 10 1`] = `
+{
+  "_cmd": "de b 2, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de w 11 1`] = `
+{
+  "_cmd": "de b 2, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de w 12 1`] = `
+{
+  "_cmd": "de b 2, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de w 13 1`] = `
+{
+  "_cmd": "de b 2, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de w 14 1`] = `
+{
+  "_cmd": "de b 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de w 15 1`] = `
+{
+  "_cmd": "de b 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de w v 1 1`] = `
+{
+  "_cmd": "de b 2, de w v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, de w v 2 1`] = `
+{
+  "_cmd": "de b 2, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, de w v 3 1`] = `
+{
+  "_cmd": "de b 2, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, de w v 4 1`] = `
+{
+  "_cmd": "de b 2, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, de w v 5 1`] = `
+{
+  "_cmd": "de b 2, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, de w v 6 1`] = `
+{
+  "_cmd": "de b 2, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, de w v 7 1`] = `
+{
+  "_cmd": "de b 2, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, de w v 8 1`] = `
+{
+  "_cmd": "de b 2, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, de w v 9 1`] = `
+{
+  "_cmd": "de b 2, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, de w v 10 1`] = `
+{
+  "_cmd": "de b 2, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, de w v 11 1`] = `
+{
+  "_cmd": "de b 2, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, de w v 12 1`] = `
+{
+  "_cmd": "de b 2, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, de w v 13 1`] = `
+{
+  "_cmd": "de b 2, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, de w v 14 1`] = `
+{
+  "_cmd": "de b 2, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, de w v 15 1`] = `
+{
+  "_cmd": "de b 2, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, de w v 16 1`] = `
+{
+  "_cmd": "de b 2, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 2, de w v 17 1`] = `
+{
+  "_cmd": "de b 2, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 2, de w v 18 1`] = `
+{
+  "_cmd": "de b 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 2, de w v 19 1`] = `
+{
+  "_cmd": "de b 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 2, de w v 20 1`] = `
+{
+  "_cmd": "de b 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 3, de d 1 1`] = `
+{
+  "_cmd": "de b 3, de d 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b 3, de d 2 1`] = `
+{
+  "_cmd": "de b 3, de d 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, de d 3 1`] = `
+{
+  "_cmd": "de b 3, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, de d 4 1`] = `
+{
+  "_cmd": "de b 3, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de d 5 1`] = `
+{
+  "_cmd": "de b 3, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de d 6 1`] = `
+{
+  "_cmd": "de b 3, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de d 7 1`] = `
+{
+  "_cmd": "de b 3, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, de d 8 1`] = `
+{
+  "_cmd": "de b 3, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de d 9 1`] = `
+{
+  "_cmd": "de b 3, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de d 10 1`] = `
+{
+  "_cmd": "de b 3, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de d 11 1`] = `
+{
+  "_cmd": "de b 3, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de d 12 1`] = `
+{
+  "_cmd": "de b 3, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de d 13 1`] = `
+{
+  "_cmd": "de b 3, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de d 14 1`] = `
+{
+  "_cmd": "de b 3, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de d 15 1`] = `
+{
+  "_cmd": "de b 3, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de d v 1 1`] = `
+{
+  "_cmd": "de b 3, de d v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b 3, de d v 2 1`] = `
+{
+  "_cmd": "de b 3, de d v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, de d v 3 1`] = `
+{
+  "_cmd": "de b 3, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, de d v 4 1`] = `
+{
+  "_cmd": "de b 3, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, de d v 5 1`] = `
+{
+  "_cmd": "de b 3, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de d v 6 1`] = `
+{
+  "_cmd": "de b 3, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de d v 7 1`] = `
+{
+  "_cmd": "de b 3, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, de d v 8 1`] = `
+{
+  "_cmd": "de b 3, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de d v 9 1`] = `
+{
+  "_cmd": "de b 3, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de d v 10 1`] = `
+{
+  "_cmd": "de b 3, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de d v 11 1`] = `
+{
+  "_cmd": "de b 3, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de d v 12 1`] = `
+{
+  "_cmd": "de b 3, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de d v 13 1`] = `
+{
+  "_cmd": "de b 3, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de d v 14 1`] = `
+{
+  "_cmd": "de b 3, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de d v 15 1`] = `
+{
+  "_cmd": "de b 3, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de d v 16 1`] = `
+{
+  "_cmd": "de b 3, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de d v 17 1`] = `
+{
+  "_cmd": "de b 3, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 3, de d v 18 1`] = `
+{
+  "_cmd": "de b 3, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 3, de d v 19 1`] = `
+{
+  "_cmd": "de b 3, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 3, de d v 20 1`] = `
+{
+  "_cmd": "de b 3, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 3, de p 1 1`] = `
+{
+  "_cmd": "de b 3, de p 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, de p 2 1`] = `
+{
+  "_cmd": "de b 3, de p 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, de p 3 1`] = `
+{
+  "_cmd": "de b 3, de p 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, de p 4 1`] = `
+{
+  "_cmd": "de b 3, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, de p 5 1`] = `
+{
+  "_cmd": "de b 3, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de p 6 1`] = `
+{
+  "_cmd": "de b 3, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de p 7 1`] = `
+{
+  "_cmd": "de b 3, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de p 8 1`] = `
+{
+  "_cmd": "de b 3, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de p 9 1`] = `
+{
+  "_cmd": "de b 3, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de p 10 1`] = `
+{
+  "_cmd": "de b 3, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de p 11 1`] = `
+{
+  "_cmd": "de b 3, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de p 12 1`] = `
+{
+  "_cmd": "de b 3, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de p 13 1`] = `
+{
+  "_cmd": "de b 3, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de p 14 1`] = `
+{
+  "_cmd": "de b 3, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de p 15 1`] = `
+{
+  "_cmd": "de b 3, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de p v 1 1`] = `
+{
+  "_cmd": "de b 3, de p v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, de p v 2 1`] = `
+{
+  "_cmd": "de b 3, de p v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b 3, de p v 3 1`] = `
+{
+  "_cmd": "de b 3, de p v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, de p v 4 1`] = `
+{
+  "_cmd": "de b 3, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, de p v 5 1`] = `
+{
+  "_cmd": "de b 3, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de p v 6 1`] = `
+{
+  "_cmd": "de b 3, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de p v 7 1`] = `
+{
+  "_cmd": "de b 3, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de p v 8 1`] = `
+{
+  "_cmd": "de b 3, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, de p v 9 1`] = `
+{
+  "_cmd": "de b 3, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de p v 10 1`] = `
+{
+  "_cmd": "de b 3, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de p v 11 1`] = `
+{
+  "_cmd": "de b 3, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de p v 12 1`] = `
+{
+  "_cmd": "de b 3, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de p v 13 1`] = `
+{
+  "_cmd": "de b 3, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de p v 14 1`] = `
+{
+  "_cmd": "de b 3, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de p v 15 1`] = `
+{
+  "_cmd": "de b 3, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de p v 16 1`] = `
+{
+  "_cmd": "de b 3, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de p v 17 1`] = `
+{
+  "_cmd": "de b 3, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 3, de p v 18 1`] = `
+{
+  "_cmd": "de b 3, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 3, de p v 19 1`] = `
+{
+  "_cmd": "de b 3, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 3, de p v 20 1`] = `
+{
+  "_cmd": "de b 3, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 3, de v 1 1`] = `
+{
+  "_cmd": "de b 3, de v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, de v 2 1`] = `
+{
+  "_cmd": "de b 3, de v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, de v 3 1`] = `
+{
+  "_cmd": "de b 3, de v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, de v 4 1`] = `
+{
+  "_cmd": "de b 3, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, de v 5 1`] = `
+{
+  "_cmd": "de b 3, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de v 6 1`] = `
+{
+  "_cmd": "de b 3, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de v 7 1`] = `
+{
+  "_cmd": "de b 3, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de v 8 1`] = `
+{
+  "_cmd": "de b 3, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de v 9 1`] = `
+{
+  "_cmd": "de b 3, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de v 10 1`] = `
+{
+  "_cmd": "de b 3, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de v 11 1`] = `
+{
+  "_cmd": "de b 3, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de v 12 1`] = `
+{
+  "_cmd": "de b 3, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de v 13 1`] = `
+{
+  "_cmd": "de b 3, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de v 14 1`] = `
+{
+  "_cmd": "de b 3, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de v 15 1`] = `
+{
+  "_cmd": "de b 3, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de v 16 1`] = `
+{
+  "_cmd": "de b 3, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de v 17 1`] = `
+{
+  "_cmd": "de b 3, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 3, de v 18 1`] = `
+{
+  "_cmd": "de b 3, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 3, de v 19 1`] = `
+{
+  "_cmd": "de b 3, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 3, de v 20 1`] = `
+{
+  "_cmd": "de b 3, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 3, de w 1 1`] = `
+{
+  "_cmd": "de b 3, de w 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, de w 2 1`] = `
+{
+  "_cmd": "de b 3, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, de w 3 1`] = `
+{
+  "_cmd": "de b 3, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, de w 4 1`] = `
+{
+  "_cmd": "de b 3, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de w 5 1`] = `
+{
+  "_cmd": "de b 3, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de w 6 1`] = `
+{
+  "_cmd": "de b 3, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, de w 7 1`] = `
+{
+  "_cmd": "de b 3, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de w 8 1`] = `
+{
+  "_cmd": "de b 3, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de w 9 1`] = `
+{
+  "_cmd": "de b 3, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de w 10 1`] = `
+{
+  "_cmd": "de b 3, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de w 11 1`] = `
+{
+  "_cmd": "de b 3, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de w 12 1`] = `
+{
+  "_cmd": "de b 3, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de w 13 1`] = `
+{
+  "_cmd": "de b 3, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de w 14 1`] = `
+{
+  "_cmd": "de b 3, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de w 15 1`] = `
+{
+  "_cmd": "de b 3, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de w v 1 1`] = `
+{
+  "_cmd": "de b 3, de w v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, de w v 2 1`] = `
+{
+  "_cmd": "de b 3, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, de w v 3 1`] = `
+{
+  "_cmd": "de b 3, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, de w v 4 1`] = `
+{
+  "_cmd": "de b 3, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, de w v 5 1`] = `
+{
+  "_cmd": "de b 3, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, de w v 6 1`] = `
+{
+  "_cmd": "de b 3, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, de w v 7 1`] = `
+{
+  "_cmd": "de b 3, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, de w v 8 1`] = `
+{
+  "_cmd": "de b 3, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, de w v 9 1`] = `
+{
+  "_cmd": "de b 3, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, de w v 10 1`] = `
+{
+  "_cmd": "de b 3, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, de w v 11 1`] = `
+{
+  "_cmd": "de b 3, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, de w v 12 1`] = `
+{
+  "_cmd": "de b 3, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, de w v 13 1`] = `
+{
+  "_cmd": "de b 3, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, de w v 14 1`] = `
+{
+  "_cmd": "de b 3, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, de w v 15 1`] = `
+{
+  "_cmd": "de b 3, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, de w v 16 1`] = `
+{
+  "_cmd": "de b 3, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 3, de w v 17 1`] = `
+{
+  "_cmd": "de b 3, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 3, de w v 18 1`] = `
+{
+  "_cmd": "de b 3, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 3, de w v 19 1`] = `
+{
+  "_cmd": "de b 3, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 3, de w v 20 1`] = `
+{
+  "_cmd": "de b 3, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 4, de d 1 1`] = `
+{
+  "_cmd": "de b 4, de d 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b 4, de d 2 1`] = `
+{
+  "_cmd": "de b 4, de d 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, de d 3 1`] = `
+{
+  "_cmd": "de b 4, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, de d 4 1`] = `
+{
+  "_cmd": "de b 4, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, de d 5 1`] = `
+{
+  "_cmd": "de b 4, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de d 6 1`] = `
+{
+  "_cmd": "de b 4, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de d 7 1`] = `
+{
+  "_cmd": "de b 4, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de d 8 1`] = `
+{
+  "_cmd": "de b 4, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de d 9 1`] = `
+{
+  "_cmd": "de b 4, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, de d 10 1`] = `
+{
+  "_cmd": "de b 4, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de d 11 1`] = `
+{
+  "_cmd": "de b 4, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de d 12 1`] = `
+{
+  "_cmd": "de b 4, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de d 13 1`] = `
+{
+  "_cmd": "de b 4, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de d 14 1`] = `
+{
+  "_cmd": "de b 4, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de d 15 1`] = `
+{
+  "_cmd": "de b 4, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de d v 1 1`] = `
+{
+  "_cmd": "de b 4, de d v 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b 4, de d v 2 1`] = `
+{
+  "_cmd": "de b 4, de d v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, de d v 3 1`] = `
+{
+  "_cmd": "de b 4, de d v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, de d v 4 1`] = `
+{
+  "_cmd": "de b 4, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, de d v 5 1`] = `
+{
+  "_cmd": "de b 4, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de d v 6 1`] = `
+{
+  "_cmd": "de b 4, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de d v 7 1`] = `
+{
+  "_cmd": "de b 4, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de d v 8 1`] = `
+{
+  "_cmd": "de b 4, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de d v 9 1`] = `
+{
+  "_cmd": "de b 4, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, de d v 10 1`] = `
+{
+  "_cmd": "de b 4, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de d v 11 1`] = `
+{
+  "_cmd": "de b 4, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de d v 12 1`] = `
+{
+  "_cmd": "de b 4, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de d v 13 1`] = `
+{
+  "_cmd": "de b 4, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de d v 14 1`] = `
+{
+  "_cmd": "de b 4, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de d v 15 1`] = `
+{
+  "_cmd": "de b 4, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de d v 16 1`] = `
+{
+  "_cmd": "de b 4, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, de d v 17 1`] = `
+{
+  "_cmd": "de b 4, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 4, de d v 18 1`] = `
+{
+  "_cmd": "de b 4, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 4, de d v 19 1`] = `
+{
+  "_cmd": "de b 4, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 4, de d v 20 1`] = `
+{
+  "_cmd": "de b 4, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 4, de p 1 1`] = `
+{
+  "_cmd": "de b 4, de p 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, de p 2 1`] = `
+{
+  "_cmd": "de b 4, de p 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, de p 3 1`] = `
+{
+  "_cmd": "de b 4, de p 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, de p 4 1`] = `
+{
+  "_cmd": "de b 4, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, de p 5 1`] = `
+{
+  "_cmd": "de b 4, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de p 6 1`] = `
+{
+  "_cmd": "de b 4, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de p 7 1`] = `
+{
+  "_cmd": "de b 4, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de p 8 1`] = `
+{
+  "_cmd": "de b 4, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de p 9 1`] = `
+{
+  "_cmd": "de b 4, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de p 10 1`] = `
+{
+  "_cmd": "de b 4, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, de p 11 1`] = `
+{
+  "_cmd": "de b 4, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de p 12 1`] = `
+{
+  "_cmd": "de b 4, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de p 13 1`] = `
+{
+  "_cmd": "de b 4, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de p 14 1`] = `
+{
+  "_cmd": "de b 4, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de p 15 1`] = `
+{
+  "_cmd": "de b 4, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de p v 1 1`] = `
+{
+  "_cmd": "de b 4, de p v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, de p v 2 1`] = `
+{
+  "_cmd": "de b 4, de p v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, de p v 3 1`] = `
+{
+  "_cmd": "de b 4, de p v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, de p v 4 1`] = `
+{
+  "_cmd": "de b 4, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, de p v 5 1`] = `
+{
+  "_cmd": "de b 4, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, de p v 6 1`] = `
+{
+  "_cmd": "de b 4, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de p v 7 1`] = `
+{
+  "_cmd": "de b 4, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de p v 8 1`] = `
+{
+  "_cmd": "de b 4, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de p v 9 1`] = `
+{
+  "_cmd": "de b 4, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de p v 10 1`] = `
+{
+  "_cmd": "de b 4, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, de p v 11 1`] = `
+{
+  "_cmd": "de b 4, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de p v 12 1`] = `
+{
+  "_cmd": "de b 4, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de p v 13 1`] = `
+{
+  "_cmd": "de b 4, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de p v 14 1`] = `
+{
+  "_cmd": "de b 4, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de p v 15 1`] = `
+{
+  "_cmd": "de b 4, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de p v 16 1`] = `
+{
+  "_cmd": "de b 4, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, de p v 17 1`] = `
+{
+  "_cmd": "de b 4, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 4, de p v 18 1`] = `
+{
+  "_cmd": "de b 4, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 4, de p v 19 1`] = `
+{
+  "_cmd": "de b 4, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 4, de p v 20 1`] = `
+{
+  "_cmd": "de b 4, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 4, de v 1 1`] = `
+{
+  "_cmd": "de b 4, de v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, de v 2 1`] = `
+{
+  "_cmd": "de b 4, de v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, de v 3 1`] = `
+{
+  "_cmd": "de b 4, de v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, de v 4 1`] = `
+{
+  "_cmd": "de b 4, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, de v 5 1`] = `
+{
+  "_cmd": "de b 4, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de v 6 1`] = `
+{
+  "_cmd": "de b 4, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de v 7 1`] = `
+{
+  "_cmd": "de b 4, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de v 8 1`] = `
+{
+  "_cmd": "de b 4, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de v 9 1`] = `
+{
+  "_cmd": "de b 4, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de v 10 1`] = `
+{
+  "_cmd": "de b 4, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de v 11 1`] = `
+{
+  "_cmd": "de b 4, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de v 12 1`] = `
+{
+  "_cmd": "de b 4, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de v 13 1`] = `
+{
+  "_cmd": "de b 4, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de v 14 1`] = `
+{
+  "_cmd": "de b 4, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de v 15 1`] = `
+{
+  "_cmd": "de b 4, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de v 16 1`] = `
+{
+  "_cmd": "de b 4, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, de v 17 1`] = `
+{
+  "_cmd": "de b 4, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 4, de v 18 1`] = `
+{
+  "_cmd": "de b 4, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 4, de v 19 1`] = `
+{
+  "_cmd": "de b 4, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 4, de v 20 1`] = `
+{
+  "_cmd": "de b 4, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 4, de w 1 1`] = `
+{
+  "_cmd": "de b 4, de w 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, de w 2 1`] = `
+{
+  "_cmd": "de b 4, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, de w 3 1`] = `
+{
+  "_cmd": "de b 4, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, de w 4 1`] = `
+{
+  "_cmd": "de b 4, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de w 5 1`] = `
+{
+  "_cmd": "de b 4, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de w 6 1`] = `
+{
+  "_cmd": "de b 4, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de w 7 1`] = `
+{
+  "_cmd": "de b 4, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de w 8 1`] = `
+{
+  "_cmd": "de b 4, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, de w 9 1`] = `
+{
+  "_cmd": "de b 4, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de w 10 1`] = `
+{
+  "_cmd": "de b 4, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de w 11 1`] = `
+{
+  "_cmd": "de b 4, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de w 12 1`] = `
+{
+  "_cmd": "de b 4, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de w 13 1`] = `
+{
+  "_cmd": "de b 4, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de w 14 1`] = `
+{
+  "_cmd": "de b 4, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de w 15 1`] = `
+{
+  "_cmd": "de b 4, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, de w v 1 1`] = `
+{
+  "_cmd": "de b 4, de w v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, de w v 2 1`] = `
+{
+  "_cmd": "de b 4, de w v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, de w v 3 1`] = `
+{
+  "_cmd": "de b 4, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, de w v 4 1`] = `
+{
+  "_cmd": "de b 4, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, de w v 5 1`] = `
+{
+  "_cmd": "de b 4, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, de w v 6 1`] = `
+{
+  "_cmd": "de b 4, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, de w v 7 1`] = `
+{
+  "_cmd": "de b 4, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, de w v 8 1`] = `
+{
+  "_cmd": "de b 4, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, de w v 9 1`] = `
+{
+  "_cmd": "de b 4, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, de w v 10 1`] = `
+{
+  "_cmd": "de b 4, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, de w v 11 1`] = `
+{
+  "_cmd": "de b 4, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, de w v 12 1`] = `
+{
+  "_cmd": "de b 4, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, de w v 13 1`] = `
+{
+  "_cmd": "de b 4, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, de w v 14 1`] = `
+{
+  "_cmd": "de b 4, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, de w v 15 1`] = `
+{
+  "_cmd": "de b 4, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, de w v 16 1`] = `
+{
+  "_cmd": "de b 4, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 4, de w v 17 1`] = `
+{
+  "_cmd": "de b 4, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 4, de w v 18 1`] = `
+{
+  "_cmd": "de b 4, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 4, de w v 19 1`] = `
+{
+  "_cmd": "de b 4, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 4, de w v 20 1`] = `
+{
+  "_cmd": "de b 4, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 5, de d 1 1`] = `
+{
+  "_cmd": "de b 5, de d 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b 5, de d 2 1`] = `
+{
+  "_cmd": "de b 5, de d 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, de d 3 1`] = `
+{
+  "_cmd": "de b 5, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, de d 4 1`] = `
+{
+  "_cmd": "de b 5, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de d 5 1`] = `
+{
+  "_cmd": "de b 5, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de d 6 1`] = `
+{
+  "_cmd": "de b 5, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de d 7 1`] = `
+{
+  "_cmd": "de b 5, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, de d 8 1`] = `
+{
+  "_cmd": "de b 5, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de d 9 1`] = `
+{
+  "_cmd": "de b 5, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de d 10 1`] = `
+{
+  "_cmd": "de b 5, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de d 11 1`] = `
+{
+  "_cmd": "de b 5, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, de d 12 1`] = `
+{
+  "_cmd": "de b 5, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de d 13 1`] = `
+{
+  "_cmd": "de b 5, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de d 14 1`] = `
+{
+  "_cmd": "de b 5, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de d 15 1`] = `
+{
+  "_cmd": "de b 5, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de d v 1 1`] = `
+{
+  "_cmd": "de b 5, de d v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, de d v 2 1`] = `
+{
+  "_cmd": "de b 5, de d v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, de d v 3 1`] = `
+{
+  "_cmd": "de b 5, de d v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, de d v 4 1`] = `
+{
+  "_cmd": "de b 5, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de d v 5 1`] = `
+{
+  "_cmd": "de b 5, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de d v 6 1`] = `
+{
+  "_cmd": "de b 5, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, de d v 7 1`] = `
+{
+  "_cmd": "de b 5, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de d v 8 1`] = `
+{
+  "_cmd": "de b 5, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de d v 9 1`] = `
+{
+  "_cmd": "de b 5, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de d v 10 1`] = `
+{
+  "_cmd": "de b 5, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de d v 11 1`] = `
+{
+  "_cmd": "de b 5, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, de d v 12 1`] = `
+{
+  "_cmd": "de b 5, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de d v 13 1`] = `
+{
+  "_cmd": "de b 5, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de d v 14 1`] = `
+{
+  "_cmd": "de b 5, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de d v 15 1`] = `
+{
+  "_cmd": "de b 5, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de d v 16 1`] = `
+{
+  "_cmd": "de b 5, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 5, de d v 17 1`] = `
+{
+  "_cmd": "de b 5, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 5, de d v 18 1`] = `
+{
+  "_cmd": "de b 5, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 5, de d v 19 1`] = `
+{
+  "_cmd": "de b 5, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 5, de d v 20 1`] = `
+{
+  "_cmd": "de b 5, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 5, de p 1 1`] = `
+{
+  "_cmd": "de b 5, de p 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, de p 2 1`] = `
+{
+  "_cmd": "de b 5, de p 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, de p 3 1`] = `
+{
+  "_cmd": "de b 5, de p 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, de p 4 1`] = `
+{
+  "_cmd": "de b 5, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, de p 5 1`] = `
+{
+  "_cmd": "de b 5, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de p 6 1`] = `
+{
+  "_cmd": "de b 5, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de p 7 1`] = `
+{
+  "_cmd": "de b 5, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de p 8 1`] = `
+{
+  "_cmd": "de b 5, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, de p 9 1`] = `
+{
+  "_cmd": "de b 5, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de p 10 1`] = `
+{
+  "_cmd": "de b 5, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de p 11 1`] = `
+{
+  "_cmd": "de b 5, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de p 12 1`] = `
+{
+  "_cmd": "de b 5, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, de p 13 1`] = `
+{
+  "_cmd": "de b 5, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de p 14 1`] = `
+{
+  "_cmd": "de b 5, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de p 15 1`] = `
+{
+  "_cmd": "de b 5, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de p v 1 1`] = `
+{
+  "_cmd": "de b 5, de p v 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`de b 5, de p v 2 1`] = `
+{
+  "_cmd": "de b 5, de p v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b 5, de p v 3 1`] = `
+{
+  "_cmd": "de b 5, de p v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, de p v 4 1`] = `
+{
+  "_cmd": "de b 5, de p v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, de p v 5 1`] = `
+{
+  "_cmd": "de b 5, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de p v 6 1`] = `
+{
+  "_cmd": "de b 5, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de p v 7 1`] = `
+{
+  "_cmd": "de b 5, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, de p v 8 1`] = `
+{
+  "_cmd": "de b 5, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de p v 9 1`] = `
+{
+  "_cmd": "de b 5, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de p v 10 1`] = `
+{
+  "_cmd": "de b 5, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de p v 11 1`] = `
+{
+  "_cmd": "de b 5, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de p v 12 1`] = `
+{
+  "_cmd": "de b 5, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, de p v 13 1`] = `
+{
+  "_cmd": "de b 5, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de p v 14 1`] = `
+{
+  "_cmd": "de b 5, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de p v 15 1`] = `
+{
+  "_cmd": "de b 5, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de p v 16 1`] = `
+{
+  "_cmd": "de b 5, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de p v 17 1`] = `
+{
+  "_cmd": "de b 5, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 5, de p v 18 1`] = `
+{
+  "_cmd": "de b 5, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 5, de p v 19 1`] = `
+{
+  "_cmd": "de b 5, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 5, de p v 20 1`] = `
+{
+  "_cmd": "de b 5, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 5, de v 1 1`] = `
+{
+  "_cmd": "de b 5, de v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, de v 2 1`] = `
+{
+  "_cmd": "de b 5, de v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, de v 3 1`] = `
+{
+  "_cmd": "de b 5, de v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, de v 4 1`] = `
+{
+  "_cmd": "de b 5, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, de v 5 1`] = `
+{
+  "_cmd": "de b 5, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de v 6 1`] = `
+{
+  "_cmd": "de b 5, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, de v 7 1`] = `
+{
+  "_cmd": "de b 5, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de v 8 1`] = `
+{
+  "_cmd": "de b 5, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, de v 9 1`] = `
+{
+  "_cmd": "de b 5, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de v 10 1`] = `
+{
+  "_cmd": "de b 5, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de v 11 1`] = `
+{
+  "_cmd": "de b 5, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de v 12 1`] = `
+{
+  "_cmd": "de b 5, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de v 13 1`] = `
+{
+  "_cmd": "de b 5, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de v 14 1`] = `
+{
+  "_cmd": "de b 5, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de v 15 1`] = `
+{
+  "_cmd": "de b 5, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de v 16 1`] = `
+{
+  "_cmd": "de b 5, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 5, de v 17 1`] = `
+{
+  "_cmd": "de b 5, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 5, de v 18 1`] = `
+{
+  "_cmd": "de b 5, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 5, de v 19 1`] = `
+{
+  "_cmd": "de b 5, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 5, de v 20 1`] = `
+{
+  "_cmd": "de b 5, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 5, de w 1 1`] = `
+{
+  "_cmd": "de b 5, de w 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, de w 2 1`] = `
+{
+  "_cmd": "de b 5, de w 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, de w 3 1`] = `
+{
+  "_cmd": "de b 5, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de w 4 1`] = `
+{
+  "_cmd": "de b 5, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de w 5 1`] = `
+{
+  "_cmd": "de b 5, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, de w 6 1`] = `
+{
+  "_cmd": "de b 5, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de w 7 1`] = `
+{
+  "_cmd": "de b 5, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, de w 8 1`] = `
+{
+  "_cmd": "de b 5, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de w 9 1`] = `
+{
+  "_cmd": "de b 5, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de w 10 1`] = `
+{
+  "_cmd": "de b 5, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, de w 11 1`] = `
+{
+  "_cmd": "de b 5, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de w 12 1`] = `
+{
+  "_cmd": "de b 5, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de w 13 1`] = `
+{
+  "_cmd": "de b 5, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de w 14 1`] = `
+{
+  "_cmd": "de b 5, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de w 15 1`] = `
+{
+  "_cmd": "de b 5, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 5, de w v 1 1`] = `
+{
+  "_cmd": "de b 5, de w v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, de w v 2 1`] = `
+{
+  "_cmd": "de b 5, de w v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, de w v 3 1`] = `
+{
+  "_cmd": "de b 5, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, de w v 4 1`] = `
+{
+  "_cmd": "de b 5, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, de w v 5 1`] = `
+{
+  "_cmd": "de b 5, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, de w v 6 1`] = `
+{
+  "_cmd": "de b 5, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, de w v 7 1`] = `
+{
+  "_cmd": "de b 5, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, de w v 8 1`] = `
+{
+  "_cmd": "de b 5, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, de w v 9 1`] = `
+{
+  "_cmd": "de b 5, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, de w v 10 1`] = `
+{
+  "_cmd": "de b 5, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, de w v 11 1`] = `
+{
+  "_cmd": "de b 5, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, de w v 12 1`] = `
+{
+  "_cmd": "de b 5, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, de w v 13 1`] = `
+{
+  "_cmd": "de b 5, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, de w v 14 1`] = `
+{
+  "_cmd": "de b 5, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, de w v 15 1`] = `
+{
+  "_cmd": "de b 5, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 5, de w v 16 1`] = `
+{
+  "_cmd": "de b 5, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 5, de w v 17 1`] = `
+{
+  "_cmd": "de b 5, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 5, de w v 18 1`] = `
+{
+  "_cmd": "de b 5, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 5, de w v 19 1`] = `
+{
+  "_cmd": "de b 5, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 5, de w v 20 1`] = `
+{
+  "_cmd": "de b 5, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 6, de d 1 1`] = `
+{
+  "_cmd": "de b 6, de d 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, de d 2 1`] = `
+{
+  "_cmd": "de b 6, de d 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, de d 3 1`] = `
+{
+  "_cmd": "de b 6, de d 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, de d 4 1`] = `
+{
+  "_cmd": "de b 6, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, de d 5 1`] = `
+{
+  "_cmd": "de b 6, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de d 6 1`] = `
+{
+  "_cmd": "de b 6, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de d 7 1`] = `
+{
+  "_cmd": "de b 6, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de d 8 1`] = `
+{
+  "_cmd": "de b 6, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de d 9 1`] = `
+{
+  "_cmd": "de b 6, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de d 10 1`] = `
+{
+  "_cmd": "de b 6, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de d 11 1`] = `
+{
+  "_cmd": "de b 6, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de d 12 1`] = `
+{
+  "_cmd": "de b 6, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de d 13 1`] = `
+{
+  "_cmd": "de b 6, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de d 14 1`] = `
+{
+  "_cmd": "de b 6, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de d 15 1`] = `
+{
+  "_cmd": "de b 6, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de d v 1 1`] = `
+{
+  "_cmd": "de b 6, de d v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, de d v 2 1`] = `
+{
+  "_cmd": "de b 6, de d v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, de d v 3 1`] = `
+{
+  "_cmd": "de b 6, de d v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, de d v 4 1`] = `
+{
+  "_cmd": "de b 6, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, de d v 5 1`] = `
+{
+  "_cmd": "de b 6, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de d v 6 1`] = `
+{
+  "_cmd": "de b 6, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de d v 7 1`] = `
+{
+  "_cmd": "de b 6, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de d v 8 1`] = `
+{
+  "_cmd": "de b 6, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de d v 9 1`] = `
+{
+  "_cmd": "de b 6, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de d v 10 1`] = `
+{
+  "_cmd": "de b 6, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de d v 11 1`] = `
+{
+  "_cmd": "de b 6, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de d v 12 1`] = `
+{
+  "_cmd": "de b 6, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de d v 13 1`] = `
+{
+  "_cmd": "de b 6, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de d v 14 1`] = `
+{
+  "_cmd": "de b 6, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de d v 15 1`] = `
+{
+  "_cmd": "de b 6, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de d v 16 1`] = `
+{
+  "_cmd": "de b 6, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, de d v 17 1`] = `
+{
+  "_cmd": "de b 6, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 6, de d v 18 1`] = `
+{
+  "_cmd": "de b 6, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 6, de d v 19 1`] = `
+{
+  "_cmd": "de b 6, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 6, de d v 20 1`] = `
+{
+  "_cmd": "de b 6, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 6, de p 1 1`] = `
+{
+  "_cmd": "de b 6, de p 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, de p 2 1`] = `
+{
+  "_cmd": "de b 6, de p 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, de p 3 1`] = `
+{
+  "_cmd": "de b 6, de p 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, de p 4 1`] = `
+{
+  "_cmd": "de b 6, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, de p 5 1`] = `
+{
+  "_cmd": "de b 6, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, de p 6 1`] = `
+{
+  "_cmd": "de b 6, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de p 7 1`] = `
+{
+  "_cmd": "de b 6, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de p 8 1`] = `
+{
+  "_cmd": "de b 6, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de p 9 1`] = `
+{
+  "_cmd": "de b 6, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de p 10 1`] = `
+{
+  "_cmd": "de b 6, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de p 11 1`] = `
+{
+  "_cmd": "de b 6, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de p 12 1`] = `
+{
+  "_cmd": "de b 6, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de p 13 1`] = `
+{
+  "_cmd": "de b 6, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de p 14 1`] = `
+{
+  "_cmd": "de b 6, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de p 15 1`] = `
+{
+  "_cmd": "de b 6, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de p v 1 1`] = `
+{
+  "_cmd": "de b 6, de p v 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`de b 6, de p v 2 1`] = `
+{
+  "_cmd": "de b 6, de p v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, de p v 3 1`] = `
+{
+  "_cmd": "de b 6, de p v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, de p v 4 1`] = `
+{
+  "_cmd": "de b 6, de p v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, de p v 5 1`] = `
+{
+  "_cmd": "de b 6, de p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, de p v 6 1`] = `
+{
+  "_cmd": "de b 6, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de p v 7 1`] = `
+{
+  "_cmd": "de b 6, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de p v 8 1`] = `
+{
+  "_cmd": "de b 6, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de p v 9 1`] = `
+{
+  "_cmd": "de b 6, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de p v 10 1`] = `
+{
+  "_cmd": "de b 6, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de p v 11 1`] = `
+{
+  "_cmd": "de b 6, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de p v 12 1`] = `
+{
+  "_cmd": "de b 6, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de p v 13 1`] = `
+{
+  "_cmd": "de b 6, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de p v 14 1`] = `
+{
+  "_cmd": "de b 6, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de p v 15 1`] = `
+{
+  "_cmd": "de b 6, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de p v 16 1`] = `
+{
+  "_cmd": "de b 6, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de p v 17 1`] = `
+{
+  "_cmd": "de b 6, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, de p v 18 1`] = `
+{
+  "_cmd": "de b 6, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 6, de p v 19 1`] = `
+{
+  "_cmd": "de b 6, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 6, de p v 20 1`] = `
+{
+  "_cmd": "de b 6, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 6, de v 1 1`] = `
+{
+  "_cmd": "de b 6, de v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, de v 2 1`] = `
+{
+  "_cmd": "de b 6, de v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, de v 3 1`] = `
+{
+  "_cmd": "de b 6, de v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, de v 4 1`] = `
+{
+  "_cmd": "de b 6, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, de v 5 1`] = `
+{
+  "_cmd": "de b 6, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, de v 6 1`] = `
+{
+  "_cmd": "de b 6, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de v 7 1`] = `
+{
+  "_cmd": "de b 6, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de v 8 1`] = `
+{
+  "_cmd": "de b 6, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de v 9 1`] = `
+{
+  "_cmd": "de b 6, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de v 10 1`] = `
+{
+  "_cmd": "de b 6, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de v 11 1`] = `
+{
+  "_cmd": "de b 6, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de v 12 1`] = `
+{
+  "_cmd": "de b 6, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de v 13 1`] = `
+{
+  "_cmd": "de b 6, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de v 14 1`] = `
+{
+  "_cmd": "de b 6, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de v 15 1`] = `
+{
+  "_cmd": "de b 6, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de v 16 1`] = `
+{
+  "_cmd": "de b 6, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, de v 17 1`] = `
+{
+  "_cmd": "de b 6, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 6, de v 18 1`] = `
+{
+  "_cmd": "de b 6, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 6, de v 19 1`] = `
+{
+  "_cmd": "de b 6, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 6, de v 20 1`] = `
+{
+  "_cmd": "de b 6, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 6, de w 1 1`] = `
+{
+  "_cmd": "de b 6, de w 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, de w 2 1`] = `
+{
+  "_cmd": "de b 6, de w 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, de w 3 1`] = `
+{
+  "_cmd": "de b 6, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, de w 4 1`] = `
+{
+  "_cmd": "de b 6, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de w 5 1`] = `
+{
+  "_cmd": "de b 6, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de w 6 1`] = `
+{
+  "_cmd": "de b 6, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de w 7 1`] = `
+{
+  "_cmd": "de b 6, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de w 8 1`] = `
+{
+  "_cmd": "de b 6, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de w 9 1`] = `
+{
+  "_cmd": "de b 6, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de w 10 1`] = `
+{
+  "_cmd": "de b 6, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de w 11 1`] = `
+{
+  "_cmd": "de b 6, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de w 12 1`] = `
+{
+  "_cmd": "de b 6, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, de w 13 1`] = `
+{
+  "_cmd": "de b 6, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de w 14 1`] = `
+{
+  "_cmd": "de b 6, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de w 15 1`] = `
+{
+  "_cmd": "de b 6, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, de w v 1 1`] = `
+{
+  "_cmd": "de b 6, de w v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, de w v 2 1`] = `
+{
+  "_cmd": "de b 6, de w v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, de w v 3 1`] = `
+{
+  "_cmd": "de b 6, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, de w v 4 1`] = `
+{
+  "_cmd": "de b 6, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, de w v 5 1`] = `
+{
+  "_cmd": "de b 6, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, de w v 6 1`] = `
+{
+  "_cmd": "de b 6, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, de w v 7 1`] = `
+{
+  "_cmd": "de b 6, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, de w v 8 1`] = `
+{
+  "_cmd": "de b 6, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, de w v 9 1`] = `
+{
+  "_cmd": "de b 6, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, de w v 10 1`] = `
+{
+  "_cmd": "de b 6, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, de w v 11 1`] = `
+{
+  "_cmd": "de b 6, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, de w v 12 1`] = `
+{
+  "_cmd": "de b 6, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, de w v 13 1`] = `
+{
+  "_cmd": "de b 6, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, de w v 14 1`] = `
+{
+  "_cmd": "de b 6, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, de w v 15 1`] = `
+{
+  "_cmd": "de b 6, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, de w v 16 1`] = `
+{
+  "_cmd": "de b 6, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 6, de w v 17 1`] = `
+{
+  "_cmd": "de b 6, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 6, de w v 18 1`] = `
+{
+  "_cmd": "de b 6, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 6, de w v 19 1`] = `
+{
+  "_cmd": "de b 6, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 6, de w v 20 1`] = `
+{
+  "_cmd": "de b 6, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 7, de d 1 1`] = `
+{
+  "_cmd": "de b 7, de d 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b 7, de d 2 1`] = `
+{
+  "_cmd": "de b 7, de d 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, de d 3 1`] = `
+{
+  "_cmd": "de b 7, de d 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de d 4 1`] = `
+{
+  "_cmd": "de b 7, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de d 5 1`] = `
+{
+  "_cmd": "de b 7, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, de d 6 1`] = `
+{
+  "_cmd": "de b 7, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de d 7 1`] = `
+{
+  "_cmd": "de b 7, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de d 8 1`] = `
+{
+  "_cmd": "de b 7, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de d 9 1`] = `
+{
+  "_cmd": "de b 7, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de d 10 1`] = `
+{
+  "_cmd": "de b 7, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, de d 11 1`] = `
+{
+  "_cmd": "de b 7, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de d 12 1`] = `
+{
+  "_cmd": "de b 7, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de d 13 1`] = `
+{
+  "_cmd": "de b 7, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de d 14 1`] = `
+{
+  "_cmd": "de b 7, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de d 15 1`] = `
+{
+  "_cmd": "de b 7, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, de d v 1 1`] = `
+{
+  "_cmd": "de b 7, de d v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b 7, de d v 2 1`] = `
+{
+  "_cmd": "de b 7, de d v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, de d v 3 1`] = `
+{
+  "_cmd": "de b 7, de d v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de d v 4 1`] = `
+{
+  "_cmd": "de b 7, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, de d v 5 1`] = `
+{
+  "_cmd": "de b 7, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de d v 6 1`] = `
+{
+  "_cmd": "de b 7, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de d v 7 1`] = `
+{
+  "_cmd": "de b 7, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de d v 8 1`] = `
+{
+  "_cmd": "de b 7, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de d v 9 1`] = `
+{
+  "_cmd": "de b 7, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de d v 10 1`] = `
+{
+  "_cmd": "de b 7, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de d v 11 1`] = `
+{
+  "_cmd": "de b 7, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de d v 12 1`] = `
+{
+  "_cmd": "de b 7, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de d v 13 1`] = `
+{
+  "_cmd": "de b 7, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de d v 14 1`] = `
+{
+  "_cmd": "de b 7, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de d v 15 1`] = `
+{
+  "_cmd": "de b 7, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, de d v 16 1`] = `
+{
+  "_cmd": "de b 7, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 7, de d v 17 1`] = `
+{
+  "_cmd": "de b 7, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 7, de d v 18 1`] = `
+{
+  "_cmd": "de b 7, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 7, de d v 19 1`] = `
+{
+  "_cmd": "de b 7, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 7, de d v 20 1`] = `
+{
+  "_cmd": "de b 7, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 7, de p 1 1`] = `
+{
+  "_cmd": "de b 7, de p 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, de p 2 1`] = `
+{
+  "_cmd": "de b 7, de p 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, de p 3 1`] = `
+{
+  "_cmd": "de b 7, de p 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, de p 4 1`] = `
+{
+  "_cmd": "de b 7, de p 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de p 5 1`] = `
+{
+  "_cmd": "de b 7, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de p 6 1`] = `
+{
+  "_cmd": "de b 7, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, de p 7 1`] = `
+{
+  "_cmd": "de b 7, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de p 8 1`] = `
+{
+  "_cmd": "de b 7, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de p 9 1`] = `
+{
+  "_cmd": "de b 7, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de p 10 1`] = `
+{
+  "_cmd": "de b 7, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de p 11 1`] = `
+{
+  "_cmd": "de b 7, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, de p 12 1`] = `
+{
+  "_cmd": "de b 7, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de p 13 1`] = `
+{
+  "_cmd": "de b 7, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de p 14 1`] = `
+{
+  "_cmd": "de b 7, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de p 15 1`] = `
+{
+  "_cmd": "de b 7, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de p v 1 1`] = `
+{
+  "_cmd": "de b 7, de p v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, de p v 2 1`] = `
+{
+  "_cmd": "de b 7, de p v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, de p v 3 1`] = `
+{
+  "_cmd": "de b 7, de p v 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, de p v 4 1`] = `
+{
+  "_cmd": "de b 7, de p v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de p v 5 1`] = `
+{
+  "_cmd": "de b 7, de p v 5",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, de p v 6 1`] = `
+{
+  "_cmd": "de b 7, de p v 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de p v 7 1`] = `
+{
+  "_cmd": "de b 7, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de p v 8 1`] = `
+{
+  "_cmd": "de b 7, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de p v 9 1`] = `
+{
+  "_cmd": "de b 7, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de p v 10 1`] = `
+{
+  "_cmd": "de b 7, de p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de p v 11 1`] = `
+{
+  "_cmd": "de b 7, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de p v 12 1`] = `
+{
+  "_cmd": "de b 7, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de p v 13 1`] = `
+{
+  "_cmd": "de b 7, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de p v 14 1`] = `
+{
+  "_cmd": "de b 7, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de p v 15 1`] = `
+{
+  "_cmd": "de b 7, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de p v 16 1`] = `
+{
+  "_cmd": "de b 7, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, de p v 17 1`] = `
+{
+  "_cmd": "de b 7, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 7, de p v 18 1`] = `
+{
+  "_cmd": "de b 7, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 7, de p v 19 1`] = `
+{
+  "_cmd": "de b 7, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 7, de p v 20 1`] = `
+{
+  "_cmd": "de b 7, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 7, de v 1 1`] = `
+{
+  "_cmd": "de b 7, de v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, de v 2 1`] = `
+{
+  "_cmd": "de b 7, de v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, de v 3 1`] = `
+{
+  "_cmd": "de b 7, de v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, de v 4 1`] = `
+{
+  "_cmd": "de b 7, de v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de v 5 1`] = `
+{
+  "_cmd": "de b 7, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de v 6 1`] = `
+{
+  "_cmd": "de b 7, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, de v 7 1`] = `
+{
+  "_cmd": "de b 7, de v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de v 8 1`] = `
+{
+  "_cmd": "de b 7, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de v 9 1`] = `
+{
+  "_cmd": "de b 7, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de v 10 1`] = `
+{
+  "_cmd": "de b 7, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de v 11 1`] = `
+{
+  "_cmd": "de b 7, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, de v 12 1`] = `
+{
+  "_cmd": "de b 7, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de v 13 1`] = `
+{
+  "_cmd": "de b 7, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de v 14 1`] = `
+{
+  "_cmd": "de b 7, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de v 15 1`] = `
+{
+  "_cmd": "de b 7, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de v 16 1`] = `
+{
+  "_cmd": "de b 7, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, de v 17 1`] = `
+{
+  "_cmd": "de b 7, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 7, de v 18 1`] = `
+{
+  "_cmd": "de b 7, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 7, de v 19 1`] = `
+{
+  "_cmd": "de b 7, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 7, de v 20 1`] = `
+{
+  "_cmd": "de b 7, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 7, de w 1 1`] = `
+{
+  "_cmd": "de b 7, de w 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, de w 2 1`] = `
+{
+  "_cmd": "de b 7, de w 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de w 3 1`] = `
+{
+  "_cmd": "de b 7, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, de w 4 1`] = `
+{
+  "_cmd": "de b 7, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, de w 5 1`] = `
+{
+  "_cmd": "de b 7, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de w 6 1`] = `
+{
+  "_cmd": "de b 7, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de w 7 1`] = `
+{
+  "_cmd": "de b 7, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de w 8 1`] = `
+{
+  "_cmd": "de b 7, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de w 9 1`] = `
+{
+  "_cmd": "de b 7, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de w 10 1`] = `
+{
+  "_cmd": "de b 7, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, de w 11 1`] = `
+{
+  "_cmd": "de b 7, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de w 12 1`] = `
+{
+  "_cmd": "de b 7, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de w 13 1`] = `
+{
+  "_cmd": "de b 7, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de w 14 1`] = `
+{
+  "_cmd": "de b 7, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, de w 15 1`] = `
+{
+  "_cmd": "de b 7, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 7, de w v 1 1`] = `
+{
+  "_cmd": "de b 7, de w v 1",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, de w v 2 1`] = `
+{
+  "_cmd": "de b 7, de w v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, de w v 3 1`] = `
+{
+  "_cmd": "de b 7, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, de w v 4 1`] = `
+{
+  "_cmd": "de b 7, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, de w v 5 1`] = `
+{
+  "_cmd": "de b 7, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, de w v 6 1`] = `
+{
+  "_cmd": "de b 7, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, de w v 7 1`] = `
+{
+  "_cmd": "de b 7, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, de w v 8 1`] = `
+{
+  "_cmd": "de b 7, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, de w v 9 1`] = `
+{
+  "_cmd": "de b 7, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, de w v 10 1`] = `
+{
+  "_cmd": "de b 7, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, de w v 11 1`] = `
+{
+  "_cmd": "de b 7, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, de w v 12 1`] = `
+{
+  "_cmd": "de b 7, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, de w v 13 1`] = `
+{
+  "_cmd": "de b 7, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, de w v 14 1`] = `
+{
+  "_cmd": "de b 7, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, de w v 15 1`] = `
+{
+  "_cmd": "de b 7, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 7, de w v 16 1`] = `
+{
+  "_cmd": "de b 7, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 7, de w v 17 1`] = `
+{
+  "_cmd": "de b 7, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 7, de w v 18 1`] = `
+{
+  "_cmd": "de b 7, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 7, de w v 19 1`] = `
+{
+  "_cmd": "de b 7, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 7, de w v 20 1`] = `
+{
+  "_cmd": "de b 7, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 8, de d 1 1`] = `
+{
+  "_cmd": "de b 8, de d 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b 8, de d 2 1`] = `
+{
+  "_cmd": "de b 8, de d 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, de d 3 1`] = `
+{
+  "_cmd": "de b 8, de d 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, de d 4 1`] = `
+{
+  "_cmd": "de b 8, de d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de d 5 1`] = `
+{
+  "_cmd": "de b 8, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de d 6 1`] = `
+{
+  "_cmd": "de b 8, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, de d 7 1`] = `
+{
+  "_cmd": "de b 8, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de d 8 1`] = `
+{
+  "_cmd": "de b 8, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de d 9 1`] = `
+{
+  "_cmd": "de b 8, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, de d 10 1`] = `
+{
+  "_cmd": "de b 8, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de d 11 1`] = `
+{
+  "_cmd": "de b 8, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de d 12 1`] = `
+{
+  "_cmd": "de b 8, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de d 13 1`] = `
+{
+  "_cmd": "de b 8, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de d 14 1`] = `
+{
+  "_cmd": "de b 8, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de d 15 1`] = `
+{
+  "_cmd": "de b 8, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de d v 1 1`] = `
+{
+  "_cmd": "de b 8, de d v 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b 8, de d v 2 1`] = `
+{
+  "_cmd": "de b 8, de d v 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, de d v 3 1`] = `
+{
+  "_cmd": "de b 8, de d v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, de d v 4 1`] = `
+{
+  "_cmd": "de b 8, de d v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de d v 5 1`] = `
+{
+  "_cmd": "de b 8, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, de d v 6 1`] = `
+{
+  "_cmd": "de b 8, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de d v 7 1`] = `
+{
+  "_cmd": "de b 8, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de d v 8 1`] = `
+{
+  "_cmd": "de b 8, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de d v 9 1`] = `
+{
+  "_cmd": "de b 8, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, de d v 10 1`] = `
+{
+  "_cmd": "de b 8, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de d v 11 1`] = `
+{
+  "_cmd": "de b 8, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de d v 12 1`] = `
+{
+  "_cmd": "de b 8, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de d v 13 1`] = `
+{
+  "_cmd": "de b 8, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de d v 14 1`] = `
+{
+  "_cmd": "de b 8, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de d v 15 1`] = `
+{
+  "_cmd": "de b 8, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de d v 16 1`] = `
+{
+  "_cmd": "de b 8, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 8, de d v 17 1`] = `
+{
+  "_cmd": "de b 8, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 8, de d v 18 1`] = `
+{
+  "_cmd": "de b 8, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 8, de d v 19 1`] = `
+{
+  "_cmd": "de b 8, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 8, de d v 20 1`] = `
+{
+  "_cmd": "de b 8, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 8, de p 1 1`] = `
+{
+  "_cmd": "de b 8, de p 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, de p 2 1`] = `
+{
+  "_cmd": "de b 8, de p 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, de p 3 1`] = `
+{
+  "_cmd": "de b 8, de p 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, de p 4 1`] = `
+{
+  "_cmd": "de b 8, de p 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, de p 5 1`] = `
+{
+  "_cmd": "de b 8, de p 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de p 6 1`] = `
+{
+  "_cmd": "de b 8, de p 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de p 7 1`] = `
+{
+  "_cmd": "de b 8, de p 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, de p 8 1`] = `
+{
+  "_cmd": "de b 8, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de p 9 1`] = `
+{
+  "_cmd": "de b 8, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de p 10 1`] = `
+{
+  "_cmd": "de b 8, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de p 11 1`] = `
+{
+  "_cmd": "de b 8, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de p 12 1`] = `
+{
+  "_cmd": "de b 8, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de p 13 1`] = `
+{
+  "_cmd": "de b 8, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de p 14 1`] = `
+{
+  "_cmd": "de b 8, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de p 15 1`] = `
+{
+  "_cmd": "de b 8, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de p v 1 1`] = `
+{
+  "_cmd": "de b 8, de p v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, de p v 2 1`] = `
+{
+  "_cmd": "de b 8, de p v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, de p v 3 1`] = `
+{
+  "_cmd": "de b 8, de p v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, de p v 4 1`] = `
+{
+  "_cmd": "de b 8, de p v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, de p v 5 1`] = `
+{
+  "_cmd": "de b 8, de p v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de p v 6 1`] = `
+{
+  "_cmd": "de b 8, de p v 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, de p v 7 1`] = `
+{
+  "_cmd": "de b 8, de p v 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de p v 8 1`] = `
+{
+  "_cmd": "de b 8, de p v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de p v 9 1`] = `
+{
+  "_cmd": "de b 8, de p v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de p v 10 1`] = `
+{
+  "_cmd": "de b 8, de p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, de p v 11 1`] = `
+{
+  "_cmd": "de b 8, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de p v 12 1`] = `
+{
+  "_cmd": "de b 8, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de p v 13 1`] = `
+{
+  "_cmd": "de b 8, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de p v 14 1`] = `
+{
+  "_cmd": "de b 8, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de p v 15 1`] = `
+{
+  "_cmd": "de b 8, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de p v 16 1`] = `
+{
+  "_cmd": "de b 8, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de p v 17 1`] = `
+{
+  "_cmd": "de b 8, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 8, de p v 18 1`] = `
+{
+  "_cmd": "de b 8, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 8, de p v 19 1`] = `
+{
+  "_cmd": "de b 8, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 8, de p v 20 1`] = `
+{
+  "_cmd": "de b 8, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 8, de v 1 1`] = `
+{
+  "_cmd": "de b 8, de v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, de v 2 1`] = `
+{
+  "_cmd": "de b 8, de v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, de v 3 1`] = `
+{
+  "_cmd": "de b 8, de v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, de v 4 1`] = `
+{
+  "_cmd": "de b 8, de v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, de v 5 1`] = `
+{
+  "_cmd": "de b 8, de v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, de v 6 1`] = `
+{
+  "_cmd": "de b 8, de v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de v 7 1`] = `
+{
+  "_cmd": "de b 8, de v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, de v 8 1`] = `
+{
+  "_cmd": "de b 8, de v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de v 9 1`] = `
+{
+  "_cmd": "de b 8, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de v 10 1`] = `
+{
+  "_cmd": "de b 8, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de v 11 1`] = `
+{
+  "_cmd": "de b 8, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de v 12 1`] = `
+{
+  "_cmd": "de b 8, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de v 13 1`] = `
+{
+  "_cmd": "de b 8, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de v 14 1`] = `
+{
+  "_cmd": "de b 8, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de v 15 1`] = `
+{
+  "_cmd": "de b 8, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de v 16 1`] = `
+{
+  "_cmd": "de b 8, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de v 17 1`] = `
+{
+  "_cmd": "de b 8, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 8, de v 18 1`] = `
+{
+  "_cmd": "de b 8, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 8, de v 19 1`] = `
+{
+  "_cmd": "de b 8, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 8, de v 20 1`] = `
+{
+  "_cmd": "de b 8, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 8, de w 1 1`] = `
+{
+  "_cmd": "de b 8, de w 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, de w 2 1`] = `
+{
+  "_cmd": "de b 8, de w 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, de w 3 1`] = `
+{
+  "_cmd": "de b 8, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de w 4 1`] = `
+{
+  "_cmd": "de b 8, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, de w 5 1`] = `
+{
+  "_cmd": "de b 8, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, de w 6 1`] = `
+{
+  "_cmd": "de b 8, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de w 7 1`] = `
+{
+  "_cmd": "de b 8, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de w 8 1`] = `
+{
+  "_cmd": "de b 8, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, de w 9 1`] = `
+{
+  "_cmd": "de b 8, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de w 10 1`] = `
+{
+  "_cmd": "de b 8, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de w 11 1`] = `
+{
+  "_cmd": "de b 8, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de w 12 1`] = `
+{
+  "_cmd": "de b 8, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de w 13 1`] = `
+{
+  "_cmd": "de b 8, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de w 14 1`] = `
+{
+  "_cmd": "de b 8, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de w 15 1`] = `
+{
+  "_cmd": "de b 8, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 8, de w v 1 1`] = `
+{
+  "_cmd": "de b 8, de w v 1",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, de w v 2 1`] = `
+{
+  "_cmd": "de b 8, de w v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, de w v 3 1`] = `
+{
+  "_cmd": "de b 8, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, de w v 4 1`] = `
+{
+  "_cmd": "de b 8, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, de w v 5 1`] = `
+{
+  "_cmd": "de b 8, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, de w v 6 1`] = `
+{
+  "_cmd": "de b 8, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, de w v 7 1`] = `
+{
+  "_cmd": "de b 8, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, de w v 8 1`] = `
+{
+  "_cmd": "de b 8, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, de w v 9 1`] = `
+{
+  "_cmd": "de b 8, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, de w v 10 1`] = `
+{
+  "_cmd": "de b 8, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, de w v 11 1`] = `
+{
+  "_cmd": "de b 8, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, de w v 12 1`] = `
+{
+  "_cmd": "de b 8, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, de w v 13 1`] = `
+{
+  "_cmd": "de b 8, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, de w v 14 1`] = `
+{
+  "_cmd": "de b 8, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, de w v 15 1`] = `
+{
+  "_cmd": "de b 8, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, de w v 16 1`] = `
+{
+  "_cmd": "de b 8, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 8, de w v 17 1`] = `
+{
+  "_cmd": "de b 8, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 8, de w v 18 1`] = `
+{
+  "_cmd": "de b 8, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 8, de w v 19 1`] = `
+{
+  "_cmd": "de b 8, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 8, de w v 20 1`] = `
+{
+  "_cmd": "de b 8, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 9, de d 1 1`] = `
+{
+  "_cmd": "de b 9, de d 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b 9, de d 2 1`] = `
+{
+  "_cmd": "de b 9, de d 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, de d 3 1`] = `
+{
+  "_cmd": "de b 9, de d 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, de d 4 1`] = `
+{
+  "_cmd": "de b 9, de d 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de d 5 1`] = `
+{
+  "_cmd": "de b 9, de d 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, de d 6 1`] = `
+{
+  "_cmd": "de b 9, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, de d 7 1`] = `
+{
+  "_cmd": "de b 9, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de d 8 1`] = `
+{
+  "_cmd": "de b 9, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de d 9 1`] = `
+{
+  "_cmd": "de b 9, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de d 10 1`] = `
+{
+  "_cmd": "de b 9, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, de d 11 1`] = `
+{
+  "_cmd": "de b 9, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de d 12 1`] = `
+{
+  "_cmd": "de b 9, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de d 13 1`] = `
+{
+  "_cmd": "de b 9, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de d 14 1`] = `
+{
+  "_cmd": "de b 9, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de d 15 1`] = `
+{
+  "_cmd": "de b 9, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, de d v 1 1`] = `
+{
+  "_cmd": "de b 9, de d v 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b 9, de d v 2 1`] = `
+{
+  "_cmd": "de b 9, de d v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de d v 3 1`] = `
+{
+  "_cmd": "de b 9, de d v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, de d v 4 1`] = `
+{
+  "_cmd": "de b 9, de d v 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de d v 5 1`] = `
+{
+  "_cmd": "de b 9, de d v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, de d v 6 1`] = `
+{
+  "_cmd": "de b 9, de d v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de d v 7 1`] = `
+{
+  "_cmd": "de b 9, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de d v 8 1`] = `
+{
+  "_cmd": "de b 9, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de d v 9 1`] = `
+{
+  "_cmd": "de b 9, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de d v 10 1`] = `
+{
+  "_cmd": "de b 9, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, de d v 11 1`] = `
+{
+  "_cmd": "de b 9, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de d v 12 1`] = `
+{
+  "_cmd": "de b 9, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de d v 13 1`] = `
+{
+  "_cmd": "de b 9, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de d v 14 1`] = `
+{
+  "_cmd": "de b 9, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de d v 15 1`] = `
+{
+  "_cmd": "de b 9, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, de d v 16 1`] = `
+{
+  "_cmd": "de b 9, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 9, de d v 17 1`] = `
+{
+  "_cmd": "de b 9, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 9, de d v 18 1`] = `
+{
+  "_cmd": "de b 9, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 9, de d v 19 1`] = `
+{
+  "_cmd": "de b 9, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 9, de d v 20 1`] = `
+{
+  "_cmd": "de b 9, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 9, de p 1 1`] = `
+{
+  "_cmd": "de b 9, de p 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, de p 2 1`] = `
+{
+  "_cmd": "de b 9, de p 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de p 3 1`] = `
+{
+  "_cmd": "de b 9, de p 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, de p 4 1`] = `
+{
+  "_cmd": "de b 9, de p 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, de p 5 1`] = `
+{
+  "_cmd": "de b 9, de p 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de p 6 1`] = `
+{
+  "_cmd": "de b 9, de p 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de p 7 1`] = `
+{
+  "_cmd": "de b 9, de p 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, de p 8 1`] = `
+{
+  "_cmd": "de b 9, de p 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de p 9 1`] = `
+{
+  "_cmd": "de b 9, de p 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de p 10 1`] = `
+{
+  "_cmd": "de b 9, de p 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de p 11 1`] = `
+{
+  "_cmd": "de b 9, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de p 12 1`] = `
+{
+  "_cmd": "de b 9, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de p 13 1`] = `
+{
+  "_cmd": "de b 9, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de p 14 1`] = `
+{
+  "_cmd": "de b 9, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de p 15 1`] = `
+{
+  "_cmd": "de b 9, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de p v 1 1`] = `
+{
+  "_cmd": "de b 9, de p v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, de p v 2 1`] = `
+{
+  "_cmd": "de b 9, de p v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de p v 3 1`] = `
+{
+  "_cmd": "de b 9, de p v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, de p v 4 1`] = `
+{
+  "_cmd": "de b 9, de p v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, de p v 5 1`] = `
+{
+  "_cmd": "de b 9, de p v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de p v 6 1`] = `
+{
+  "_cmd": "de b 9, de p v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, de p v 7 1`] = `
+{
+  "_cmd": "de b 9, de p v 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de p v 8 1`] = `
+{
+  "_cmd": "de b 9, de p v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de p v 9 1`] = `
+{
+  "_cmd": "de b 9, de p v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de p v 10 1`] = `
+{
+  "_cmd": "de b 9, de p v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de p v 11 1`] = `
+{
+  "_cmd": "de b 9, de p v 11",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, de p v 12 1`] = `
+{
+  "_cmd": "de b 9, de p v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de p v 13 1`] = `
+{
+  "_cmd": "de b 9, de p v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de p v 14 1`] = `
+{
+  "_cmd": "de b 9, de p v 14",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de p v 15 1`] = `
+{
+  "_cmd": "de b 9, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de p v 16 1`] = `
+{
+  "_cmd": "de b 9, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, de p v 17 1`] = `
+{
+  "_cmd": "de b 9, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 9, de p v 18 1`] = `
+{
+  "_cmd": "de b 9, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 9, de p v 19 1`] = `
+{
+  "_cmd": "de b 9, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 9, de p v 20 1`] = `
+{
+  "_cmd": "de b 9, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 9, de v 1 1`] = `
+{
+  "_cmd": "de b 9, de v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, de v 2 1`] = `
+{
+  "_cmd": "de b 9, de v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de v 3 1`] = `
+{
+  "_cmd": "de b 9, de v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, de v 4 1`] = `
+{
+  "_cmd": "de b 9, de v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, de v 5 1`] = `
+{
+  "_cmd": "de b 9, de v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de v 6 1`] = `
+{
+  "_cmd": "de b 9, de v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de v 7 1`] = `
+{
+  "_cmd": "de b 9, de v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, de v 8 1`] = `
+{
+  "_cmd": "de b 9, de v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de v 9 1`] = `
+{
+  "_cmd": "de b 9, de v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de v 10 1`] = `
+{
+  "_cmd": "de b 9, de v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de v 11 1`] = `
+{
+  "_cmd": "de b 9, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de v 12 1`] = `
+{
+  "_cmd": "de b 9, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de v 13 1`] = `
+{
+  "_cmd": "de b 9, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de v 14 1`] = `
+{
+  "_cmd": "de b 9, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de v 15 1`] = `
+{
+  "_cmd": "de b 9, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de v 16 1`] = `
+{
+  "_cmd": "de b 9, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, de v 17 1`] = `
+{
+  "_cmd": "de b 9, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 9, de v 18 1`] = `
+{
+  "_cmd": "de b 9, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 9, de v 19 1`] = `
+{
+  "_cmd": "de b 9, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 9, de v 20 1`] = `
+{
+  "_cmd": "de b 9, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 9, de w 1 1`] = `
+{
+  "_cmd": "de b 9, de w 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de w 2 1`] = `
+{
+  "_cmd": "de b 9, de w 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, de w 3 1`] = `
+{
+  "_cmd": "de b 9, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de w 4 1`] = `
+{
+  "_cmd": "de b 9, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de w 5 1`] = `
+{
+  "_cmd": "de b 9, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, de w 6 1`] = `
+{
+  "_cmd": "de b 9, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de w 7 1`] = `
+{
+  "_cmd": "de b 9, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de w 8 1`] = `
+{
+  "_cmd": "de b 9, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de w 9 1`] = `
+{
+  "_cmd": "de b 9, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, de w 10 1`] = `
+{
+  "_cmd": "de b 9, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de w 11 1`] = `
+{
+  "_cmd": "de b 9, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de w 12 1`] = `
+{
+  "_cmd": "de b 9, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de w 13 1`] = `
+{
+  "_cmd": "de b 9, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de w 14 1`] = `
+{
+  "_cmd": "de b 9, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de w 15 1`] = `
+{
+  "_cmd": "de b 9, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 9, de w v 1 1`] = `
+{
+  "_cmd": "de b 9, de w v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, de w v 2 1`] = `
+{
+  "_cmd": "de b 9, de w v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, de w v 3 1`] = `
+{
+  "_cmd": "de b 9, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, de w v 4 1`] = `
+{
+  "_cmd": "de b 9, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, de w v 5 1`] = `
+{
+  "_cmd": "de b 9, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, de w v 6 1`] = `
+{
+  "_cmd": "de b 9, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, de w v 7 1`] = `
+{
+  "_cmd": "de b 9, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, de w v 8 1`] = `
+{
+  "_cmd": "de b 9, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, de w v 9 1`] = `
+{
+  "_cmd": "de b 9, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, de w v 10 1`] = `
+{
+  "_cmd": "de b 9, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, de w v 11 1`] = `
+{
+  "_cmd": "de b 9, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, de w v 12 1`] = `
+{
+  "_cmd": "de b 9, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, de w v 13 1`] = `
+{
+  "_cmd": "de b 9, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, de w v 14 1`] = `
+{
+  "_cmd": "de b 9, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, de w v 15 1`] = `
+{
+  "_cmd": "de b 9, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, de w v 16 1`] = `
+{
+  "_cmd": "de b 9, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 9, de w v 17 1`] = `
+{
+  "_cmd": "de b 9, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 9, de w v 18 1`] = `
+{
+  "_cmd": "de b 9, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 9, de w v 19 1`] = `
+{
+  "_cmd": "de b 9, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 9, de w v 20 1`] = `
+{
+  "_cmd": "de b 9, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b 10, de d 1 1`] = `
+{
+  "_cmd": "de b 10, de d 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b 10, de d 2 1`] = `
+{
+  "_cmd": "de b 10, de d 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, de d 3 1`] = `
+{
+  "_cmd": "de b 10, de d 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, de d 4 1`] = `
+{
+  "_cmd": "de b 10, de d 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de d 5 1`] = `
+{
+  "_cmd": "de b 10, de d 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de d 6 1`] = `
+{
+  "_cmd": "de b 10, de d 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de d 7 1`] = `
+{
+  "_cmd": "de b 10, de d 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, de d 8 1`] = `
+{
+  "_cmd": "de b 10, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de d 9 1`] = `
+{
+  "_cmd": "de b 10, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de d 10 1`] = `
+{
+  "_cmd": "de b 10, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de d 11 1`] = `
+{
+  "_cmd": "de b 10, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de d 12 1`] = `
+{
+  "_cmd": "de b 10, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de d 13 1`] = `
+{
+  "_cmd": "de b 10, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de d 14 1`] = `
+{
+  "_cmd": "de b 10, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de d 15 1`] = `
+{
+  "_cmd": "de b 10, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 10, de d v 1 1`] = `
+{
+  "_cmd": "de b 10, de d v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, de d v 2 1`] = `
+{
+  "_cmd": "de b 10, de d v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, de d v 3 1`] = `
+{
+  "_cmd": "de b 10, de d v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, de d v 4 1`] = `
+{
+  "_cmd": "de b 10, de d v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, de d v 5 1`] = `
+{
+  "_cmd": "de b 10, de d v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de d v 6 1`] = `
+{
+  "_cmd": "de b 10, de d v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, de d v 7 1`] = `
+{
+  "_cmd": "de b 10, de d v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de d v 8 1`] = `
+{
+  "_cmd": "de b 10, de d v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de d v 9 1`] = `
+{
+  "_cmd": "de b 10, de d v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de d v 10 1`] = `
+{
+  "_cmd": "de b 10, de d v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de d v 11 1`] = `
+{
+  "_cmd": "de b 10, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de d v 12 1`] = `
+{
+  "_cmd": "de b 10, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, de d v 13 1`] = `
+{
+  "_cmd": "de b 10, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de d v 14 1`] = `
+{
+  "_cmd": "de b 10, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de d v 15 1`] = `
+{
+  "_cmd": "de b 10, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de d v 16 1`] = `
+{
+  "_cmd": "de b 10, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 10, de d v 17 1`] = `
+{
+  "_cmd": "de b 10, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 10, de d v 18 1`] = `
+{
+  "_cmd": "de b 10, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 10, de d v 19 1`] = `
+{
+  "_cmd": "de b 10, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 10, de d v 20 1`] = `
+{
+  "_cmd": "de b 10, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 10, de p 1 1`] = `
+{
+  "_cmd": "de b 10, de p 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, de p 2 1`] = `
+{
+  "_cmd": "de b 10, de p 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, de p 3 1`] = `
+{
+  "_cmd": "de b 10, de p 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, de p 4 1`] = `
+{
+  "_cmd": "de b 10, de p 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, de p 5 1`] = `
+{
+  "_cmd": "de b 10, de p 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de p 6 1`] = `
+{
+  "_cmd": "de b 10, de p 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de p 7 1`] = `
+{
+  "_cmd": "de b 10, de p 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de p 8 1`] = `
+{
+  "_cmd": "de b 10, de p 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, de p 9 1`] = `
+{
+  "_cmd": "de b 10, de p 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de p 10 1`] = `
+{
+  "_cmd": "de b 10, de p 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de p 11 1`] = `
+{
+  "_cmd": "de b 10, de p 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de p 12 1`] = `
+{
+  "_cmd": "de b 10, de p 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de p 13 1`] = `
+{
+  "_cmd": "de b 10, de p 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de p 14 1`] = `
+{
+  "_cmd": "de b 10, de p 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de p 15 1`] = `
+{
+  "_cmd": "de b 10, de p 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de p v 1 1`] = `
+{
+  "_cmd": "de b 10, de p v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, de p v 2 1`] = `
+{
+  "_cmd": "de b 10, de p v 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b 10, de p v 3 1`] = `
+{
+  "_cmd": "de b 10, de p v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, de p v 4 1`] = `
+{
+  "_cmd": "de b 10, de p v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, de p v 5 1`] = `
+{
+  "_cmd": "de b 10, de p v 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de p v 6 1`] = `
+{
+  "_cmd": "de b 10, de p v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de p v 7 1`] = `
+{
+  "_cmd": "de b 10, de p v 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, de p v 8 1`] = `
+{
+  "_cmd": "de b 10, de p v 8",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de p v 9 1`] = `
+{
+  "_cmd": "de b 10, de p v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de p v 10 1`] = `
+{
+  "_cmd": "de b 10, de p v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de p v 11 1`] = `
+{
+  "_cmd": "de b 10, de p v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de p v 12 1`] = `
+{
+  "_cmd": "de b 10, de p v 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de p v 13 1`] = `
+{
+  "_cmd": "de b 10, de p v 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, de p v 14 1`] = `
+{
+  "_cmd": "de b 10, de p v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de p v 15 1`] = `
+{
+  "_cmd": "de b 10, de p v 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de p v 16 1`] = `
+{
+  "_cmd": "de b 10, de p v 16",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de p v 17 1`] = `
+{
+  "_cmd": "de b 10, de p v 17",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b 10, de p v 18 1`] = `
+{
+  "_cmd": "de b 10, de p v 18",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b 10, de p v 19 1`] = `
+{
+  "_cmd": "de b 10, de p v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b 10, de p v 20 1`] = `
+{
+  "_cmd": "de b 10, de p v 20",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b 10, de v 1 1`] = `
+{
+  "_cmd": "de b 10, de v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, de v 2 1`] = `
+{
+  "_cmd": "de b 10, de v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, de v 3 1`] = `
+{
+  "_cmd": "de b 10, de v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, de v 4 1`] = `
+{
+  "_cmd": "de b 10, de v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, de v 5 1`] = `
+{
+  "_cmd": "de b 10, de v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de v 6 1`] = `
+{
+  "_cmd": "de b 10, de v 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de v 7 1`] = `
+{
+  "_cmd": "de b 10, de v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de v 8 1`] = `
+{
+  "_cmd": "de b 10, de v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, de v 9 1`] = `
+{
+  "_cmd": "de b 10, de v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de v 10 1`] = `
+{
+  "_cmd": "de b 10, de v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de v 11 1`] = `
+{
+  "_cmd": "de b 10, de v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de v 12 1`] = `
+{
+  "_cmd": "de b 10, de v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, de v 13 1`] = `
+{
+  "_cmd": "de b 10, de v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de v 14 1`] = `
+{
+  "_cmd": "de b 10, de v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de v 15 1`] = `
+{
+  "_cmd": "de b 10, de v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de v 16 1`] = `
+{
+  "_cmd": "de b 10, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 10, de v 17 1`] = `
+{
+  "_cmd": "de b 10, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 10, de v 18 1`] = `
+{
+  "_cmd": "de b 10, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 10, de v 19 1`] = `
+{
+  "_cmd": "de b 10, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 10, de v 20 1`] = `
+{
+  "_cmd": "de b 10, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 10, de w 1 1`] = `
+{
+  "_cmd": "de b 10, de w 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, de w 2 1`] = `
+{
+  "_cmd": "de b 10, de w 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, de w 3 1`] = `
+{
+  "_cmd": "de b 10, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de w 4 1`] = `
+{
+  "_cmd": "de b 10, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de w 5 1`] = `
+{
+  "_cmd": "de b 10, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, de w 6 1`] = `
+{
+  "_cmd": "de b 10, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, de w 7 1`] = `
+{
+  "_cmd": "de b 10, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de w 8 1`] = `
+{
+  "_cmd": "de b 10, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de w 9 1`] = `
+{
+  "_cmd": "de b 10, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de w 10 1`] = `
+{
+  "_cmd": "de b 10, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de w 11 1`] = `
+{
+  "_cmd": "de b 10, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, de w 12 1`] = `
+{
+  "_cmd": "de b 10, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de w 13 1`] = `
+{
+  "_cmd": "de b 10, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de w 14 1`] = `
+{
+  "_cmd": "de b 10, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de w 15 1`] = `
+{
+  "_cmd": "de b 10, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 10, de w v 1 1`] = `
+{
+  "_cmd": "de b 10, de w v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, de w v 2 1`] = `
+{
+  "_cmd": "de b 10, de w v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, de w v 3 1`] = `
+{
+  "_cmd": "de b 10, de w v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, de w v 4 1`] = `
+{
+  "_cmd": "de b 10, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, de w v 5 1`] = `
+{
+  "_cmd": "de b 10, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, de w v 6 1`] = `
+{
+  "_cmd": "de b 10, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, de w v 7 1`] = `
+{
+  "_cmd": "de b 10, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, de w v 8 1`] = `
+{
+  "_cmd": "de b 10, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, de w v 9 1`] = `
+{
+  "_cmd": "de b 10, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, de w v 10 1`] = `
+{
+  "_cmd": "de b 10, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, de w v 11 1`] = `
+{
+  "_cmd": "de b 10, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, de w v 12 1`] = `
+{
+  "_cmd": "de b 10, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, de w v 13 1`] = `
+{
+  "_cmd": "de b 10, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, de w v 14 1`] = `
+{
+  "_cmd": "de b 10, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, de w v 15 1`] = `
+{
+  "_cmd": "de b 10, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 10, de w v 16 1`] = `
+{
+  "_cmd": "de b 10, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 10, de w v 17 1`] = `
+{
+  "_cmd": "de b 10, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 10, de w v 18 1`] = `
+{
+  "_cmd": "de b 10, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 10, de w v 19 1`] = `
+{
+  "_cmd": "de b 10, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 10, de w v 20 1`] = `
+{
+  "_cmd": "de b 10, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 11, de d 1 1`] = `
+{
+  "_cmd": "de b 11, de d 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b 11, de d 2 1`] = `
+{
+  "_cmd": "de b 11, de d 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, de d 3 1`] = `
+{
+  "_cmd": "de b 11, de d 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, de d 4 1`] = `
+{
+  "_cmd": "de b 11, de d 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, de d 5 1`] = `
+{
+  "_cmd": "de b 11, de d 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de d 6 1`] = `
+{
+  "_cmd": "de b 11, de d 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, de d 7 1`] = `
+{
+  "_cmd": "de b 11, de d 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de d 8 1`] = `
+{
+  "_cmd": "de b 11, de d 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, de d 9 1`] = `
+{
+  "_cmd": "de b 11, de d 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de d 10 1`] = `
+{
+  "_cmd": "de b 11, de d 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de d 11 1`] = `
+{
+  "_cmd": "de b 11, de d 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de d 12 1`] = `
+{
+  "_cmd": "de b 11, de d 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de d 13 1`] = `
+{
+  "_cmd": "de b 11, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de d 14 1`] = `
+{
+  "_cmd": "de b 11, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de d 15 1`] = `
+{
+  "_cmd": "de b 11, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de d v 1 1`] = `
+{
+  "_cmd": "de b 11, de d v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, de d v 2 1`] = `
+{
+  "_cmd": "de b 11, de d v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, de d v 3 1`] = `
+{
+  "_cmd": "de b 11, de d v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, de d v 4 1`] = `
+{
+  "_cmd": "de b 11, de d v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, de d v 5 1`] = `
+{
+  "_cmd": "de b 11, de d v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de d v 6 1`] = `
+{
+  "_cmd": "de b 11, de d v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, de d v 7 1`] = `
+{
+  "_cmd": "de b 11, de d v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, de d v 8 1`] = `
+{
+  "_cmd": "de b 11, de d v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de d v 9 1`] = `
+{
+  "_cmd": "de b 11, de d v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de d v 10 1`] = `
+{
+  "_cmd": "de b 11, de d v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de d v 11 1`] = `
+{
+  "_cmd": "de b 11, de d v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de d v 12 1`] = `
+{
+  "_cmd": "de b 11, de d v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de d v 13 1`] = `
+{
+  "_cmd": "de b 11, de d v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, de d v 14 1`] = `
+{
+  "_cmd": "de b 11, de d v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de d v 15 1`] = `
+{
+  "_cmd": "de b 11, de d v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de d v 16 1`] = `
+{
+  "_cmd": "de b 11, de d v 16",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de d v 17 1`] = `
+{
+  "_cmd": "de b 11, de d v 17",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b 11, de d v 18 1`] = `
+{
+  "_cmd": "de b 11, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 11, de d v 19 1`] = `
+{
+  "_cmd": "de b 11, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 11, de d v 20 1`] = `
+{
+  "_cmd": "de b 11, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 11, de p 1 1`] = `
+{
+  "_cmd": "de b 11, de p 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, de p 2 1`] = `
+{
+  "_cmd": "de b 11, de p 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, de p 3 1`] = `
+{
+  "_cmd": "de b 11, de p 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, de p 4 1`] = `
+{
+  "_cmd": "de b 11, de p 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, de p 5 1`] = `
+{
+  "_cmd": "de b 11, de p 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, de p 6 1`] = `
+{
+  "_cmd": "de b 11, de p 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de p 7 1`] = `
+{
+  "_cmd": "de b 11, de p 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, de p 8 1`] = `
+{
+  "_cmd": "de b 11, de p 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de p 9 1`] = `
+{
+  "_cmd": "de b 11, de p 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, de p 10 1`] = `
+{
+  "_cmd": "de b 11, de p 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de p 11 1`] = `
+{
+  "_cmd": "de b 11, de p 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de p 12 1`] = `
+{
+  "_cmd": "de b 11, de p 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de p 13 1`] = `
+{
+  "_cmd": "de b 11, de p 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de p 14 1`] = `
+{
+  "_cmd": "de b 11, de p 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de p 15 1`] = `
+{
+  "_cmd": "de b 11, de p 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de p v 1 1`] = `
+{
+  "_cmd": "de b 11, de p v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, de p v 2 1`] = `
+{
+  "_cmd": "de b 11, de p v 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b 11, de p v 3 1`] = `
+{
+  "_cmd": "de b 11, de p v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, de p v 4 1`] = `
+{
+  "_cmd": "de b 11, de p v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, de p v 5 1`] = `
+{
+  "_cmd": "de b 11, de p v 5",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, de p v 6 1`] = `
+{
+  "_cmd": "de b 11, de p v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de p v 7 1`] = `
+{
+  "_cmd": "de b 11, de p v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, de p v 8 1`] = `
+{
+  "_cmd": "de b 11, de p v 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, de p v 9 1`] = `
+{
+  "_cmd": "de b 11, de p v 9",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de p v 10 1`] = `
+{
+  "_cmd": "de b 11, de p v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de p v 11 1`] = `
+{
+  "_cmd": "de b 11, de p v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de p v 12 1`] = `
+{
+  "_cmd": "de b 11, de p v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de p v 13 1`] = `
+{
+  "_cmd": "de b 11, de p v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de p v 14 1`] = `
+{
+  "_cmd": "de b 11, de p v 14",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, de p v 15 1`] = `
+{
+  "_cmd": "de b 11, de p v 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de p v 16 1`] = `
+{
+  "_cmd": "de b 11, de p v 16",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de p v 17 1`] = `
+{
+  "_cmd": "de b 11, de p v 17",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de p v 18 1`] = `
+{
+  "_cmd": "de b 11, de p v 18",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b 11, de p v 19 1`] = `
+{
+  "_cmd": "de b 11, de p v 19",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b 11, de p v 20 1`] = `
+{
+  "_cmd": "de b 11, de p v 20",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b 11, de v 1 1`] = `
+{
+  "_cmd": "de b 11, de v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, de v 2 1`] = `
+{
+  "_cmd": "de b 11, de v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, de v 3 1`] = `
+{
+  "_cmd": "de b 11, de v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, de v 4 1`] = `
+{
+  "_cmd": "de b 11, de v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, de v 5 1`] = `
+{
+  "_cmd": "de b 11, de v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, de v 6 1`] = `
+{
+  "_cmd": "de b 11, de v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de v 7 1`] = `
+{
+  "_cmd": "de b 11, de v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, de v 8 1`] = `
+{
+  "_cmd": "de b 11, de v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de v 9 1`] = `
+{
+  "_cmd": "de b 11, de v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, de v 10 1`] = `
+{
+  "_cmd": "de b 11, de v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de v 11 1`] = `
+{
+  "_cmd": "de b 11, de v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de v 12 1`] = `
+{
+  "_cmd": "de b 11, de v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de v 13 1`] = `
+{
+  "_cmd": "de b 11, de v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, de v 14 1`] = `
+{
+  "_cmd": "de b 11, de v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de v 15 1`] = `
+{
+  "_cmd": "de b 11, de v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de v 16 1`] = `
+{
+  "_cmd": "de b 11, de v 16",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de v 17 1`] = `
+{
+  "_cmd": "de b 11, de v 17",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b 11, de v 18 1`] = `
+{
+  "_cmd": "de b 11, de v 18",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b 11, de v 19 1`] = `
+{
+  "_cmd": "de b 11, de v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b 11, de v 20 1`] = `
+{
+  "_cmd": "de b 11, de v 20",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b 11, de w 1 1`] = `
+{
+  "_cmd": "de b 11, de w 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, de w 2 1`] = `
+{
+  "_cmd": "de b 11, de w 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, de w 3 1`] = `
+{
+  "_cmd": "de b 11, de w 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, de w 4 1`] = `
+{
+  "_cmd": "de b 11, de w 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de w 5 1`] = `
+{
+  "_cmd": "de b 11, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, de w 6 1`] = `
+{
+  "_cmd": "de b 11, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, de w 7 1`] = `
+{
+  "_cmd": "de b 11, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, de w 8 1`] = `
+{
+  "_cmd": "de b 11, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de w 9 1`] = `
+{
+  "_cmd": "de b 11, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de w 10 1`] = `
+{
+  "_cmd": "de b 11, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de w 11 1`] = `
+{
+  "_cmd": "de b 11, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de w 12 1`] = `
+{
+  "_cmd": "de b 11, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, de w 13 1`] = `
+{
+  "_cmd": "de b 11, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de w 14 1`] = `
+{
+  "_cmd": "de b 11, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de w 15 1`] = `
+{
+  "_cmd": "de b 11, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de w v 1 1`] = `
+{
+  "_cmd": "de b 11, de w v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, de w v 2 1`] = `
+{
+  "_cmd": "de b 11, de w v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, de w v 3 1`] = `
+{
+  "_cmd": "de b 11, de w v 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, de w v 4 1`] = `
+{
+  "_cmd": "de b 11, de w v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, de w v 5 1`] = `
+{
+  "_cmd": "de b 11, de w v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, de w v 6 1`] = `
+{
+  "_cmd": "de b 11, de w v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, de w v 7 1`] = `
+{
+  "_cmd": "de b 11, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, de w v 8 1`] = `
+{
+  "_cmd": "de b 11, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, de w v 9 1`] = `
+{
+  "_cmd": "de b 11, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, de w v 10 1`] = `
+{
+  "_cmd": "de b 11, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, de w v 11 1`] = `
+{
+  "_cmd": "de b 11, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, de w v 12 1`] = `
+{
+  "_cmd": "de b 11, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, de w v 13 1`] = `
+{
+  "_cmd": "de b 11, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, de w v 14 1`] = `
+{
+  "_cmd": "de b 11, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, de w v 15 1`] = `
+{
+  "_cmd": "de b 11, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, de w v 16 1`] = `
+{
+  "_cmd": "de b 11, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 11, de w v 17 1`] = `
+{
+  "_cmd": "de b 11, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 11, de w v 18 1`] = `
+{
+  "_cmd": "de b 11, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 11, de w v 19 1`] = `
+{
+  "_cmd": "de b 11, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 11, de w v 20 1`] = `
+{
+  "_cmd": "de b 11, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 12, de d 1 1`] = `
+{
+  "_cmd": "de b 12, de d 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, de d 2 1`] = `
+{
+  "_cmd": "de b 12, de d 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, de d 3 1`] = `
+{
+  "_cmd": "de b 12, de d 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de d 4 1`] = `
+{
+  "_cmd": "de b 12, de d 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, de d 5 1`] = `
+{
+  "_cmd": "de b 12, de d 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de d 6 1`] = `
+{
+  "_cmd": "de b 12, de d 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de d 7 1`] = `
+{
+  "_cmd": "de b 12, de d 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de d 8 1`] = `
+{
+  "_cmd": "de b 12, de d 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de d 9 1`] = `
+{
+  "_cmd": "de b 12, de d 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, de d 10 1`] = `
+{
+  "_cmd": "de b 12, de d 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de d 11 1`] = `
+{
+  "_cmd": "de b 12, de d 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de d 12 1`] = `
+{
+  "_cmd": "de b 12, de d 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de d 13 1`] = `
+{
+  "_cmd": "de b 12, de d 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de d 14 1`] = `
+{
+  "_cmd": "de b 12, de d 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de d 15 1`] = `
+{
+  "_cmd": "de b 12, de d 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de d v 1 1`] = `
+{
+  "_cmd": "de b 12, de d v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, de d v 2 1`] = `
+{
+  "_cmd": "de b 12, de d v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, de d v 3 1`] = `
+{
+  "_cmd": "de b 12, de d v 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de d v 4 1`] = `
+{
+  "_cmd": "de b 12, de d v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, de d v 5 1`] = `
+{
+  "_cmd": "de b 12, de d v 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de d v 6 1`] = `
+{
+  "_cmd": "de b 12, de d v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de d v 7 1`] = `
+{
+  "_cmd": "de b 12, de d v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, de d v 8 1`] = `
+{
+  "_cmd": "de b 12, de d v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de d v 9 1`] = `
+{
+  "_cmd": "de b 12, de d v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de d v 10 1`] = `
+{
+  "_cmd": "de b 12, de d v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de d v 11 1`] = `
+{
+  "_cmd": "de b 12, de d v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de d v 12 1`] = `
+{
+  "_cmd": "de b 12, de d v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de d v 13 1`] = `
+{
+  "_cmd": "de b 12, de d v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de d v 14 1`] = `
+{
+  "_cmd": "de b 12, de d v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de d v 15 1`] = `
+{
+  "_cmd": "de b 12, de d v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de d v 16 1`] = `
+{
+  "_cmd": "de b 12, de d v 16",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de d v 17 1`] = `
+{
+  "_cmd": "de b 12, de d v 17",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b 12, de d v 18 1`] = `
+{
+  "_cmd": "de b 12, de d v 18",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b 12, de d v 19 1`] = `
+{
+  "_cmd": "de b 12, de d v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b 12, de d v 20 1`] = `
+{
+  "_cmd": "de b 12, de d v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de b 12, de p 1 1`] = `
+{
+  "_cmd": "de b 12, de p 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, de p 2 1`] = `
+{
+  "_cmd": "de b 12, de p 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, de p 3 1`] = `
+{
+  "_cmd": "de b 12, de p 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, de p 4 1`] = `
+{
+  "_cmd": "de b 12, de p 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de p 5 1`] = `
+{
+  "_cmd": "de b 12, de p 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, de p 6 1`] = `
+{
+  "_cmd": "de b 12, de p 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de p 7 1`] = `
+{
+  "_cmd": "de b 12, de p 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de p 8 1`] = `
+{
+  "_cmd": "de b 12, de p 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de p 9 1`] = `
+{
+  "_cmd": "de b 12, de p 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de p 10 1`] = `
+{
+  "_cmd": "de b 12, de p 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, de p 11 1`] = `
+{
+  "_cmd": "de b 12, de p 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de p 12 1`] = `
+{
+  "_cmd": "de b 12, de p 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de p 13 1`] = `
+{
+  "_cmd": "de b 12, de p 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de p 14 1`] = `
+{
+  "_cmd": "de b 12, de p 14",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de p 15 1`] = `
+{
+  "_cmd": "de b 12, de p 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de p v 1 1`] = `
+{
+  "_cmd": "de b 12, de p v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, de p v 2 1`] = `
+{
+  "_cmd": "de b 12, de p v 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, de p v 3 1`] = `
+{
+  "_cmd": "de b 12, de p v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, de p v 4 1`] = `
+{
+  "_cmd": "de b 12, de p v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de p v 5 1`] = `
+{
+  "_cmd": "de b 12, de p v 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, de p v 6 1`] = `
+{
+  "_cmd": "de b 12, de p v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de p v 7 1`] = `
+{
+  "_cmd": "de b 12, de p v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de p v 8 1`] = `
+{
+  "_cmd": "de b 12, de p v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, de p v 9 1`] = `
+{
+  "_cmd": "de b 12, de p v 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de p v 10 1`] = `
+{
+  "_cmd": "de b 12, de p v 10",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de p v 11 1`] = `
+{
+  "_cmd": "de b 12, de p v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de p v 12 1`] = `
+{
+  "_cmd": "de b 12, de p v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de p v 13 1`] = `
+{
+  "_cmd": "de b 12, de p v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de p v 14 1`] = `
+{
+  "_cmd": "de b 12, de p v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de p v 15 1`] = `
+{
+  "_cmd": "de b 12, de p v 15",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de p v 16 1`] = `
+{
+  "_cmd": "de b 12, de p v 16",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de p v 17 1`] = `
+{
+  "_cmd": "de b 12, de p v 17",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de p v 18 1`] = `
+{
+  "_cmd": "de b 12, de p v 18",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b 12, de p v 19 1`] = `
+{
+  "_cmd": "de b 12, de p v 19",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b 12, de p v 20 1`] = `
+{
+  "_cmd": "de b 12, de p v 20",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b 12, de v 1 1`] = `
+{
+  "_cmd": "de b 12, de v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, de v 2 1`] = `
+{
+  "_cmd": "de b 12, de v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, de v 3 1`] = `
+{
+  "_cmd": "de b 12, de v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, de v 4 1`] = `
+{
+  "_cmd": "de b 12, de v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de v 5 1`] = `
+{
+  "_cmd": "de b 12, de v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, de v 6 1`] = `
+{
+  "_cmd": "de b 12, de v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de v 7 1`] = `
+{
+  "_cmd": "de b 12, de v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de v 8 1`] = `
+{
+  "_cmd": "de b 12, de v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de v 9 1`] = `
+{
+  "_cmd": "de b 12, de v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de v 10 1`] = `
+{
+  "_cmd": "de b 12, de v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, de v 11 1`] = `
+{
+  "_cmd": "de b 12, de v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de v 12 1`] = `
+{
+  "_cmd": "de b 12, de v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de v 13 1`] = `
+{
+  "_cmd": "de b 12, de v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de v 14 1`] = `
+{
+  "_cmd": "de b 12, de v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de v 15 1`] = `
+{
+  "_cmd": "de b 12, de v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de v 16 1`] = `
+{
+  "_cmd": "de b 12, de v 16",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de v 17 1`] = `
+{
+  "_cmd": "de b 12, de v 17",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b 12, de v 18 1`] = `
+{
+  "_cmd": "de b 12, de v 18",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b 12, de v 19 1`] = `
+{
+  "_cmd": "de b 12, de v 19",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b 12, de v 20 1`] = `
+{
+  "_cmd": "de b 12, de v 20",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b 12, de w 1 1`] = `
+{
+  "_cmd": "de b 12, de w 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, de w 2 1`] = `
+{
+  "_cmd": "de b 12, de w 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de w 3 1`] = `
+{
+  "_cmd": "de b 12, de w 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, de w 4 1`] = `
+{
+  "_cmd": "de b 12, de w 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de w 5 1`] = `
+{
+  "_cmd": "de b 12, de w 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de w 6 1`] = `
+{
+  "_cmd": "de b 12, de w 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de w 7 1`] = `
+{
+  "_cmd": "de b 12, de w 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, de w 8 1`] = `
+{
+  "_cmd": "de b 12, de w 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, de w 9 1`] = `
+{
+  "_cmd": "de b 12, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de w 10 1`] = `
+{
+  "_cmd": "de b 12, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de w 11 1`] = `
+{
+  "_cmd": "de b 12, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de w 12 1`] = `
+{
+  "_cmd": "de b 12, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de w 13 1`] = `
+{
+  "_cmd": "de b 12, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de w 14 1`] = `
+{
+  "_cmd": "de b 12, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de w 15 1`] = `
+{
+  "_cmd": "de b 12, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de w v 1 1`] = `
+{
+  "_cmd": "de b 12, de w v 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, de w v 2 1`] = `
+{
+  "_cmd": "de b 12, de w v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, de w v 3 1`] = `
+{
+  "_cmd": "de b 12, de w v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, de w v 4 1`] = `
+{
+  "_cmd": "de b 12, de w v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, de w v 5 1`] = `
+{
+  "_cmd": "de b 12, de w v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, de w v 6 1`] = `
+{
+  "_cmd": "de b 12, de w v 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, de w v 7 1`] = `
+{
+  "_cmd": "de b 12, de w v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, de w v 8 1`] = `
+{
+  "_cmd": "de b 12, de w v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, de w v 9 1`] = `
+{
+  "_cmd": "de b 12, de w v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, de w v 10 1`] = `
+{
+  "_cmd": "de b 12, de w v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, de w v 11 1`] = `
+{
+  "_cmd": "de b 12, de w v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, de w v 12 1`] = `
+{
+  "_cmd": "de b 12, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, de w v 13 1`] = `
+{
+  "_cmd": "de b 12, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, de w v 14 1`] = `
+{
+  "_cmd": "de b 12, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, de w v 15 1`] = `
+{
+  "_cmd": "de b 12, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, de w v 16 1`] = `
+{
+  "_cmd": "de b 12, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 12, de w v 17 1`] = `
+{
+  "_cmd": "de b 12, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b 12, de w v 18 1`] = `
+{
+  "_cmd": "de b 12, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b 12, de w v 19 1`] = `
+{
+  "_cmd": "de b 12, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b 12, de w v 20 1`] = `
+{
+  "_cmd": "de b 12, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b 13, de d 1 1`] = `
+{
+  "_cmd": "de b 13, de d 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, de d 2 1`] = `
+{
+  "_cmd": "de b 13, de d 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, de d 3 1`] = `
+{
+  "_cmd": "de b 13, de d 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de d 4 1`] = `
+{
+  "_cmd": "de b 13, de d 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, de d 5 1`] = `
+{
+  "_cmd": "de b 13, de d 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, de d 6 1`] = `
+{
+  "_cmd": "de b 13, de d 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de d 7 1`] = `
+{
+  "_cmd": "de b 13, de d 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de d 8 1`] = `
+{
+  "_cmd": "de b 13, de d 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de d 9 1`] = `
+{
+  "_cmd": "de b 13, de d 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de d 10 1`] = `
+{
+  "_cmd": "de b 13, de d 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de d 11 1`] = `
+{
+  "_cmd": "de b 13, de d 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de d 12 1`] = `
+{
+  "_cmd": "de b 13, de d 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de d 13 1`] = `
+{
+  "_cmd": "de b 13, de d 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de d 14 1`] = `
+{
+  "_cmd": "de b 13, de d 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de d 15 1`] = `
+{
+  "_cmd": "de b 13, de d 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de d v 1 1`] = `
+{
+  "_cmd": "de b 13, de d v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, de d v 2 1`] = `
+{
+  "_cmd": "de b 13, de d v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, de d v 3 1`] = `
+{
+  "_cmd": "de b 13, de d v 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de d v 4 1`] = `
+{
+  "_cmd": "de b 13, de d v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, de d v 5 1`] = `
+{
+  "_cmd": "de b 13, de d v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, de d v 6 1`] = `
+{
+  "_cmd": "de b 13, de d v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de d v 7 1`] = `
+{
+  "_cmd": "de b 13, de d v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de d v 8 1`] = `
+{
+  "_cmd": "de b 13, de d v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, de d v 9 1`] = `
+{
+  "_cmd": "de b 13, de d v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de d v 10 1`] = `
+{
+  "_cmd": "de b 13, de d v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de d v 11 1`] = `
+{
+  "_cmd": "de b 13, de d v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de d v 12 1`] = `
+{
+  "_cmd": "de b 13, de d v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de d v 13 1`] = `
+{
+  "_cmd": "de b 13, de d v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de d v 14 1`] = `
+{
+  "_cmd": "de b 13, de d v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de d v 15 1`] = `
+{
+  "_cmd": "de b 13, de d v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de d v 16 1`] = `
+{
+  "_cmd": "de b 13, de d v 16",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, de d v 17 1`] = `
+{
+  "_cmd": "de b 13, de d v 17",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b 13, de d v 18 1`] = `
+{
+  "_cmd": "de b 13, de d v 18",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b 13, de d v 19 1`] = `
+{
+  "_cmd": "de b 13, de d v 19",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b 13, de d v 20 1`] = `
+{
+  "_cmd": "de b 13, de d v 20",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b 13, de p 1 1`] = `
+{
+  "_cmd": "de b 13, de p 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, de p 2 1`] = `
+{
+  "_cmd": "de b 13, de p 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, de p 3 1`] = `
+{
+  "_cmd": "de b 13, de p 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, de p 4 1`] = `
+{
+  "_cmd": "de b 13, de p 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de p 5 1`] = `
+{
+  "_cmd": "de b 13, de p 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, de p 6 1`] = `
+{
+  "_cmd": "de b 13, de p 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, de p 7 1`] = `
+{
+  "_cmd": "de b 13, de p 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de p 8 1`] = `
+{
+  "_cmd": "de b 13, de p 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de p 9 1`] = `
+{
+  "_cmd": "de b 13, de p 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de p 10 1`] = `
+{
+  "_cmd": "de b 13, de p 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de p 11 1`] = `
+{
+  "_cmd": "de b 13, de p 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de p 12 1`] = `
+{
+  "_cmd": "de b 13, de p 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de p 13 1`] = `
+{
+  "_cmd": "de b 13, de p 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de p 14 1`] = `
+{
+  "_cmd": "de b 13, de p 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de p 15 1`] = `
+{
+  "_cmd": "de b 13, de p 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de p v 1 1`] = `
+{
+  "_cmd": "de b 13, de p v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, de p v 2 1`] = `
+{
+  "_cmd": "de b 13, de p v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, de p v 3 1`] = `
+{
+  "_cmd": "de b 13, de p v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, de p v 4 1`] = `
+{
+  "_cmd": "de b 13, de p v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de p v 5 1`] = `
+{
+  "_cmd": "de b 13, de p v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, de p v 6 1`] = `
+{
+  "_cmd": "de b 13, de p v 6",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, de p v 7 1`] = `
+{
+  "_cmd": "de b 13, de p v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de p v 8 1`] = `
+{
+  "_cmd": "de b 13, de p v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de p v 9 1`] = `
+{
+  "_cmd": "de b 13, de p v 9",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, de p v 10 1`] = `
+{
+  "_cmd": "de b 13, de p v 10",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de p v 11 1`] = `
+{
+  "_cmd": "de b 13, de p v 11",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de p v 12 1`] = `
+{
+  "_cmd": "de b 13, de p v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de p v 13 1`] = `
+{
+  "_cmd": "de b 13, de p v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de p v 14 1`] = `
+{
+  "_cmd": "de b 13, de p v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de p v 15 1`] = `
+{
+  "_cmd": "de b 13, de p v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de p v 16 1`] = `
+{
+  "_cmd": "de b 13, de p v 16",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de p v 17 1`] = `
+{
+  "_cmd": "de b 13, de p v 17",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, de p v 18 1`] = `
+{
+  "_cmd": "de b 13, de p v 18",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de b 13, de p v 19 1`] = `
+{
+  "_cmd": "de b 13, de p v 19",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b 13, de p v 20 1`] = `
+{
+  "_cmd": "de b 13, de p v 20",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b 13, de v 1 1`] = `
+{
+  "_cmd": "de b 13, de v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, de v 2 1`] = `
+{
+  "_cmd": "de b 13, de v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, de v 3 1`] = `
+{
+  "_cmd": "de b 13, de v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, de v 4 1`] = `
+{
+  "_cmd": "de b 13, de v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de v 5 1`] = `
+{
+  "_cmd": "de b 13, de v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, de v 6 1`] = `
+{
+  "_cmd": "de b 13, de v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, de v 7 1`] = `
+{
+  "_cmd": "de b 13, de v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de v 8 1`] = `
+{
+  "_cmd": "de b 13, de v 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de v 9 1`] = `
+{
+  "_cmd": "de b 13, de v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de v 10 1`] = `
+{
+  "_cmd": "de b 13, de v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de v 11 1`] = `
+{
+  "_cmd": "de b 13, de v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de v 12 1`] = `
+{
+  "_cmd": "de b 13, de v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de v 13 1`] = `
+{
+  "_cmd": "de b 13, de v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de v 14 1`] = `
+{
+  "_cmd": "de b 13, de v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de v 15 1`] = `
+{
+  "_cmd": "de b 13, de v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de v 16 1`] = `
+{
+  "_cmd": "de b 13, de v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, de v 17 1`] = `
+{
+  "_cmd": "de b 13, de v 17",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b 13, de v 18 1`] = `
+{
+  "_cmd": "de b 13, de v 18",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b 13, de v 19 1`] = `
+{
+  "_cmd": "de b 13, de v 19",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b 13, de v 20 1`] = `
+{
+  "_cmd": "de b 13, de v 20",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b 13, de w 1 1`] = `
+{
+  "_cmd": "de b 13, de w 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, de w 2 1`] = `
+{
+  "_cmd": "de b 13, de w 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, de w 3 1`] = `
+{
+  "_cmd": "de b 13, de w 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, de w 4 1`] = `
+{
+  "_cmd": "de b 13, de w 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, de w 5 1`] = `
+{
+  "_cmd": "de b 13, de w 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de w 6 1`] = `
+{
+  "_cmd": "de b 13, de w 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, de w 7 1`] = `
+{
+  "_cmd": "de b 13, de w 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, de w 8 1`] = `
+{
+  "_cmd": "de b 13, de w 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de w 9 1`] = `
+{
+  "_cmd": "de b 13, de w 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de w 10 1`] = `
+{
+  "_cmd": "de b 13, de w 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de w 11 1`] = `
+{
+  "_cmd": "de b 13, de w 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de w 12 1`] = `
+{
+  "_cmd": "de b 13, de w 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de w 13 1`] = `
+{
+  "_cmd": "de b 13, de w 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de w 14 1`] = `
+{
+  "_cmd": "de b 13, de w 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de w 15 1`] = `
+{
+  "_cmd": "de b 13, de w 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, de w v 1 1`] = `
+{
+  "_cmd": "de b 13, de w v 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, de w v 2 1`] = `
+{
+  "_cmd": "de b 13, de w v 2",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, de w v 3 1`] = `
+{
+  "_cmd": "de b 13, de w v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, de w v 4 1`] = `
+{
+  "_cmd": "de b 13, de w v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, de w v 5 1`] = `
+{
+  "_cmd": "de b 13, de w v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, de w v 6 1`] = `
+{
+  "_cmd": "de b 13, de w v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, de w v 7 1`] = `
+{
+  "_cmd": "de b 13, de w v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, de w v 8 1`] = `
+{
+  "_cmd": "de b 13, de w v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, de w v 9 1`] = `
+{
+  "_cmd": "de b 13, de w v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, de w v 10 1`] = `
+{
+  "_cmd": "de b 13, de w v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, de w v 11 1`] = `
+{
+  "_cmd": "de b 13, de w v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, de w v 12 1`] = `
+{
+  "_cmd": "de b 13, de w v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, de w v 13 1`] = `
+{
+  "_cmd": "de b 13, de w v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, de w v 14 1`] = `
+{
+  "_cmd": "de b 13, de w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, de w v 15 1`] = `
+{
+  "_cmd": "de b 13, de w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, de w v 16 1`] = `
+{
+  "_cmd": "de b 13, de w v 16",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b 13, de w v 17 1`] = `
+{
+  "_cmd": "de b 13, de w v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b 13, de w v 18 1`] = `
+{
+  "_cmd": "de b 13, de w v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b 13, de w v 19 1`] = `
+{
+  "_cmd": "de b 13, de w v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b 13, de w v 20 1`] = `
+{
+  "_cmd": "de b 13, de w v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de b 14, de d 1 1`] = `
+{
+  "_cmd": "de b 14, de d 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, de d 2 1`] = `
+{
+  "_cmd": "de b 14, de d 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, de d 3 1`] = `
+{
+  "_cmd": "de b 14, de d 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, de d 4 1`] = `
+{
+  "_cmd": "de b 14, de d 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, de d 5 1`] = `
+{
+  "_cmd": "de b 14, de d 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, de d 6 1`] = `
+{
+  "_cmd": "de b 14, de d 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de d 7 1`] = `
+{
+  "_cmd": "de b 14, de d 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de d 8 1`] = `
+{
+  "_cmd": "de b 14, de d 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de d 9 1`] = `
+{
+  "_cmd": "de b 14, de d 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de d 10 1`] = `
+{
+  "_cmd": "de b 14, de d 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de d 11 1`] = `
+{
+  "_cmd": "de b 14, de d 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de d 12 1`] = `
+{
+  "_cmd": "de b 14, de d 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de d 13 1`] = `
+{
+  "_cmd": "de b 14, de d 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de d 14 1`] = `
+{
+  "_cmd": "de b 14, de d 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de d 15 1`] = `
+{
+  "_cmd": "de b 14, de d 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, de d v 1 1`] = `
+{
+  "_cmd": "de b 14, de d v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, de d v 2 1`] = `
+{
+  "_cmd": "de b 14, de d v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, de d v 3 1`] = `
+{
+  "_cmd": "de b 14, de d v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, de d v 4 1`] = `
+{
+  "_cmd": "de b 14, de d v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, de d v 5 1`] = `
+{
+  "_cmd": "de b 14, de d v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, de d v 6 1`] = `
+{
+  "_cmd": "de b 14, de d v 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de d v 7 1`] = `
+{
+  "_cmd": "de b 14, de d v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de d v 8 1`] = `
+{
+  "_cmd": "de b 14, de d v 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, de d v 9 1`] = `
+{
+  "_cmd": "de b 14, de d v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de d v 10 1`] = `
+{
+  "_cmd": "de b 14, de d v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de d v 11 1`] = `
+{
+  "_cmd": "de b 14, de d v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de d v 12 1`] = `
+{
+  "_cmd": "de b 14, de d v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de d v 13 1`] = `
+{
+  "_cmd": "de b 14, de d v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de d v 14 1`] = `
+{
+  "_cmd": "de b 14, de d v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de d v 15 1`] = `
+{
+  "_cmd": "de b 14, de d v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, de d v 16 1`] = `
+{
+  "_cmd": "de b 14, de d v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, de d v 17 1`] = `
+{
+  "_cmd": "de b 14, de d v 17",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b 14, de d v 18 1`] = `
+{
+  "_cmd": "de b 14, de d v 18",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b 14, de d v 19 1`] = `
+{
+  "_cmd": "de b 14, de d v 19",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b 14, de d v 20 1`] = `
+{
+  "_cmd": "de b 14, de d v 20",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b 14, de p 1 1`] = `
+{
+  "_cmd": "de b 14, de p 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, de p 2 1`] = `
+{
+  "_cmd": "de b 14, de p 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, de p 3 1`] = `
+{
+  "_cmd": "de b 14, de p 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, de p 4 1`] = `
+{
+  "_cmd": "de b 14, de p 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, de p 5 1`] = `
+{
+  "_cmd": "de b 14, de p 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, de p 6 1`] = `
+{
+  "_cmd": "de b 14, de p 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, de p 7 1`] = `
+{
+  "_cmd": "de b 14, de p 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de p 8 1`] = `
+{
+  "_cmd": "de b 14, de p 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de p 9 1`] = `
+{
+  "_cmd": "de b 14, de p 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, de p 10 1`] = `
+{
+  "_cmd": "de b 14, de p 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de p 11 1`] = `
+{
+  "_cmd": "de b 14, de p 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de p 12 1`] = `
+{
+  "_cmd": "de b 14, de p 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de p 13 1`] = `
+{
+  "_cmd": "de b 14, de p 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de p 14 1`] = `
+{
+  "_cmd": "de b 14, de p 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de p 15 1`] = `
+{
+  "_cmd": "de b 14, de p 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de p v 1 1`] = `
+{
+  "_cmd": "de b 14, de p v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, de p v 2 1`] = `
+{
+  "_cmd": "de b 14, de p v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, de p v 3 1`] = `
+{
+  "_cmd": "de b 14, de p v 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, de p v 4 1`] = `
+{
+  "_cmd": "de b 14, de p v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, de p v 5 1`] = `
+{
+  "_cmd": "de b 14, de p v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, de p v 6 1`] = `
+{
+  "_cmd": "de b 14, de p v 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, de p v 7 1`] = `
+{
+  "_cmd": "de b 14, de p v 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de p v 8 1`] = `
+{
+  "_cmd": "de b 14, de p v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de p v 9 1`] = `
+{
+  "_cmd": "de b 14, de p v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, de p v 10 1`] = `
+{
+  "_cmd": "de b 14, de p v 10",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de p v 11 1`] = `
+{
+  "_cmd": "de b 14, de p v 11",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de p v 12 1`] = `
+{
+  "_cmd": "de b 14, de p v 12",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de p v 13 1`] = `
+{
+  "_cmd": "de b 14, de p v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de p v 14 1`] = `
+{
+  "_cmd": "de b 14, de p v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de p v 15 1`] = `
+{
+  "_cmd": "de b 14, de p v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de p v 16 1`] = `
+{
+  "_cmd": "de b 14, de p v 16",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, de p v 17 1`] = `
+{
+  "_cmd": "de b 14, de p v 17",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, de p v 18 1`] = `
+{
+  "_cmd": "de b 14, de p v 18",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de b 14, de p v 19 1`] = `
+{
+  "_cmd": "de b 14, de p v 19",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de b 14, de p v 20 1`] = `
+{
+  "_cmd": "de b 14, de p v 20",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de b 14, de v 1 1`] = `
+{
+  "_cmd": "de b 14, de v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, de v 2 1`] = `
+{
+  "_cmd": "de b 14, de v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, de v 3 1`] = `
+{
+  "_cmd": "de b 14, de v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, de v 4 1`] = `
+{
+  "_cmd": "de b 14, de v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, de v 5 1`] = `
+{
+  "_cmd": "de b 14, de v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, de v 6 1`] = `
+{
+  "_cmd": "de b 14, de v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, de v 7 1`] = `
+{
+  "_cmd": "de b 14, de v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de v 8 1`] = `
+{
+  "_cmd": "de b 14, de v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de v 9 1`] = `
+{
+  "_cmd": "de b 14, de v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de v 10 1`] = `
+{
+  "_cmd": "de b 14, de v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de v 11 1`] = `
+{
+  "_cmd": "de b 14, de v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de v 12 1`] = `
+{
+  "_cmd": "de b 14, de v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de v 13 1`] = `
+{
+  "_cmd": "de b 14, de v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de v 14 1`] = `
+{
+  "_cmd": "de b 14, de v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de v 15 1`] = `
+{
+  "_cmd": "de b 14, de v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de v 16 1`] = `
+{
+  "_cmd": "de b 14, de v 16",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, de v 17 1`] = `
+{
+  "_cmd": "de b 14, de v 17",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de b 14, de v 18 1`] = `
+{
+  "_cmd": "de b 14, de v 18",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b 14, de v 19 1`] = `
+{
+  "_cmd": "de b 14, de v 19",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b 14, de v 20 1`] = `
+{
+  "_cmd": "de b 14, de v 20",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b 14, de w 1 1`] = `
+{
+  "_cmd": "de b 14, de w 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, de w 2 1`] = `
+{
+  "_cmd": "de b 14, de w 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, de w 3 1`] = `
+{
+  "_cmd": "de b 14, de w 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, de w 4 1`] = `
+{
+  "_cmd": "de b 14, de w 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, de w 5 1`] = `
+{
+  "_cmd": "de b 14, de w 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de w 6 1`] = `
+{
+  "_cmd": "de b 14, de w 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de w 7 1`] = `
+{
+  "_cmd": "de b 14, de w 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de w 8 1`] = `
+{
+  "_cmd": "de b 14, de w 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, de w 9 1`] = `
+{
+  "_cmd": "de b 14, de w 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de w 10 1`] = `
+{
+  "_cmd": "de b 14, de w 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de w 11 1`] = `
+{
+  "_cmd": "de b 14, de w 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de w 12 1`] = `
+{
+  "_cmd": "de b 14, de w 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de w 13 1`] = `
+{
+  "_cmd": "de b 14, de w 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de w 14 1`] = `
+{
+  "_cmd": "de b 14, de w 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, de w 15 1`] = `
+{
+  "_cmd": "de b 14, de w 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, de w v 1 1`] = `
+{
+  "_cmd": "de b 14, de w v 1",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, de w v 2 1`] = `
+{
+  "_cmd": "de b 14, de w v 2",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, de w v 3 1`] = `
+{
+  "_cmd": "de b 14, de w v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, de w v 4 1`] = `
+{
+  "_cmd": "de b 14, de w v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, de w v 5 1`] = `
+{
+  "_cmd": "de b 14, de w v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, de w v 6 1`] = `
+{
+  "_cmd": "de b 14, de w v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, de w v 7 1`] = `
+{
+  "_cmd": "de b 14, de w v 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, de w v 8 1`] = `
+{
+  "_cmd": "de b 14, de w v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, de w v 9 1`] = `
+{
+  "_cmd": "de b 14, de w v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, de w v 10 1`] = `
+{
+  "_cmd": "de b 14, de w v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, de w v 11 1`] = `
+{
+  "_cmd": "de b 14, de w v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, de w v 12 1`] = `
+{
+  "_cmd": "de b 14, de w v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, de w v 13 1`] = `
+{
+  "_cmd": "de b 14, de w v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, de w v 14 1`] = `
+{
+  "_cmd": "de b 14, de w v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, de w v 15 1`] = `
+{
+  "_cmd": "de b 14, de w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, de w v 16 1`] = `
+{
+  "_cmd": "de b 14, de w v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b 14, de w v 17 1`] = `
+{
+  "_cmd": "de b 14, de w v 17",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b 14, de w v 18 1`] = `
+{
+  "_cmd": "de b 14, de w v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b 14, de w v 19 1`] = `
+{
+  "_cmd": "de b 14, de w v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b 14, de w v 20 1`] = `
+{
+  "_cmd": "de b 14, de w v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de b 15, de d 1 1`] = `
+{
+  "_cmd": "de b 15, de d 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, de d 2 1`] = `
+{
+  "_cmd": "de b 15, de d 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, de d 3 1`] = `
+{
+  "_cmd": "de b 15, de d 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, de d 4 1`] = `
+{
+  "_cmd": "de b 15, de d 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de d 5 1`] = `
+{
+  "_cmd": "de b 15, de d 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de d 6 1`] = `
+{
+  "_cmd": "de b 15, de d 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, de d 7 1`] = `
+{
+  "_cmd": "de b 15, de d 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de d 8 1`] = `
+{
+  "_cmd": "de b 15, de d 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de d 9 1`] = `
+{
+  "_cmd": "de b 15, de d 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de d 10 1`] = `
+{
+  "_cmd": "de b 15, de d 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de d 11 1`] = `
+{
+  "_cmd": "de b 15, de d 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de d 12 1`] = `
+{
+  "_cmd": "de b 15, de d 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de d 13 1`] = `
+{
+  "_cmd": "de b 15, de d 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de d 14 1`] = `
+{
+  "_cmd": "de b 15, de d 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de d 15 1`] = `
+{
+  "_cmd": "de b 15, de d 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de d v 1 1`] = `
+{
+  "_cmd": "de b 15, de d v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, de d v 2 1`] = `
+{
+  "_cmd": "de b 15, de d v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, de d v 3 1`] = `
+{
+  "_cmd": "de b 15, de d v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, de d v 4 1`] = `
+{
+  "_cmd": "de b 15, de d v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de d v 5 1`] = `
+{
+  "_cmd": "de b 15, de d v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, de d v 6 1`] = `
+{
+  "_cmd": "de b 15, de d v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de d v 7 1`] = `
+{
+  "_cmd": "de b 15, de d v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de d v 8 1`] = `
+{
+  "_cmd": "de b 15, de d v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de d v 9 1`] = `
+{
+  "_cmd": "de b 15, de d v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, de d v 10 1`] = `
+{
+  "_cmd": "de b 15, de d v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de d v 11 1`] = `
+{
+  "_cmd": "de b 15, de d v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de d v 12 1`] = `
+{
+  "_cmd": "de b 15, de d v 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de d v 13 1`] = `
+{
+  "_cmd": "de b 15, de d v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de d v 14 1`] = `
+{
+  "_cmd": "de b 15, de d v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de d v 15 1`] = `
+{
+  "_cmd": "de b 15, de d v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de d v 16 1`] = `
+{
+  "_cmd": "de b 15, de d v 16",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, de d v 17 1`] = `
+{
+  "_cmd": "de b 15, de d v 17",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de b 15, de d v 18 1`] = `
+{
+  "_cmd": "de b 15, de d v 18",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b 15, de d v 19 1`] = `
+{
+  "_cmd": "de b 15, de d v 19",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b 15, de d v 20 1`] = `
+{
+  "_cmd": "de b 15, de d v 20",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b 15, de p 1 1`] = `
+{
+  "_cmd": "de b 15, de p 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, de p 2 1`] = `
+{
+  "_cmd": "de b 15, de p 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, de p 3 1`] = `
+{
+  "_cmd": "de b 15, de p 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, de p 4 1`] = `
+{
+  "_cmd": "de b 15, de p 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, de p 5 1`] = `
+{
+  "_cmd": "de b 15, de p 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de p 6 1`] = `
+{
+  "_cmd": "de b 15, de p 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de p 7 1`] = `
+{
+  "_cmd": "de b 15, de p 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, de p 8 1`] = `
+{
+  "_cmd": "de b 15, de p 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de p 9 1`] = `
+{
+  "_cmd": "de b 15, de p 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de p 10 1`] = `
+{
+  "_cmd": "de b 15, de p 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de p 11 1`] = `
+{
+  "_cmd": "de b 15, de p 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de p 12 1`] = `
+{
+  "_cmd": "de b 15, de p 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de p 13 1`] = `
+{
+  "_cmd": "de b 15, de p 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de p 14 1`] = `
+{
+  "_cmd": "de b 15, de p 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de p 15 1`] = `
+{
+  "_cmd": "de b 15, de p 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de p v 1 1`] = `
+{
+  "_cmd": "de b 15, de p v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, de p v 2 1`] = `
+{
+  "_cmd": "de b 15, de p v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, de p v 3 1`] = `
+{
+  "_cmd": "de b 15, de p v 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, de p v 4 1`] = `
+{
+  "_cmd": "de b 15, de p v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, de p v 5 1`] = `
+{
+  "_cmd": "de b 15, de p v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de p v 6 1`] = `
+{
+  "_cmd": "de b 15, de p v 6",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, de p v 7 1`] = `
+{
+  "_cmd": "de b 15, de p v 7",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de p v 8 1`] = `
+{
+  "_cmd": "de b 15, de p v 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de p v 9 1`] = `
+{
+  "_cmd": "de b 15, de p v 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de p v 10 1`] = `
+{
+  "_cmd": "de b 15, de p v 10",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, de p v 11 1`] = `
+{
+  "_cmd": "de b 15, de p v 11",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de p v 12 1`] = `
+{
+  "_cmd": "de b 15, de p v 12",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de p v 13 1`] = `
+{
+  "_cmd": "de b 15, de p v 13",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de p v 14 1`] = `
+{
+  "_cmd": "de b 15, de p v 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de p v 15 1`] = `
+{
+  "_cmd": "de b 15, de p v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de p v 16 1`] = `
+{
+  "_cmd": "de b 15, de p v 16",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de p v 17 1`] = `
+{
+  "_cmd": "de b 15, de p v 17",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, de p v 18 1`] = `
+{
+  "_cmd": "de b 15, de p v 18",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de b 15, de p v 19 1`] = `
+{
+  "_cmd": "de b 15, de p v 19",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de b 15, de p v 20 1`] = `
+{
+  "_cmd": "de b 15, de p v 20",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de b 15, de v 1 1`] = `
+{
+  "_cmd": "de b 15, de v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, de v 2 1`] = `
+{
+  "_cmd": "de b 15, de v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, de v 3 1`] = `
+{
+  "_cmd": "de b 15, de v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, de v 4 1`] = `
+{
+  "_cmd": "de b 15, de v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, de v 5 1`] = `
+{
+  "_cmd": "de b 15, de v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de v 6 1`] = `
+{
+  "_cmd": "de b 15, de v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de v 7 1`] = `
+{
+  "_cmd": "de b 15, de v 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, de v 8 1`] = `
+{
+  "_cmd": "de b 15, de v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de v 9 1`] = `
+{
+  "_cmd": "de b 15, de v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de v 10 1`] = `
+{
+  "_cmd": "de b 15, de v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de v 11 1`] = `
+{
+  "_cmd": "de b 15, de v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de v 12 1`] = `
+{
+  "_cmd": "de b 15, de v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de v 13 1`] = `
+{
+  "_cmd": "de b 15, de v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de v 14 1`] = `
+{
+  "_cmd": "de b 15, de v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de v 15 1`] = `
+{
+  "_cmd": "de b 15, de v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de v 16 1`] = `
+{
+  "_cmd": "de b 15, de v 16",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de v 17 1`] = `
+{
+  "_cmd": "de b 15, de v 17",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, de v 18 1`] = `
+{
+  "_cmd": "de b 15, de v 18",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de b 15, de v 19 1`] = `
+{
+  "_cmd": "de b 15, de v 19",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de b 15, de v 20 1`] = `
+{
+  "_cmd": "de b 15, de v 20",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de b 15, de w 1 1`] = `
+{
+  "_cmd": "de b 15, de w 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, de w 2 1`] = `
+{
+  "_cmd": "de b 15, de w 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, de w 3 1`] = `
+{
+  "_cmd": "de b 15, de w 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de w 4 1`] = `
+{
+  "_cmd": "de b 15, de w 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, de w 5 1`] = `
+{
+  "_cmd": "de b 15, de w 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, de w 6 1`] = `
+{
+  "_cmd": "de b 15, de w 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de w 7 1`] = `
+{
+  "_cmd": "de b 15, de w 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, de w 8 1`] = `
+{
+  "_cmd": "de b 15, de w 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, de w 9 1`] = `
+{
+  "_cmd": "de b 15, de w 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de w 10 1`] = `
+{
+  "_cmd": "de b 15, de w 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de w 11 1`] = `
+{
+  "_cmd": "de b 15, de w 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de w 12 1`] = `
+{
+  "_cmd": "de b 15, de w 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de w 13 1`] = `
+{
+  "_cmd": "de b 15, de w 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de w 14 1`] = `
+{
+  "_cmd": "de b 15, de w 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de w 15 1`] = `
+{
+  "_cmd": "de b 15, de w 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, de w v 1 1`] = `
+{
+  "_cmd": "de b 15, de w v 1",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, de w v 2 1`] = `
+{
+  "_cmd": "de b 15, de w v 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, de w v 3 1`] = `
+{
+  "_cmd": "de b 15, de w v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, de w v 4 1`] = `
+{
+  "_cmd": "de b 15, de w v 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, de w v 5 1`] = `
+{
+  "_cmd": "de b 15, de w v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, de w v 6 1`] = `
+{
+  "_cmd": "de b 15, de w v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, de w v 7 1`] = `
+{
+  "_cmd": "de b 15, de w v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, de w v 8 1`] = `
+{
+  "_cmd": "de b 15, de w v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, de w v 9 1`] = `
+{
+  "_cmd": "de b 15, de w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, de w v 10 1`] = `
+{
+  "_cmd": "de b 15, de w v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, de w v 11 1`] = `
+{
+  "_cmd": "de b 15, de w v 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, de w v 12 1`] = `
+{
+  "_cmd": "de b 15, de w v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, de w v 13 1`] = `
+{
+  "_cmd": "de b 15, de w v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, de w v 14 1`] = `
+{
+  "_cmd": "de b 15, de w v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, de w v 15 1`] = `
+{
+  "_cmd": "de b 15, de w v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, de w v 16 1`] = `
+{
+  "_cmd": "de b 15, de w v 16",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b 15, de w v 17 1`] = `
+{
+  "_cmd": "de b 15, de w v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b 15, de w v 18 1`] = `
+{
+  "_cmd": "de b 15, de w v 18",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b 15, de w v 19 1`] = `
+{
+  "_cmd": "de b 15, de w v 19",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b 15, de w v 20 1`] = `
+{
+  "_cmd": "de b 15, de w v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 1, de d 1 1`] = `
+{
+  "_cmd": "de b v 1, de d 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, de d 2 1`] = `
+{
+  "_cmd": "de b v 1, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, de d 3 1`] = `
+{
+  "_cmd": "de b v 1, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de d 4 1`] = `
+{
+  "_cmd": "de b v 1, de d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de d 5 1`] = `
+{
+  "_cmd": "de b v 1, de d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de d 6 1`] = `
+{
+  "_cmd": "de b v 1, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, de d 7 1`] = `
+{
+  "_cmd": "de b v 1, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de d 8 1`] = `
+{
+  "_cmd": "de b v 1, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de d 9 1`] = `
+{
+  "_cmd": "de b v 1, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de d 10 1`] = `
+{
+  "_cmd": "de b v 1, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de d 11 1`] = `
+{
+  "_cmd": "de b v 1, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de d 12 1`] = `
+{
+  "_cmd": "de b v 1, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de d 13 1`] = `
+{
+  "_cmd": "de b v 1, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de d 14 1`] = `
+{
+  "_cmd": "de b v 1, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de d 15 1`] = `
+{
+  "_cmd": "de b v 1, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de d v 1 1`] = `
+{
+  "_cmd": "de b v 1, de d v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, de d v 2 1`] = `
+{
+  "_cmd": "de b v 1, de d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, de d v 3 1`] = `
+{
+  "_cmd": "de b v 1, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de d v 4 1`] = `
+{
+  "_cmd": "de b v 1, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de d v 5 1`] = `
+{
+  "_cmd": "de b v 1, de d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de d v 6 1`] = `
+{
+  "_cmd": "de b v 1, de d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, de d v 7 1`] = `
+{
+  "_cmd": "de b v 1, de d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de d v 8 1`] = `
+{
+  "_cmd": "de b v 1, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de d v 9 1`] = `
+{
+  "_cmd": "de b v 1, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de d v 10 1`] = `
+{
+  "_cmd": "de b v 1, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de d v 11 1`] = `
+{
+  "_cmd": "de b v 1, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de d v 12 1`] = `
+{
+  "_cmd": "de b v 1, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de d v 13 1`] = `
+{
+  "_cmd": "de b v 1, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de d v 14 1`] = `
+{
+  "_cmd": "de b v 1, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de d v 15 1`] = `
+{
+  "_cmd": "de b v 1, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de d v 16 1`] = `
+{
+  "_cmd": "de b v 1, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 1, de d v 17 1`] = `
+{
+  "_cmd": "de b v 1, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 1, de d v 18 1`] = `
+{
+  "_cmd": "de b v 1, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 1, de d v 19 1`] = `
+{
+  "_cmd": "de b v 1, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 1, de d v 20 1`] = `
+{
+  "_cmd": "de b v 1, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 1, de p 1 1`] = `
+{
+  "_cmd": "de b v 1, de p 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, de p 2 1`] = `
+{
+  "_cmd": "de b v 1, de p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, de p 3 1`] = `
+{
+  "_cmd": "de b v 1, de p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de p 4 1`] = `
+{
+  "_cmd": "de b v 1, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de p 5 1`] = `
+{
+  "_cmd": "de b v 1, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de p 6 1`] = `
+{
+  "_cmd": "de b v 1, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de p 7 1`] = `
+{
+  "_cmd": "de b v 1, de p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de p 8 1`] = `
+{
+  "_cmd": "de b v 1, de p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de p 9 1`] = `
+{
+  "_cmd": "de b v 1, de p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de p 10 1`] = `
+{
+  "_cmd": "de b v 1, de p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de p 11 1`] = `
+{
+  "_cmd": "de b v 1, de p 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de p 12 1`] = `
+{
+  "_cmd": "de b v 1, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de p 13 1`] = `
+{
+  "_cmd": "de b v 1, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de p 14 1`] = `
+{
+  "_cmd": "de b v 1, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de p 15 1`] = `
+{
+  "_cmd": "de b v 1, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de p v 1 1`] = `
+{
+  "_cmd": "de b v 1, de p v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 1, de p v 2 1`] = `
+{
+  "_cmd": "de b v 1, de p v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, de p v 3 1`] = `
+{
+  "_cmd": "de b v 1, de p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de p v 4 1`] = `
+{
+  "_cmd": "de b v 1, de p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de p v 5 1`] = `
+{
+  "_cmd": "de b v 1, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de p v 6 1`] = `
+{
+  "_cmd": "de b v 1, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de p v 7 1`] = `
+{
+  "_cmd": "de b v 1, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, de p v 8 1`] = `
+{
+  "_cmd": "de b v 1, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de p v 9 1`] = `
+{
+  "_cmd": "de b v 1, de p v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de p v 10 1`] = `
+{
+  "_cmd": "de b v 1, de p v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de p v 11 1`] = `
+{
+  "_cmd": "de b v 1, de p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de p v 12 1`] = `
+{
+  "_cmd": "de b v 1, de p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de p v 13 1`] = `
+{
+  "_cmd": "de b v 1, de p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de p v 14 1`] = `
+{
+  "_cmd": "de b v 1, de p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de p v 15 1`] = `
+{
+  "_cmd": "de b v 1, de p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de p v 16 1`] = `
+{
+  "_cmd": "de b v 1, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 1, de p v 17 1`] = `
+{
+  "_cmd": "de b v 1, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 1, de p v 18 1`] = `
+{
+  "_cmd": "de b v 1, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 1, de p v 19 1`] = `
+{
+  "_cmd": "de b v 1, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 1, de p v 20 1`] = `
+{
+  "_cmd": "de b v 1, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 1, de v 1 1`] = `
+{
+  "_cmd": "de b v 1, de v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, de v 2 1`] = `
+{
+  "_cmd": "de b v 1, de v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, de v 3 1`] = `
+{
+  "_cmd": "de b v 1, de v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de v 4 1`] = `
+{
+  "_cmd": "de b v 1, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de v 5 1`] = `
+{
+  "_cmd": "de b v 1, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de v 6 1`] = `
+{
+  "_cmd": "de b v 1, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de v 7 1`] = `
+{
+  "_cmd": "de b v 1, de v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de v 8 1`] = `
+{
+  "_cmd": "de b v 1, de v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de v 9 1`] = `
+{
+  "_cmd": "de b v 1, de v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de v 10 1`] = `
+{
+  "_cmd": "de b v 1, de v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de v 11 1`] = `
+{
+  "_cmd": "de b v 1, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de v 12 1`] = `
+{
+  "_cmd": "de b v 1, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de v 13 1`] = `
+{
+  "_cmd": "de b v 1, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de v 14 1`] = `
+{
+  "_cmd": "de b v 1, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de v 15 1`] = `
+{
+  "_cmd": "de b v 1, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de v 16 1`] = `
+{
+  "_cmd": "de b v 1, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 1, de v 17 1`] = `
+{
+  "_cmd": "de b v 1, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 1, de v 18 1`] = `
+{
+  "_cmd": "de b v 1, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 1, de v 19 1`] = `
+{
+  "_cmd": "de b v 1, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 1, de v 20 1`] = `
+{
+  "_cmd": "de b v 1, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 1, de w 1 1`] = `
+{
+  "_cmd": "de b v 1, de w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, de w 2 1`] = `
+{
+  "_cmd": "de b v 1, de w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de w 3 1`] = `
+{
+  "_cmd": "de b v 1, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de w 4 1`] = `
+{
+  "_cmd": "de b v 1, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de w 5 1`] = `
+{
+  "_cmd": "de b v 1, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de w 6 1`] = `
+{
+  "_cmd": "de b v 1, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, de w 7 1`] = `
+{
+  "_cmd": "de b v 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de w 8 1`] = `
+{
+  "_cmd": "de b v 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de w 9 1`] = `
+{
+  "_cmd": "de b v 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de w 10 1`] = `
+{
+  "_cmd": "de b v 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de w 11 1`] = `
+{
+  "_cmd": "de b v 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de w 12 1`] = `
+{
+  "_cmd": "de b v 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de w 13 1`] = `
+{
+  "_cmd": "de b v 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de w 14 1`] = `
+{
+  "_cmd": "de b v 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de w 15 1`] = `
+{
+  "_cmd": "de b v 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de w v 1 1`] = `
+{
+  "_cmd": "de b v 1, de w v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, de w v 2 1`] = `
+{
+  "_cmd": "de b v 1, de w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, de w v 3 1`] = `
+{
+  "_cmd": "de b v 1, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, de w v 4 1`] = `
+{
+  "_cmd": "de b v 1, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, de w v 5 1`] = `
+{
+  "_cmd": "de b v 1, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, de w v 6 1`] = `
+{
+  "_cmd": "de b v 1, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, de w v 7 1`] = `
+{
+  "_cmd": "de b v 1, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, de w v 8 1`] = `
+{
+  "_cmd": "de b v 1, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, de w v 9 1`] = `
+{
+  "_cmd": "de b v 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, de w v 10 1`] = `
+{
+  "_cmd": "de b v 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, de w v 11 1`] = `
+{
+  "_cmd": "de b v 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, de w v 12 1`] = `
+{
+  "_cmd": "de b v 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, de w v 13 1`] = `
+{
+  "_cmd": "de b v 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, de w v 14 1`] = `
+{
+  "_cmd": "de b v 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, de w v 15 1`] = `
+{
+  "_cmd": "de b v 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, de w v 16 1`] = `
+{
+  "_cmd": "de b v 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 1, de w v 17 1`] = `
+{
+  "_cmd": "de b v 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 1, de w v 18 1`] = `
+{
+  "_cmd": "de b v 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 1, de w v 19 1`] = `
+{
+  "_cmd": "de b v 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 1, de w v 20 1`] = `
+{
+  "_cmd": "de b v 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 2, de d 1 1`] = `
+{
+  "_cmd": "de b v 2, de d 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 2, de d 2 1`] = `
+{
+  "_cmd": "de b v 2, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de d 3 1`] = `
+{
+  "_cmd": "de b v 2, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, de d 4 1`] = `
+{
+  "_cmd": "de b v 2, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de d 5 1`] = `
+{
+  "_cmd": "de b v 2, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de d 6 1`] = `
+{
+  "_cmd": "de b v 2, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de d 7 1`] = `
+{
+  "_cmd": "de b v 2, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de d 8 1`] = `
+{
+  "_cmd": "de b v 2, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de d 9 1`] = `
+{
+  "_cmd": "de b v 2, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de d 10 1`] = `
+{
+  "_cmd": "de b v 2, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de d 11 1`] = `
+{
+  "_cmd": "de b v 2, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de d 12 1`] = `
+{
+  "_cmd": "de b v 2, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de d 13 1`] = `
+{
+  "_cmd": "de b v 2, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de d 14 1`] = `
+{
+  "_cmd": "de b v 2, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de d 15 1`] = `
+{
+  "_cmd": "de b v 2, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de d v 1 1`] = `
+{
+  "_cmd": "de b v 2, de d v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 2, de d v 2 1`] = `
+{
+  "_cmd": "de b v 2, de d v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, de d v 3 1`] = `
+{
+  "_cmd": "de b v 2, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, de d v 4 1`] = `
+{
+  "_cmd": "de b v 2, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de d v 5 1`] = `
+{
+  "_cmd": "de b v 2, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de d v 6 1`] = `
+{
+  "_cmd": "de b v 2, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de d v 7 1`] = `
+{
+  "_cmd": "de b v 2, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de d v 8 1`] = `
+{
+  "_cmd": "de b v 2, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de d v 9 1`] = `
+{
+  "_cmd": "de b v 2, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de d v 10 1`] = `
+{
+  "_cmd": "de b v 2, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de d v 11 1`] = `
+{
+  "_cmd": "de b v 2, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de d v 12 1`] = `
+{
+  "_cmd": "de b v 2, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de d v 13 1`] = `
+{
+  "_cmd": "de b v 2, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de d v 14 1`] = `
+{
+  "_cmd": "de b v 2, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de d v 15 1`] = `
+{
+  "_cmd": "de b v 2, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de d v 16 1`] = `
+{
+  "_cmd": "de b v 2, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 2, de d v 17 1`] = `
+{
+  "_cmd": "de b v 2, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 2, de d v 18 1`] = `
+{
+  "_cmd": "de b v 2, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 2, de d v 19 1`] = `
+{
+  "_cmd": "de b v 2, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 2, de d v 20 1`] = `
+{
+  "_cmd": "de b v 2, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 2, de p 1 1`] = `
+{
+  "_cmd": "de b v 2, de p 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 2, de p 2 1`] = `
+{
+  "_cmd": "de b v 2, de p 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, de p 3 1`] = `
+{
+  "_cmd": "de b v 2, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de p 4 1`] = `
+{
+  "_cmd": "de b v 2, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de p 5 1`] = `
+{
+  "_cmd": "de b v 2, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de p 6 1`] = `
+{
+  "_cmd": "de b v 2, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de p 7 1`] = `
+{
+  "_cmd": "de b v 2, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de p 8 1`] = `
+{
+  "_cmd": "de b v 2, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de p 9 1`] = `
+{
+  "_cmd": "de b v 2, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de p 10 1`] = `
+{
+  "_cmd": "de b v 2, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de p 11 1`] = `
+{
+  "_cmd": "de b v 2, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de p 12 1`] = `
+{
+  "_cmd": "de b v 2, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de p 13 1`] = `
+{
+  "_cmd": "de b v 2, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de p 14 1`] = `
+{
+  "_cmd": "de b v 2, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de p 15 1`] = `
+{
+  "_cmd": "de b v 2, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de p v 1 1`] = `
+{
+  "_cmd": "de b v 2, de p v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 2, de p v 2 1`] = `
+{
+  "_cmd": "de b v 2, de p v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 2, de p v 3 1`] = `
+{
+  "_cmd": "de b v 2, de p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de p v 4 1`] = `
+{
+  "_cmd": "de b v 2, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, de p v 5 1`] = `
+{
+  "_cmd": "de b v 2, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de p v 6 1`] = `
+{
+  "_cmd": "de b v 2, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de p v 7 1`] = `
+{
+  "_cmd": "de b v 2, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de p v 8 1`] = `
+{
+  "_cmd": "de b v 2, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de p v 9 1`] = `
+{
+  "_cmd": "de b v 2, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de p v 10 1`] = `
+{
+  "_cmd": "de b v 2, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de p v 11 1`] = `
+{
+  "_cmd": "de b v 2, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de p v 12 1`] = `
+{
+  "_cmd": "de b v 2, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de p v 13 1`] = `
+{
+  "_cmd": "de b v 2, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de p v 14 1`] = `
+{
+  "_cmd": "de b v 2, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de p v 15 1`] = `
+{
+  "_cmd": "de b v 2, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de p v 16 1`] = `
+{
+  "_cmd": "de b v 2, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de p v 17 1`] = `
+{
+  "_cmd": "de b v 2, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 2, de p v 18 1`] = `
+{
+  "_cmd": "de b v 2, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 2, de p v 19 1`] = `
+{
+  "_cmd": "de b v 2, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 2, de p v 20 1`] = `
+{
+  "_cmd": "de b v 2, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 2, de v 1 1`] = `
+{
+  "_cmd": "de b v 2, de v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 2, de v 2 1`] = `
+{
+  "_cmd": "de b v 2, de v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, de v 3 1`] = `
+{
+  "_cmd": "de b v 2, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de v 4 1`] = `
+{
+  "_cmd": "de b v 2, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de v 5 1`] = `
+{
+  "_cmd": "de b v 2, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de v 6 1`] = `
+{
+  "_cmd": "de b v 2, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de v 7 1`] = `
+{
+  "_cmd": "de b v 2, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de v 8 1`] = `
+{
+  "_cmd": "de b v 2, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de v 9 1`] = `
+{
+  "_cmd": "de b v 2, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de v 10 1`] = `
+{
+  "_cmd": "de b v 2, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de v 11 1`] = `
+{
+  "_cmd": "de b v 2, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de v 12 1`] = `
+{
+  "_cmd": "de b v 2, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de v 13 1`] = `
+{
+  "_cmd": "de b v 2, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de v 14 1`] = `
+{
+  "_cmd": "de b v 2, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de v 15 1`] = `
+{
+  "_cmd": "de b v 2, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de v 16 1`] = `
+{
+  "_cmd": "de b v 2, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 2, de v 17 1`] = `
+{
+  "_cmd": "de b v 2, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 2, de v 18 1`] = `
+{
+  "_cmd": "de b v 2, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 2, de v 19 1`] = `
+{
+  "_cmd": "de b v 2, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 2, de v 20 1`] = `
+{
+  "_cmd": "de b v 2, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 2, de w 1 1`] = `
+{
+  "_cmd": "de b v 2, de w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, de w 2 1`] = `
+{
+  "_cmd": "de b v 2, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de w 3 1`] = `
+{
+  "_cmd": "de b v 2, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, de w 4 1`] = `
+{
+  "_cmd": "de b v 2, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de w 5 1`] = `
+{
+  "_cmd": "de b v 2, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de w 6 1`] = `
+{
+  "_cmd": "de b v 2, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de w 7 1`] = `
+{
+  "_cmd": "de b v 2, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de w 8 1`] = `
+{
+  "_cmd": "de b v 2, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de w 9 1`] = `
+{
+  "_cmd": "de b v 2, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de w 10 1`] = `
+{
+  "_cmd": "de b v 2, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de w 11 1`] = `
+{
+  "_cmd": "de b v 2, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de w 12 1`] = `
+{
+  "_cmd": "de b v 2, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de w 13 1`] = `
+{
+  "_cmd": "de b v 2, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de w 14 1`] = `
+{
+  "_cmd": "de b v 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de w 15 1`] = `
+{
+  "_cmd": "de b v 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de w v 1 1`] = `
+{
+  "_cmd": "de b v 2, de w v 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, de w v 2 1`] = `
+{
+  "_cmd": "de b v 2, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, de w v 3 1`] = `
+{
+  "_cmd": "de b v 2, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, de w v 4 1`] = `
+{
+  "_cmd": "de b v 2, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, de w v 5 1`] = `
+{
+  "_cmd": "de b v 2, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, de w v 6 1`] = `
+{
+  "_cmd": "de b v 2, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, de w v 7 1`] = `
+{
+  "_cmd": "de b v 2, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, de w v 8 1`] = `
+{
+  "_cmd": "de b v 2, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, de w v 9 1`] = `
+{
+  "_cmd": "de b v 2, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, de w v 10 1`] = `
+{
+  "_cmd": "de b v 2, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, de w v 11 1`] = `
+{
+  "_cmd": "de b v 2, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, de w v 12 1`] = `
+{
+  "_cmd": "de b v 2, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, de w v 13 1`] = `
+{
+  "_cmd": "de b v 2, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, de w v 14 1`] = `
+{
+  "_cmd": "de b v 2, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, de w v 15 1`] = `
+{
+  "_cmd": "de b v 2, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, de w v 16 1`] = `
+{
+  "_cmd": "de b v 2, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 2, de w v 17 1`] = `
+{
+  "_cmd": "de b v 2, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 2, de w v 18 1`] = `
+{
+  "_cmd": "de b v 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 2, de w v 19 1`] = `
+{
+  "_cmd": "de b v 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 2, de w v 20 1`] = `
+{
+  "_cmd": "de b v 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 3, de d 1 1`] = `
+{
+  "_cmd": "de b v 3, de d 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 3, de d 2 1`] = `
+{
+  "_cmd": "de b v 3, de d 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, de d 3 1`] = `
+{
+  "_cmd": "de b v 3, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de d 4 1`] = `
+{
+  "_cmd": "de b v 3, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de d 5 1`] = `
+{
+  "_cmd": "de b v 3, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, de d 6 1`] = `
+{
+  "_cmd": "de b v 3, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de d 7 1`] = `
+{
+  "_cmd": "de b v 3, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de d 8 1`] = `
+{
+  "_cmd": "de b v 3, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de d 9 1`] = `
+{
+  "_cmd": "de b v 3, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de d 10 1`] = `
+{
+  "_cmd": "de b v 3, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de d 11 1`] = `
+{
+  "_cmd": "de b v 3, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de d 12 1`] = `
+{
+  "_cmd": "de b v 3, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de d 13 1`] = `
+{
+  "_cmd": "de b v 3, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de d 14 1`] = `
+{
+  "_cmd": "de b v 3, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de d 15 1`] = `
+{
+  "_cmd": "de b v 3, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de d v 1 1`] = `
+{
+  "_cmd": "de b v 3, de d v 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 3, de d v 2 1`] = `
+{
+  "_cmd": "de b v 3, de d v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, de d v 3 1`] = `
+{
+  "_cmd": "de b v 3, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, de d v 4 1`] = `
+{
+  "_cmd": "de b v 3, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de d v 5 1`] = `
+{
+  "_cmd": "de b v 3, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, de d v 6 1`] = `
+{
+  "_cmd": "de b v 3, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de d v 7 1`] = `
+{
+  "_cmd": "de b v 3, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de d v 8 1`] = `
+{
+  "_cmd": "de b v 3, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de d v 9 1`] = `
+{
+  "_cmd": "de b v 3, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de d v 10 1`] = `
+{
+  "_cmd": "de b v 3, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de d v 11 1`] = `
+{
+  "_cmd": "de b v 3, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de d v 12 1`] = `
+{
+  "_cmd": "de b v 3, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de d v 13 1`] = `
+{
+  "_cmd": "de b v 3, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de d v 14 1`] = `
+{
+  "_cmd": "de b v 3, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de d v 15 1`] = `
+{
+  "_cmd": "de b v 3, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de d v 16 1`] = `
+{
+  "_cmd": "de b v 3, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 3, de d v 17 1`] = `
+{
+  "_cmd": "de b v 3, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 3, de d v 18 1`] = `
+{
+  "_cmd": "de b v 3, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 3, de d v 19 1`] = `
+{
+  "_cmd": "de b v 3, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 3, de d v 20 1`] = `
+{
+  "_cmd": "de b v 3, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 3, de p 1 1`] = `
+{
+  "_cmd": "de b v 3, de p 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 3, de p 2 1`] = `
+{
+  "_cmd": "de b v 3, de p 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, de p 3 1`] = `
+{
+  "_cmd": "de b v 3, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, de p 4 1`] = `
+{
+  "_cmd": "de b v 3, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de p 5 1`] = `
+{
+  "_cmd": "de b v 3, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de p 6 1`] = `
+{
+  "_cmd": "de b v 3, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de p 7 1`] = `
+{
+  "_cmd": "de b v 3, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de p 8 1`] = `
+{
+  "_cmd": "de b v 3, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de p 9 1`] = `
+{
+  "_cmd": "de b v 3, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de p 10 1`] = `
+{
+  "_cmd": "de b v 3, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de p 11 1`] = `
+{
+  "_cmd": "de b v 3, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de p 12 1`] = `
+{
+  "_cmd": "de b v 3, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de p 13 1`] = `
+{
+  "_cmd": "de b v 3, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de p 14 1`] = `
+{
+  "_cmd": "de b v 3, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de p 15 1`] = `
+{
+  "_cmd": "de b v 3, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de p v 1 1`] = `
+{
+  "_cmd": "de b v 3, de p v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 3, de p v 2 1`] = `
+{
+  "_cmd": "de b v 3, de p v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, de p v 3 1`] = `
+{
+  "_cmd": "de b v 3, de p v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, de p v 4 1`] = `
+{
+  "_cmd": "de b v 3, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de p v 5 1`] = `
+{
+  "_cmd": "de b v 3, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de p v 6 1`] = `
+{
+  "_cmd": "de b v 3, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, de p v 7 1`] = `
+{
+  "_cmd": "de b v 3, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de p v 8 1`] = `
+{
+  "_cmd": "de b v 3, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de p v 9 1`] = `
+{
+  "_cmd": "de b v 3, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de p v 10 1`] = `
+{
+  "_cmd": "de b v 3, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de p v 11 1`] = `
+{
+  "_cmd": "de b v 3, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de p v 12 1`] = `
+{
+  "_cmd": "de b v 3, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de p v 13 1`] = `
+{
+  "_cmd": "de b v 3, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de p v 14 1`] = `
+{
+  "_cmd": "de b v 3, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de p v 15 1`] = `
+{
+  "_cmd": "de b v 3, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de p v 16 1`] = `
+{
+  "_cmd": "de b v 3, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de p v 17 1`] = `
+{
+  "_cmd": "de b v 3, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 3, de p v 18 1`] = `
+{
+  "_cmd": "de b v 3, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 3, de p v 19 1`] = `
+{
+  "_cmd": "de b v 3, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 3, de p v 20 1`] = `
+{
+  "_cmd": "de b v 3, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 3, de v 1 1`] = `
+{
+  "_cmd": "de b v 3, de v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 3, de v 2 1`] = `
+{
+  "_cmd": "de b v 3, de v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, de v 3 1`] = `
+{
+  "_cmd": "de b v 3, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, de v 4 1`] = `
+{
+  "_cmd": "de b v 3, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de v 5 1`] = `
+{
+  "_cmd": "de b v 3, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de v 6 1`] = `
+{
+  "_cmd": "de b v 3, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de v 7 1`] = `
+{
+  "_cmd": "de b v 3, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de v 8 1`] = `
+{
+  "_cmd": "de b v 3, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de v 9 1`] = `
+{
+  "_cmd": "de b v 3, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de v 10 1`] = `
+{
+  "_cmd": "de b v 3, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de v 11 1`] = `
+{
+  "_cmd": "de b v 3, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de v 12 1`] = `
+{
+  "_cmd": "de b v 3, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de v 13 1`] = `
+{
+  "_cmd": "de b v 3, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de v 14 1`] = `
+{
+  "_cmd": "de b v 3, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de v 15 1`] = `
+{
+  "_cmd": "de b v 3, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de v 16 1`] = `
+{
+  "_cmd": "de b v 3, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de v 17 1`] = `
+{
+  "_cmd": "de b v 3, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 3, de v 18 1`] = `
+{
+  "_cmd": "de b v 3, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 3, de v 19 1`] = `
+{
+  "_cmd": "de b v 3, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 3, de v 20 1`] = `
+{
+  "_cmd": "de b v 3, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 3, de w 1 1`] = `
+{
+  "_cmd": "de b v 3, de w 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, de w 2 1`] = `
+{
+  "_cmd": "de b v 3, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, de w 3 1`] = `
+{
+  "_cmd": "de b v 3, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de w 4 1`] = `
+{
+  "_cmd": "de b v 3, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, de w 5 1`] = `
+{
+  "_cmd": "de b v 3, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de w 6 1`] = `
+{
+  "_cmd": "de b v 3, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de w 7 1`] = `
+{
+  "_cmd": "de b v 3, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de w 8 1`] = `
+{
+  "_cmd": "de b v 3, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de w 9 1`] = `
+{
+  "_cmd": "de b v 3, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de w 10 1`] = `
+{
+  "_cmd": "de b v 3, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de w 11 1`] = `
+{
+  "_cmd": "de b v 3, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de w 12 1`] = `
+{
+  "_cmd": "de b v 3, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de w 13 1`] = `
+{
+  "_cmd": "de b v 3, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de w 14 1`] = `
+{
+  "_cmd": "de b v 3, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de w 15 1`] = `
+{
+  "_cmd": "de b v 3, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de w v 1 1`] = `
+{
+  "_cmd": "de b v 3, de w v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, de w v 2 1`] = `
+{
+  "_cmd": "de b v 3, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, de w v 3 1`] = `
+{
+  "_cmd": "de b v 3, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, de w v 4 1`] = `
+{
+  "_cmd": "de b v 3, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, de w v 5 1`] = `
+{
+  "_cmd": "de b v 3, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, de w v 6 1`] = `
+{
+  "_cmd": "de b v 3, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, de w v 7 1`] = `
+{
+  "_cmd": "de b v 3, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, de w v 8 1`] = `
+{
+  "_cmd": "de b v 3, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, de w v 9 1`] = `
+{
+  "_cmd": "de b v 3, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, de w v 10 1`] = `
+{
+  "_cmd": "de b v 3, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, de w v 11 1`] = `
+{
+  "_cmd": "de b v 3, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, de w v 12 1`] = `
+{
+  "_cmd": "de b v 3, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, de w v 13 1`] = `
+{
+  "_cmd": "de b v 3, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, de w v 14 1`] = `
+{
+  "_cmd": "de b v 3, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, de w v 15 1`] = `
+{
+  "_cmd": "de b v 3, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, de w v 16 1`] = `
+{
+  "_cmd": "de b v 3, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 3, de w v 17 1`] = `
+{
+  "_cmd": "de b v 3, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 3, de w v 18 1`] = `
+{
+  "_cmd": "de b v 3, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 3, de w v 19 1`] = `
+{
+  "_cmd": "de b v 3, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 3, de w v 20 1`] = `
+{
+  "_cmd": "de b v 3, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 4, de d 1 1`] = `
+{
+  "_cmd": "de b v 4, de d 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 4, de d 2 1`] = `
+{
+  "_cmd": "de b v 4, de d 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, de d 3 1`] = `
+{
+  "_cmd": "de b v 4, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, de d 4 1`] = `
+{
+  "_cmd": "de b v 4, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de d 5 1`] = `
+{
+  "_cmd": "de b v 4, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de d 6 1`] = `
+{
+  "_cmd": "de b v 4, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de d 7 1`] = `
+{
+  "_cmd": "de b v 4, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, de d 8 1`] = `
+{
+  "_cmd": "de b v 4, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de d 9 1`] = `
+{
+  "_cmd": "de b v 4, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de d 10 1`] = `
+{
+  "_cmd": "de b v 4, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de d 11 1`] = `
+{
+  "_cmd": "de b v 4, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de d 12 1`] = `
+{
+  "_cmd": "de b v 4, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de d 13 1`] = `
+{
+  "_cmd": "de b v 4, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de d 14 1`] = `
+{
+  "_cmd": "de b v 4, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de d 15 1`] = `
+{
+  "_cmd": "de b v 4, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de d v 1 1`] = `
+{
+  "_cmd": "de b v 4, de d v 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 4, de d v 2 1`] = `
+{
+  "_cmd": "de b v 4, de d v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, de d v 3 1`] = `
+{
+  "_cmd": "de b v 4, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, de d v 4 1`] = `
+{
+  "_cmd": "de b v 4, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, de d v 5 1`] = `
+{
+  "_cmd": "de b v 4, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de d v 6 1`] = `
+{
+  "_cmd": "de b v 4, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de d v 7 1`] = `
+{
+  "_cmd": "de b v 4, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, de d v 8 1`] = `
+{
+  "_cmd": "de b v 4, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de d v 9 1`] = `
+{
+  "_cmd": "de b v 4, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de d v 10 1`] = `
+{
+  "_cmd": "de b v 4, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de d v 11 1`] = `
+{
+  "_cmd": "de b v 4, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de d v 12 1`] = `
+{
+  "_cmd": "de b v 4, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de d v 13 1`] = `
+{
+  "_cmd": "de b v 4, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de d v 14 1`] = `
+{
+  "_cmd": "de b v 4, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de d v 15 1`] = `
+{
+  "_cmd": "de b v 4, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de d v 16 1`] = `
+{
+  "_cmd": "de b v 4, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de d v 17 1`] = `
+{
+  "_cmd": "de b v 4, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 4, de d v 18 1`] = `
+{
+  "_cmd": "de b v 4, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 4, de d v 19 1`] = `
+{
+  "_cmd": "de b v 4, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 4, de d v 20 1`] = `
+{
+  "_cmd": "de b v 4, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 4, de p 1 1`] = `
+{
+  "_cmd": "de b v 4, de p 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, de p 2 1`] = `
+{
+  "_cmd": "de b v 4, de p 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, de p 3 1`] = `
+{
+  "_cmd": "de b v 4, de p 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, de p 4 1`] = `
+{
+  "_cmd": "de b v 4, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, de p 5 1`] = `
+{
+  "_cmd": "de b v 4, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de p 6 1`] = `
+{
+  "_cmd": "de b v 4, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de p 7 1`] = `
+{
+  "_cmd": "de b v 4, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de p 8 1`] = `
+{
+  "_cmd": "de b v 4, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de p 9 1`] = `
+{
+  "_cmd": "de b v 4, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de p 10 1`] = `
+{
+  "_cmd": "de b v 4, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de p 11 1`] = `
+{
+  "_cmd": "de b v 4, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de p 12 1`] = `
+{
+  "_cmd": "de b v 4, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de p 13 1`] = `
+{
+  "_cmd": "de b v 4, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de p 14 1`] = `
+{
+  "_cmd": "de b v 4, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de p 15 1`] = `
+{
+  "_cmd": "de b v 4, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de p v 1 1`] = `
+{
+  "_cmd": "de b v 4, de p v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, de p v 2 1`] = `
+{
+  "_cmd": "de b v 4, de p v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 4, de p v 3 1`] = `
+{
+  "_cmd": "de b v 4, de p v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, de p v 4 1`] = `
+{
+  "_cmd": "de b v 4, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, de p v 5 1`] = `
+{
+  "_cmd": "de b v 4, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de p v 6 1`] = `
+{
+  "_cmd": "de b v 4, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de p v 7 1`] = `
+{
+  "_cmd": "de b v 4, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de p v 8 1`] = `
+{
+  "_cmd": "de b v 4, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, de p v 9 1`] = `
+{
+  "_cmd": "de b v 4, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de p v 10 1`] = `
+{
+  "_cmd": "de b v 4, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de p v 11 1`] = `
+{
+  "_cmd": "de b v 4, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de p v 12 1`] = `
+{
+  "_cmd": "de b v 4, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de p v 13 1`] = `
+{
+  "_cmd": "de b v 4, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de p v 14 1`] = `
+{
+  "_cmd": "de b v 4, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de p v 15 1`] = `
+{
+  "_cmd": "de b v 4, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de p v 16 1`] = `
+{
+  "_cmd": "de b v 4, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de p v 17 1`] = `
+{
+  "_cmd": "de b v 4, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 4, de p v 18 1`] = `
+{
+  "_cmd": "de b v 4, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 4, de p v 19 1`] = `
+{
+  "_cmd": "de b v 4, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 4, de p v 20 1`] = `
+{
+  "_cmd": "de b v 4, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 4, de v 1 1`] = `
+{
+  "_cmd": "de b v 4, de v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, de v 2 1`] = `
+{
+  "_cmd": "de b v 4, de v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, de v 3 1`] = `
+{
+  "_cmd": "de b v 4, de v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, de v 4 1`] = `
+{
+  "_cmd": "de b v 4, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, de v 5 1`] = `
+{
+  "_cmd": "de b v 4, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de v 6 1`] = `
+{
+  "_cmd": "de b v 4, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de v 7 1`] = `
+{
+  "_cmd": "de b v 4, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de v 8 1`] = `
+{
+  "_cmd": "de b v 4, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de v 9 1`] = `
+{
+  "_cmd": "de b v 4, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de v 10 1`] = `
+{
+  "_cmd": "de b v 4, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de v 11 1`] = `
+{
+  "_cmd": "de b v 4, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de v 12 1`] = `
+{
+  "_cmd": "de b v 4, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de v 13 1`] = `
+{
+  "_cmd": "de b v 4, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de v 14 1`] = `
+{
+  "_cmd": "de b v 4, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de v 15 1`] = `
+{
+  "_cmd": "de b v 4, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de v 16 1`] = `
+{
+  "_cmd": "de b v 4, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de v 17 1`] = `
+{
+  "_cmd": "de b v 4, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 4, de v 18 1`] = `
+{
+  "_cmd": "de b v 4, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 4, de v 19 1`] = `
+{
+  "_cmd": "de b v 4, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 4, de v 20 1`] = `
+{
+  "_cmd": "de b v 4, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 4, de w 1 1`] = `
+{
+  "_cmd": "de b v 4, de w 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, de w 2 1`] = `
+{
+  "_cmd": "de b v 4, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, de w 3 1`] = `
+{
+  "_cmd": "de b v 4, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, de w 4 1`] = `
+{
+  "_cmd": "de b v 4, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de w 5 1`] = `
+{
+  "_cmd": "de b v 4, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de w 6 1`] = `
+{
+  "_cmd": "de b v 4, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, de w 7 1`] = `
+{
+  "_cmd": "de b v 4, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de w 8 1`] = `
+{
+  "_cmd": "de b v 4, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de w 9 1`] = `
+{
+  "_cmd": "de b v 4, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de w 10 1`] = `
+{
+  "_cmd": "de b v 4, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de w 11 1`] = `
+{
+  "_cmd": "de b v 4, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de w 12 1`] = `
+{
+  "_cmd": "de b v 4, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de w 13 1`] = `
+{
+  "_cmd": "de b v 4, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de w 14 1`] = `
+{
+  "_cmd": "de b v 4, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de w 15 1`] = `
+{
+  "_cmd": "de b v 4, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de w v 1 1`] = `
+{
+  "_cmd": "de b v 4, de w v 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, de w v 2 1`] = `
+{
+  "_cmd": "de b v 4, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, de w v 3 1`] = `
+{
+  "_cmd": "de b v 4, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, de w v 4 1`] = `
+{
+  "_cmd": "de b v 4, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, de w v 5 1`] = `
+{
+  "_cmd": "de b v 4, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, de w v 6 1`] = `
+{
+  "_cmd": "de b v 4, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, de w v 7 1`] = `
+{
+  "_cmd": "de b v 4, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, de w v 8 1`] = `
+{
+  "_cmd": "de b v 4, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, de w v 9 1`] = `
+{
+  "_cmd": "de b v 4, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, de w v 10 1`] = `
+{
+  "_cmd": "de b v 4, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, de w v 11 1`] = `
+{
+  "_cmd": "de b v 4, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, de w v 12 1`] = `
+{
+  "_cmd": "de b v 4, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, de w v 13 1`] = `
+{
+  "_cmd": "de b v 4, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, de w v 14 1`] = `
+{
+  "_cmd": "de b v 4, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, de w v 15 1`] = `
+{
+  "_cmd": "de b v 4, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, de w v 16 1`] = `
+{
+  "_cmd": "de b v 4, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 4, de w v 17 1`] = `
+{
+  "_cmd": "de b v 4, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 4, de w v 18 1`] = `
+{
+  "_cmd": "de b v 4, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 4, de w v 19 1`] = `
+{
+  "_cmd": "de b v 4, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 4, de w v 20 1`] = `
+{
+  "_cmd": "de b v 4, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 5, de d 1 1`] = `
+{
+  "_cmd": "de b v 5, de d 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 5, de d 2 1`] = `
+{
+  "_cmd": "de b v 5, de d 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, de d 3 1`] = `
+{
+  "_cmd": "de b v 5, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de d 4 1`] = `
+{
+  "_cmd": "de b v 5, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, de d 5 1`] = `
+{
+  "_cmd": "de b v 5, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, de d 6 1`] = `
+{
+  "_cmd": "de b v 5, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de d 7 1`] = `
+{
+  "_cmd": "de b v 5, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de d 8 1`] = `
+{
+  "_cmd": "de b v 5, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, de d 9 1`] = `
+{
+  "_cmd": "de b v 5, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de d 10 1`] = `
+{
+  "_cmd": "de b v 5, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de d 11 1`] = `
+{
+  "_cmd": "de b v 5, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de d 12 1`] = `
+{
+  "_cmd": "de b v 5, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de d 13 1`] = `
+{
+  "_cmd": "de b v 5, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de d 14 1`] = `
+{
+  "_cmd": "de b v 5, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de d 15 1`] = `
+{
+  "_cmd": "de b v 5, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de d v 1 1`] = `
+{
+  "_cmd": "de b v 5, de d v 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 5, de d v 2 1`] = `
+{
+  "_cmd": "de b v 5, de d v 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, de d v 3 1`] = `
+{
+  "_cmd": "de b v 5, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de d v 4 1`] = `
+{
+  "_cmd": "de b v 5, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, de d v 5 1`] = `
+{
+  "_cmd": "de b v 5, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de d v 6 1`] = `
+{
+  "_cmd": "de b v 5, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de d v 7 1`] = `
+{
+  "_cmd": "de b v 5, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de d v 8 1`] = `
+{
+  "_cmd": "de b v 5, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, de d v 9 1`] = `
+{
+  "_cmd": "de b v 5, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de d v 10 1`] = `
+{
+  "_cmd": "de b v 5, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de d v 11 1`] = `
+{
+  "_cmd": "de b v 5, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de d v 12 1`] = `
+{
+  "_cmd": "de b v 5, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de d v 13 1`] = `
+{
+  "_cmd": "de b v 5, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de d v 14 1`] = `
+{
+  "_cmd": "de b v 5, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de d v 15 1`] = `
+{
+  "_cmd": "de b v 5, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de d v 16 1`] = `
+{
+  "_cmd": "de b v 5, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, de d v 17 1`] = `
+{
+  "_cmd": "de b v 5, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 5, de d v 18 1`] = `
+{
+  "_cmd": "de b v 5, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 5, de d v 19 1`] = `
+{
+  "_cmd": "de b v 5, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 5, de d v 20 1`] = `
+{
+  "_cmd": "de b v 5, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 5, de p 1 1`] = `
+{
+  "_cmd": "de b v 5, de p 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, de p 2 1`] = `
+{
+  "_cmd": "de b v 5, de p 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, de p 3 1`] = `
+{
+  "_cmd": "de b v 5, de p 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, de p 4 1`] = `
+{
+  "_cmd": "de b v 5, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de p 5 1`] = `
+{
+  "_cmd": "de b v 5, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de p 6 1`] = `
+{
+  "_cmd": "de b v 5, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, de p 7 1`] = `
+{
+  "_cmd": "de b v 5, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de p 8 1`] = `
+{
+  "_cmd": "de b v 5, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de p 9 1`] = `
+{
+  "_cmd": "de b v 5, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, de p 10 1`] = `
+{
+  "_cmd": "de b v 5, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de p 11 1`] = `
+{
+  "_cmd": "de b v 5, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de p 12 1`] = `
+{
+  "_cmd": "de b v 5, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de p 13 1`] = `
+{
+  "_cmd": "de b v 5, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de p 14 1`] = `
+{
+  "_cmd": "de b v 5, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de p 15 1`] = `
+{
+  "_cmd": "de b v 5, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de p v 1 1`] = `
+{
+  "_cmd": "de b v 5, de p v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, de p v 2 1`] = `
+{
+  "_cmd": "de b v 5, de p v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, de p v 3 1`] = `
+{
+  "_cmd": "de b v 5, de p v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, de p v 4 1`] = `
+{
+  "_cmd": "de b v 5, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de p v 5 1`] = `
+{
+  "_cmd": "de b v 5, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, de p v 6 1`] = `
+{
+  "_cmd": "de b v 5, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de p v 7 1`] = `
+{
+  "_cmd": "de b v 5, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de p v 8 1`] = `
+{
+  "_cmd": "de b v 5, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de p v 9 1`] = `
+{
+  "_cmd": "de b v 5, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, de p v 10 1`] = `
+{
+  "_cmd": "de b v 5, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de p v 11 1`] = `
+{
+  "_cmd": "de b v 5, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de p v 12 1`] = `
+{
+  "_cmd": "de b v 5, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de p v 13 1`] = `
+{
+  "_cmd": "de b v 5, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de p v 14 1`] = `
+{
+  "_cmd": "de b v 5, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de p v 15 1`] = `
+{
+  "_cmd": "de b v 5, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de p v 16 1`] = `
+{
+  "_cmd": "de b v 5, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, de p v 17 1`] = `
+{
+  "_cmd": "de b v 5, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 5, de p v 18 1`] = `
+{
+  "_cmd": "de b v 5, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 5, de p v 19 1`] = `
+{
+  "_cmd": "de b v 5, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 5, de p v 20 1`] = `
+{
+  "_cmd": "de b v 5, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 5, de v 1 1`] = `
+{
+  "_cmd": "de b v 5, de v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, de v 2 1`] = `
+{
+  "_cmd": "de b v 5, de v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, de v 3 1`] = `
+{
+  "_cmd": "de b v 5, de v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, de v 4 1`] = `
+{
+  "_cmd": "de b v 5, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de v 5 1`] = `
+{
+  "_cmd": "de b v 5, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de v 6 1`] = `
+{
+  "_cmd": "de b v 5, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, de v 7 1`] = `
+{
+  "_cmd": "de b v 5, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de v 8 1`] = `
+{
+  "_cmd": "de b v 5, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de v 9 1`] = `
+{
+  "_cmd": "de b v 5, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de v 10 1`] = `
+{
+  "_cmd": "de b v 5, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de v 11 1`] = `
+{
+  "_cmd": "de b v 5, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de v 12 1`] = `
+{
+  "_cmd": "de b v 5, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de v 13 1`] = `
+{
+  "_cmd": "de b v 5, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de v 14 1`] = `
+{
+  "_cmd": "de b v 5, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de v 15 1`] = `
+{
+  "_cmd": "de b v 5, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de v 16 1`] = `
+{
+  "_cmd": "de b v 5, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, de v 17 1`] = `
+{
+  "_cmd": "de b v 5, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 5, de v 18 1`] = `
+{
+  "_cmd": "de b v 5, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 5, de v 19 1`] = `
+{
+  "_cmd": "de b v 5, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 5, de v 20 1`] = `
+{
+  "_cmd": "de b v 5, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 5, de w 1 1`] = `
+{
+  "_cmd": "de b v 5, de w 1",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, de w 2 1`] = `
+{
+  "_cmd": "de b v 5, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, de w 3 1`] = `
+{
+  "_cmd": "de b v 5, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, de w 4 1`] = `
+{
+  "_cmd": "de b v 5, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de w 5 1`] = `
+{
+  "_cmd": "de b v 5, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, de w 6 1`] = `
+{
+  "_cmd": "de b v 5, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de w 7 1`] = `
+{
+  "_cmd": "de b v 5, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, de w 8 1`] = `
+{
+  "_cmd": "de b v 5, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de w 9 1`] = `
+{
+  "_cmd": "de b v 5, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de w 10 1`] = `
+{
+  "_cmd": "de b v 5, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de w 11 1`] = `
+{
+  "_cmd": "de b v 5, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de w 12 1`] = `
+{
+  "_cmd": "de b v 5, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de w 13 1`] = `
+{
+  "_cmd": "de b v 5, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de w 14 1`] = `
+{
+  "_cmd": "de b v 5, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de w 15 1`] = `
+{
+  "_cmd": "de b v 5, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, de w v 1 1`] = `
+{
+  "_cmd": "de b v 5, de w v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, de w v 2 1`] = `
+{
+  "_cmd": "de b v 5, de w v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, de w v 3 1`] = `
+{
+  "_cmd": "de b v 5, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, de w v 4 1`] = `
+{
+  "_cmd": "de b v 5, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, de w v 5 1`] = `
+{
+  "_cmd": "de b v 5, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, de w v 6 1`] = `
+{
+  "_cmd": "de b v 5, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, de w v 7 1`] = `
+{
+  "_cmd": "de b v 5, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, de w v 8 1`] = `
+{
+  "_cmd": "de b v 5, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, de w v 9 1`] = `
+{
+  "_cmd": "de b v 5, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, de w v 10 1`] = `
+{
+  "_cmd": "de b v 5, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, de w v 11 1`] = `
+{
+  "_cmd": "de b v 5, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, de w v 12 1`] = `
+{
+  "_cmd": "de b v 5, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, de w v 13 1`] = `
+{
+  "_cmd": "de b v 5, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, de w v 14 1`] = `
+{
+  "_cmd": "de b v 5, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, de w v 15 1`] = `
+{
+  "_cmd": "de b v 5, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, de w v 16 1`] = `
+{
+  "_cmd": "de b v 5, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 5, de w v 17 1`] = `
+{
+  "_cmd": "de b v 5, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 5, de w v 18 1`] = `
+{
+  "_cmd": "de b v 5, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 5, de w v 19 1`] = `
+{
+  "_cmd": "de b v 5, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 5, de w v 20 1`] = `
+{
+  "_cmd": "de b v 5, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 6, de d 1 1`] = `
+{
+  "_cmd": "de b v 6, de d 1",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 6, de d 2 1`] = `
+{
+  "_cmd": "de b v 6, de d 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, de d 3 1`] = `
+{
+  "_cmd": "de b v 6, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, de d 4 1`] = `
+{
+  "_cmd": "de b v 6, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de d 5 1`] = `
+{
+  "_cmd": "de b v 6, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, de d 6 1`] = `
+{
+  "_cmd": "de b v 6, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de d 7 1`] = `
+{
+  "_cmd": "de b v 6, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de d 8 1`] = `
+{
+  "_cmd": "de b v 6, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de d 9 1`] = `
+{
+  "_cmd": "de b v 6, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de d 10 1`] = `
+{
+  "_cmd": "de b v 6, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, de d 11 1`] = `
+{
+  "_cmd": "de b v 6, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de d 12 1`] = `
+{
+  "_cmd": "de b v 6, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de d 13 1`] = `
+{
+  "_cmd": "de b v 6, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de d 14 1`] = `
+{
+  "_cmd": "de b v 6, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de d 15 1`] = `
+{
+  "_cmd": "de b v 6, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de d v 1 1`] = `
+{
+  "_cmd": "de b v 6, de d v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, de d v 2 1`] = `
+{
+  "_cmd": "de b v 6, de d v 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, de d v 3 1`] = `
+{
+  "_cmd": "de b v 6, de d v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, de d v 4 1`] = `
+{
+  "_cmd": "de b v 6, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de d v 5 1`] = `
+{
+  "_cmd": "de b v 6, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, de d v 6 1`] = `
+{
+  "_cmd": "de b v 6, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de d v 7 1`] = `
+{
+  "_cmd": "de b v 6, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de d v 8 1`] = `
+{
+  "_cmd": "de b v 6, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de d v 9 1`] = `
+{
+  "_cmd": "de b v 6, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de d v 10 1`] = `
+{
+  "_cmd": "de b v 6, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, de d v 11 1`] = `
+{
+  "_cmd": "de b v 6, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de d v 12 1`] = `
+{
+  "_cmd": "de b v 6, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de d v 13 1`] = `
+{
+  "_cmd": "de b v 6, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de d v 14 1`] = `
+{
+  "_cmd": "de b v 6, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de d v 15 1`] = `
+{
+  "_cmd": "de b v 6, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de d v 16 1`] = `
+{
+  "_cmd": "de b v 6, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, de d v 17 1`] = `
+{
+  "_cmd": "de b v 6, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 6, de d v 18 1`] = `
+{
+  "_cmd": "de b v 6, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 6, de d v 19 1`] = `
+{
+  "_cmd": "de b v 6, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 6, de d v 20 1`] = `
+{
+  "_cmd": "de b v 6, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 6, de p 1 1`] = `
+{
+  "_cmd": "de b v 6, de p 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, de p 2 1`] = `
+{
+  "_cmd": "de b v 6, de p 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, de p 3 1`] = `
+{
+  "_cmd": "de b v 6, de p 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, de p 4 1`] = `
+{
+  "_cmd": "de b v 6, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, de p 5 1`] = `
+{
+  "_cmd": "de b v 6, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de p 6 1`] = `
+{
+  "_cmd": "de b v 6, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de p 7 1`] = `
+{
+  "_cmd": "de b v 6, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de p 8 1`] = `
+{
+  "_cmd": "de b v 6, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de p 9 1`] = `
+{
+  "_cmd": "de b v 6, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de p 10 1`] = `
+{
+  "_cmd": "de b v 6, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de p 11 1`] = `
+{
+  "_cmd": "de b v 6, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, de p 12 1`] = `
+{
+  "_cmd": "de b v 6, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de p 13 1`] = `
+{
+  "_cmd": "de b v 6, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de p 14 1`] = `
+{
+  "_cmd": "de b v 6, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de p 15 1`] = `
+{
+  "_cmd": "de b v 6, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de p v 1 1`] = `
+{
+  "_cmd": "de b v 6, de p v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, de p v 2 1`] = `
+{
+  "_cmd": "de b v 6, de p v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 6, de p v 3 1`] = `
+{
+  "_cmd": "de b v 6, de p v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, de p v 4 1`] = `
+{
+  "_cmd": "de b v 6, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, de p v 5 1`] = `
+{
+  "_cmd": "de b v 6, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de p v 6 1`] = `
+{
+  "_cmd": "de b v 6, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, de p v 7 1`] = `
+{
+  "_cmd": "de b v 6, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de p v 8 1`] = `
+{
+  "_cmd": "de b v 6, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de p v 9 1`] = `
+{
+  "_cmd": "de b v 6, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de p v 10 1`] = `
+{
+  "_cmd": "de b v 6, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de p v 11 1`] = `
+{
+  "_cmd": "de b v 6, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, de p v 12 1`] = `
+{
+  "_cmd": "de b v 6, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de p v 13 1`] = `
+{
+  "_cmd": "de b v 6, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de p v 14 1`] = `
+{
+  "_cmd": "de b v 6, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de p v 15 1`] = `
+{
+  "_cmd": "de b v 6, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de p v 16 1`] = `
+{
+  "_cmd": "de b v 6, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, de p v 17 1`] = `
+{
+  "_cmd": "de b v 6, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 6, de p v 18 1`] = `
+{
+  "_cmd": "de b v 6, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 6, de p v 19 1`] = `
+{
+  "_cmd": "de b v 6, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 6, de p v 20 1`] = `
+{
+  "_cmd": "de b v 6, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 6, de v 1 1`] = `
+{
+  "_cmd": "de b v 6, de v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, de v 2 1`] = `
+{
+  "_cmd": "de b v 6, de v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, de v 3 1`] = `
+{
+  "_cmd": "de b v 6, de v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, de v 4 1`] = `
+{
+  "_cmd": "de b v 6, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, de v 5 1`] = `
+{
+  "_cmd": "de b v 6, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de v 6 1`] = `
+{
+  "_cmd": "de b v 6, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de v 7 1`] = `
+{
+  "_cmd": "de b v 6, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de v 8 1`] = `
+{
+  "_cmd": "de b v 6, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de v 9 1`] = `
+{
+  "_cmd": "de b v 6, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de v 10 1`] = `
+{
+  "_cmd": "de b v 6, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de v 11 1`] = `
+{
+  "_cmd": "de b v 6, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de v 12 1`] = `
+{
+  "_cmd": "de b v 6, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de v 13 1`] = `
+{
+  "_cmd": "de b v 6, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de v 14 1`] = `
+{
+  "_cmd": "de b v 6, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de v 15 1`] = `
+{
+  "_cmd": "de b v 6, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de v 16 1`] = `
+{
+  "_cmd": "de b v 6, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, de v 17 1`] = `
+{
+  "_cmd": "de b v 6, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 6, de v 18 1`] = `
+{
+  "_cmd": "de b v 6, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 6, de v 19 1`] = `
+{
+  "_cmd": "de b v 6, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 6, de v 20 1`] = `
+{
+  "_cmd": "de b v 6, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 6, de w 1 1`] = `
+{
+  "_cmd": "de b v 6, de w 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, de w 2 1`] = `
+{
+  "_cmd": "de b v 6, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, de w 3 1`] = `
+{
+  "_cmd": "de b v 6, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de w 4 1`] = `
+{
+  "_cmd": "de b v 6, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, de w 5 1`] = `
+{
+  "_cmd": "de b v 6, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de w 6 1`] = `
+{
+  "_cmd": "de b v 6, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de w 7 1`] = `
+{
+  "_cmd": "de b v 6, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de w 8 1`] = `
+{
+  "_cmd": "de b v 6, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de w 9 1`] = `
+{
+  "_cmd": "de b v 6, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, de w 10 1`] = `
+{
+  "_cmd": "de b v 6, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de w 11 1`] = `
+{
+  "_cmd": "de b v 6, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de w 12 1`] = `
+{
+  "_cmd": "de b v 6, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de w 13 1`] = `
+{
+  "_cmd": "de b v 6, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de w 14 1`] = `
+{
+  "_cmd": "de b v 6, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de w 15 1`] = `
+{
+  "_cmd": "de b v 6, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, de w v 1 1`] = `
+{
+  "_cmd": "de b v 6, de w v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, de w v 2 1`] = `
+{
+  "_cmd": "de b v 6, de w v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, de w v 3 1`] = `
+{
+  "_cmd": "de b v 6, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, de w v 4 1`] = `
+{
+  "_cmd": "de b v 6, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, de w v 5 1`] = `
+{
+  "_cmd": "de b v 6, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, de w v 6 1`] = `
+{
+  "_cmd": "de b v 6, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, de w v 7 1`] = `
+{
+  "_cmd": "de b v 6, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, de w v 8 1`] = `
+{
+  "_cmd": "de b v 6, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, de w v 9 1`] = `
+{
+  "_cmd": "de b v 6, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, de w v 10 1`] = `
+{
+  "_cmd": "de b v 6, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, de w v 11 1`] = `
+{
+  "_cmd": "de b v 6, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, de w v 12 1`] = `
+{
+  "_cmd": "de b v 6, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, de w v 13 1`] = `
+{
+  "_cmd": "de b v 6, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, de w v 14 1`] = `
+{
+  "_cmd": "de b v 6, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, de w v 15 1`] = `
+{
+  "_cmd": "de b v 6, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, de w v 16 1`] = `
+{
+  "_cmd": "de b v 6, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 6, de w v 17 1`] = `
+{
+  "_cmd": "de b v 6, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 6, de w v 18 1`] = `
+{
+  "_cmd": "de b v 6, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 6, de w v 19 1`] = `
+{
+  "_cmd": "de b v 6, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 6, de w v 20 1`] = `
+{
+  "_cmd": "de b v 6, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 7, de d 1 1`] = `
+{
+  "_cmd": "de b v 7, de d 1",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 7, de d 2 1`] = `
+{
+  "_cmd": "de b v 7, de d 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, de d 3 1`] = `
+{
+  "_cmd": "de b v 7, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, de d 4 1`] = `
+{
+  "_cmd": "de b v 7, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de d 5 1`] = `
+{
+  "_cmd": "de b v 7, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de d 6 1`] = `
+{
+  "_cmd": "de b v 7, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de d 7 1`] = `
+{
+  "_cmd": "de b v 7, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de d 8 1`] = `
+{
+  "_cmd": "de b v 7, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de d 9 1`] = `
+{
+  "_cmd": "de b v 7, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de d 10 1`] = `
+{
+  "_cmd": "de b v 7, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de d 11 1`] = `
+{
+  "_cmd": "de b v 7, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de d 12 1`] = `
+{
+  "_cmd": "de b v 7, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de d 13 1`] = `
+{
+  "_cmd": "de b v 7, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de d 14 1`] = `
+{
+  "_cmd": "de b v 7, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de d 15 1`] = `
+{
+  "_cmd": "de b v 7, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de d v 1 1`] = `
+{
+  "_cmd": "de b v 7, de d v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, de d v 2 1`] = `
+{
+  "_cmd": "de b v 7, de d v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, de d v 3 1`] = `
+{
+  "_cmd": "de b v 7, de d v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, de d v 4 1`] = `
+{
+  "_cmd": "de b v 7, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de d v 5 1`] = `
+{
+  "_cmd": "de b v 7, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de d v 6 1`] = `
+{
+  "_cmd": "de b v 7, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de d v 7 1`] = `
+{
+  "_cmd": "de b v 7, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de d v 8 1`] = `
+{
+  "_cmd": "de b v 7, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de d v 9 1`] = `
+{
+  "_cmd": "de b v 7, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de d v 10 1`] = `
+{
+  "_cmd": "de b v 7, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de d v 11 1`] = `
+{
+  "_cmd": "de b v 7, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de d v 12 1`] = `
+{
+  "_cmd": "de b v 7, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de d v 13 1`] = `
+{
+  "_cmd": "de b v 7, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de d v 14 1`] = `
+{
+  "_cmd": "de b v 7, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de d v 15 1`] = `
+{
+  "_cmd": "de b v 7, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de d v 16 1`] = `
+{
+  "_cmd": "de b v 7, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, de d v 17 1`] = `
+{
+  "_cmd": "de b v 7, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 7, de d v 18 1`] = `
+{
+  "_cmd": "de b v 7, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 7, de d v 19 1`] = `
+{
+  "_cmd": "de b v 7, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 7, de d v 20 1`] = `
+{
+  "_cmd": "de b v 7, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 7, de p 1 1`] = `
+{
+  "_cmd": "de b v 7, de p 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, de p 2 1`] = `
+{
+  "_cmd": "de b v 7, de p 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, de p 3 1`] = `
+{
+  "_cmd": "de b v 7, de p 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, de p 4 1`] = `
+{
+  "_cmd": "de b v 7, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, de p 5 1`] = `
+{
+  "_cmd": "de b v 7, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de p 6 1`] = `
+{
+  "_cmd": "de b v 7, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de p 7 1`] = `
+{
+  "_cmd": "de b v 7, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de p 8 1`] = `
+{
+  "_cmd": "de b v 7, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de p 9 1`] = `
+{
+  "_cmd": "de b v 7, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de p 10 1`] = `
+{
+  "_cmd": "de b v 7, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de p 11 1`] = `
+{
+  "_cmd": "de b v 7, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de p 12 1`] = `
+{
+  "_cmd": "de b v 7, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de p 13 1`] = `
+{
+  "_cmd": "de b v 7, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de p 14 1`] = `
+{
+  "_cmd": "de b v 7, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de p 15 1`] = `
+{
+  "_cmd": "de b v 7, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de p v 1 1`] = `
+{
+  "_cmd": "de b v 7, de p v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 7, de p v 2 1`] = `
+{
+  "_cmd": "de b v 7, de p v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 7, de p v 3 1`] = `
+{
+  "_cmd": "de b v 7, de p v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, de p v 4 1`] = `
+{
+  "_cmd": "de b v 7, de p v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, de p v 5 1`] = `
+{
+  "_cmd": "de b v 7, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de p v 6 1`] = `
+{
+  "_cmd": "de b v 7, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de p v 7 1`] = `
+{
+  "_cmd": "de b v 7, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de p v 8 1`] = `
+{
+  "_cmd": "de b v 7, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de p v 9 1`] = `
+{
+  "_cmd": "de b v 7, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de p v 10 1`] = `
+{
+  "_cmd": "de b v 7, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de p v 11 1`] = `
+{
+  "_cmd": "de b v 7, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de p v 12 1`] = `
+{
+  "_cmd": "de b v 7, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de p v 13 1`] = `
+{
+  "_cmd": "de b v 7, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de p v 14 1`] = `
+{
+  "_cmd": "de b v 7, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de p v 15 1`] = `
+{
+  "_cmd": "de b v 7, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de p v 16 1`] = `
+{
+  "_cmd": "de b v 7, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de p v 17 1`] = `
+{
+  "_cmd": "de b v 7, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, de p v 18 1`] = `
+{
+  "_cmd": "de b v 7, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 7, de p v 19 1`] = `
+{
+  "_cmd": "de b v 7, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 7, de p v 20 1`] = `
+{
+  "_cmd": "de b v 7, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 7, de v 1 1`] = `
+{
+  "_cmd": "de b v 7, de v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, de v 2 1`] = `
+{
+  "_cmd": "de b v 7, de v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, de v 3 1`] = `
+{
+  "_cmd": "de b v 7, de v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, de v 4 1`] = `
+{
+  "_cmd": "de b v 7, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, de v 5 1`] = `
+{
+  "_cmd": "de b v 7, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de v 6 1`] = `
+{
+  "_cmd": "de b v 7, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de v 7 1`] = `
+{
+  "_cmd": "de b v 7, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de v 8 1`] = `
+{
+  "_cmd": "de b v 7, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de v 9 1`] = `
+{
+  "_cmd": "de b v 7, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de v 10 1`] = `
+{
+  "_cmd": "de b v 7, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de v 11 1`] = `
+{
+  "_cmd": "de b v 7, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de v 12 1`] = `
+{
+  "_cmd": "de b v 7, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de v 13 1`] = `
+{
+  "_cmd": "de b v 7, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de v 14 1`] = `
+{
+  "_cmd": "de b v 7, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de v 15 1`] = `
+{
+  "_cmd": "de b v 7, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de v 16 1`] = `
+{
+  "_cmd": "de b v 7, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, de v 17 1`] = `
+{
+  "_cmd": "de b v 7, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 7, de v 18 1`] = `
+{
+  "_cmd": "de b v 7, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 7, de v 19 1`] = `
+{
+  "_cmd": "de b v 7, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 7, de v 20 1`] = `
+{
+  "_cmd": "de b v 7, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 7, de w 1 1`] = `
+{
+  "_cmd": "de b v 7, de w 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, de w 2 1`] = `
+{
+  "_cmd": "de b v 7, de w 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, de w 3 1`] = `
+{
+  "_cmd": "de b v 7, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, de w 4 1`] = `
+{
+  "_cmd": "de b v 7, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de w 5 1`] = `
+{
+  "_cmd": "de b v 7, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de w 6 1`] = `
+{
+  "_cmd": "de b v 7, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de w 7 1`] = `
+{
+  "_cmd": "de b v 7, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de w 8 1`] = `
+{
+  "_cmd": "de b v 7, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de w 9 1`] = `
+{
+  "_cmd": "de b v 7, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de w 10 1`] = `
+{
+  "_cmd": "de b v 7, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, de w 11 1`] = `
+{
+  "_cmd": "de b v 7, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de w 12 1`] = `
+{
+  "_cmd": "de b v 7, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de w 13 1`] = `
+{
+  "_cmd": "de b v 7, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de w 14 1`] = `
+{
+  "_cmd": "de b v 7, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de w 15 1`] = `
+{
+  "_cmd": "de b v 7, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, de w v 1 1`] = `
+{
+  "_cmd": "de b v 7, de w v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, de w v 2 1`] = `
+{
+  "_cmd": "de b v 7, de w v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, de w v 3 1`] = `
+{
+  "_cmd": "de b v 7, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, de w v 4 1`] = `
+{
+  "_cmd": "de b v 7, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, de w v 5 1`] = `
+{
+  "_cmd": "de b v 7, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, de w v 6 1`] = `
+{
+  "_cmd": "de b v 7, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, de w v 7 1`] = `
+{
+  "_cmd": "de b v 7, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, de w v 8 1`] = `
+{
+  "_cmd": "de b v 7, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, de w v 9 1`] = `
+{
+  "_cmd": "de b v 7, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, de w v 10 1`] = `
+{
+  "_cmd": "de b v 7, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, de w v 11 1`] = `
+{
+  "_cmd": "de b v 7, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, de w v 12 1`] = `
+{
+  "_cmd": "de b v 7, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, de w v 13 1`] = `
+{
+  "_cmd": "de b v 7, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, de w v 14 1`] = `
+{
+  "_cmd": "de b v 7, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, de w v 15 1`] = `
+{
+  "_cmd": "de b v 7, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, de w v 16 1`] = `
+{
+  "_cmd": "de b v 7, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 7, de w v 17 1`] = `
+{
+  "_cmd": "de b v 7, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 7, de w v 18 1`] = `
+{
+  "_cmd": "de b v 7, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 7, de w v 19 1`] = `
+{
+  "_cmd": "de b v 7, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 7, de w v 20 1`] = `
+{
+  "_cmd": "de b v 7, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 8, de d 1 1`] = `
+{
+  "_cmd": "de b v 8, de d 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, de d 2 1`] = `
+{
+  "_cmd": "de b v 8, de d 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, de d 3 1`] = `
+{
+  "_cmd": "de b v 8, de d 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, de d 4 1`] = `
+{
+  "_cmd": "de b v 8, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, de d 5 1`] = `
+{
+  "_cmd": "de b v 8, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de d 6 1`] = `
+{
+  "_cmd": "de b v 8, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de d 7 1`] = `
+{
+  "_cmd": "de b v 8, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de d 8 1`] = `
+{
+  "_cmd": "de b v 8, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de d 9 1`] = `
+{
+  "_cmd": "de b v 8, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de d 10 1`] = `
+{
+  "_cmd": "de b v 8, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de d 11 1`] = `
+{
+  "_cmd": "de b v 8, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de d 12 1`] = `
+{
+  "_cmd": "de b v 8, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de d 13 1`] = `
+{
+  "_cmd": "de b v 8, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de d 14 1`] = `
+{
+  "_cmd": "de b v 8, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de d 15 1`] = `
+{
+  "_cmd": "de b v 8, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de d v 1 1`] = `
+{
+  "_cmd": "de b v 8, de d v 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, de d v 2 1`] = `
+{
+  "_cmd": "de b v 8, de d v 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, de d v 3 1`] = `
+{
+  "_cmd": "de b v 8, de d v 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, de d v 4 1`] = `
+{
+  "_cmd": "de b v 8, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, de d v 5 1`] = `
+{
+  "_cmd": "de b v 8, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de d v 6 1`] = `
+{
+  "_cmd": "de b v 8, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de d v 7 1`] = `
+{
+  "_cmd": "de b v 8, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de d v 8 1`] = `
+{
+  "_cmd": "de b v 8, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de d v 9 1`] = `
+{
+  "_cmd": "de b v 8, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de d v 10 1`] = `
+{
+  "_cmd": "de b v 8, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de d v 11 1`] = `
+{
+  "_cmd": "de b v 8, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de d v 12 1`] = `
+{
+  "_cmd": "de b v 8, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de d v 13 1`] = `
+{
+  "_cmd": "de b v 8, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de d v 14 1`] = `
+{
+  "_cmd": "de b v 8, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de d v 15 1`] = `
+{
+  "_cmd": "de b v 8, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de d v 16 1`] = `
+{
+  "_cmd": "de b v 8, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, de d v 17 1`] = `
+{
+  "_cmd": "de b v 8, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 8, de d v 18 1`] = `
+{
+  "_cmd": "de b v 8, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 8, de d v 19 1`] = `
+{
+  "_cmd": "de b v 8, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 8, de d v 20 1`] = `
+{
+  "_cmd": "de b v 8, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 8, de p 1 1`] = `
+{
+  "_cmd": "de b v 8, de p 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, de p 2 1`] = `
+{
+  "_cmd": "de b v 8, de p 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, de p 3 1`] = `
+{
+  "_cmd": "de b v 8, de p 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, de p 4 1`] = `
+{
+  "_cmd": "de b v 8, de p 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, de p 5 1`] = `
+{
+  "_cmd": "de b v 8, de p 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, de p 6 1`] = `
+{
+  "_cmd": "de b v 8, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de p 7 1`] = `
+{
+  "_cmd": "de b v 8, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de p 8 1`] = `
+{
+  "_cmd": "de b v 8, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de p 9 1`] = `
+{
+  "_cmd": "de b v 8, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de p 10 1`] = `
+{
+  "_cmd": "de b v 8, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de p 11 1`] = `
+{
+  "_cmd": "de b v 8, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de p 12 1`] = `
+{
+  "_cmd": "de b v 8, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de p 13 1`] = `
+{
+  "_cmd": "de b v 8, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de p 14 1`] = `
+{
+  "_cmd": "de b v 8, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de p 15 1`] = `
+{
+  "_cmd": "de b v 8, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de p v 1 1`] = `
+{
+  "_cmd": "de b v 8, de p v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 8, de p v 2 1`] = `
+{
+  "_cmd": "de b v 8, de p v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, de p v 3 1`] = `
+{
+  "_cmd": "de b v 8, de p v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, de p v 4 1`] = `
+{
+  "_cmd": "de b v 8, de p v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, de p v 5 1`] = `
+{
+  "_cmd": "de b v 8, de p v 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, de p v 6 1`] = `
+{
+  "_cmd": "de b v 8, de p v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de p v 7 1`] = `
+{
+  "_cmd": "de b v 8, de p v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de p v 8 1`] = `
+{
+  "_cmd": "de b v 8, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de p v 9 1`] = `
+{
+  "_cmd": "de b v 8, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de p v 10 1`] = `
+{
+  "_cmd": "de b v 8, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de p v 11 1`] = `
+{
+  "_cmd": "de b v 8, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de p v 12 1`] = `
+{
+  "_cmd": "de b v 8, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de p v 13 1`] = `
+{
+  "_cmd": "de b v 8, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de p v 14 1`] = `
+{
+  "_cmd": "de b v 8, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de p v 15 1`] = `
+{
+  "_cmd": "de b v 8, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de p v 16 1`] = `
+{
+  "_cmd": "de b v 8, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de p v 17 1`] = `
+{
+  "_cmd": "de b v 8, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, de p v 18 1`] = `
+{
+  "_cmd": "de b v 8, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 8, de p v 19 1`] = `
+{
+  "_cmd": "de b v 8, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 8, de p v 20 1`] = `
+{
+  "_cmd": "de b v 8, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 8, de v 1 1`] = `
+{
+  "_cmd": "de b v 8, de v 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, de v 2 1`] = `
+{
+  "_cmd": "de b v 8, de v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, de v 3 1`] = `
+{
+  "_cmd": "de b v 8, de v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, de v 4 1`] = `
+{
+  "_cmd": "de b v 8, de v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, de v 5 1`] = `
+{
+  "_cmd": "de b v 8, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, de v 6 1`] = `
+{
+  "_cmd": "de b v 8, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de v 7 1`] = `
+{
+  "_cmd": "de b v 8, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de v 8 1`] = `
+{
+  "_cmd": "de b v 8, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de v 9 1`] = `
+{
+  "_cmd": "de b v 8, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de v 10 1`] = `
+{
+  "_cmd": "de b v 8, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de v 11 1`] = `
+{
+  "_cmd": "de b v 8, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de v 12 1`] = `
+{
+  "_cmd": "de b v 8, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de v 13 1`] = `
+{
+  "_cmd": "de b v 8, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de v 14 1`] = `
+{
+  "_cmd": "de b v 8, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de v 15 1`] = `
+{
+  "_cmd": "de b v 8, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de v 16 1`] = `
+{
+  "_cmd": "de b v 8, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, de v 17 1`] = `
+{
+  "_cmd": "de b v 8, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 8, de v 18 1`] = `
+{
+  "_cmd": "de b v 8, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 8, de v 19 1`] = `
+{
+  "_cmd": "de b v 8, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 8, de v 20 1`] = `
+{
+  "_cmd": "de b v 8, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 8, de w 1 1`] = `
+{
+  "_cmd": "de b v 8, de w 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, de w 2 1`] = `
+{
+  "_cmd": "de b v 8, de w 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, de w 3 1`] = `
+{
+  "_cmd": "de b v 8, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, de w 4 1`] = `
+{
+  "_cmd": "de b v 8, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de w 5 1`] = `
+{
+  "_cmd": "de b v 8, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de w 6 1`] = `
+{
+  "_cmd": "de b v 8, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de w 7 1`] = `
+{
+  "_cmd": "de b v 8, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de w 8 1`] = `
+{
+  "_cmd": "de b v 8, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de w 9 1`] = `
+{
+  "_cmd": "de b v 8, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de w 10 1`] = `
+{
+  "_cmd": "de b v 8, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de w 11 1`] = `
+{
+  "_cmd": "de b v 8, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de w 12 1`] = `
+{
+  "_cmd": "de b v 8, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, de w 13 1`] = `
+{
+  "_cmd": "de b v 8, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de w 14 1`] = `
+{
+  "_cmd": "de b v 8, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de w 15 1`] = `
+{
+  "_cmd": "de b v 8, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, de w v 1 1`] = `
+{
+  "_cmd": "de b v 8, de w v 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, de w v 2 1`] = `
+{
+  "_cmd": "de b v 8, de w v 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, de w v 3 1`] = `
+{
+  "_cmd": "de b v 8, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, de w v 4 1`] = `
+{
+  "_cmd": "de b v 8, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, de w v 5 1`] = `
+{
+  "_cmd": "de b v 8, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, de w v 6 1`] = `
+{
+  "_cmd": "de b v 8, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, de w v 7 1`] = `
+{
+  "_cmd": "de b v 8, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, de w v 8 1`] = `
+{
+  "_cmd": "de b v 8, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, de w v 9 1`] = `
+{
+  "_cmd": "de b v 8, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, de w v 10 1`] = `
+{
+  "_cmd": "de b v 8, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, de w v 11 1`] = `
+{
+  "_cmd": "de b v 8, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, de w v 12 1`] = `
+{
+  "_cmd": "de b v 8, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, de w v 13 1`] = `
+{
+  "_cmd": "de b v 8, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, de w v 14 1`] = `
+{
+  "_cmd": "de b v 8, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, de w v 15 1`] = `
+{
+  "_cmd": "de b v 8, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, de w v 16 1`] = `
+{
+  "_cmd": "de b v 8, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 8, de w v 17 1`] = `
+{
+  "_cmd": "de b v 8, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 8, de w v 18 1`] = `
+{
+  "_cmd": "de b v 8, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 8, de w v 19 1`] = `
+{
+  "_cmd": "de b v 8, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 8, de w v 20 1`] = `
+{
+  "_cmd": "de b v 8, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 9, de d 1 1`] = `
+{
+  "_cmd": "de b v 9, de d 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 9, de d 2 1`] = `
+{
+  "_cmd": "de b v 9, de d 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, de d 3 1`] = `
+{
+  "_cmd": "de b v 9, de d 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de d 4 1`] = `
+{
+  "_cmd": "de b v 9, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, de d 5 1`] = `
+{
+  "_cmd": "de b v 9, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de d 6 1`] = `
+{
+  "_cmd": "de b v 9, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de d 7 1`] = `
+{
+  "_cmd": "de b v 9, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de d 8 1`] = `
+{
+  "_cmd": "de b v 9, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de d 9 1`] = `
+{
+  "_cmd": "de b v 9, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de d 10 1`] = `
+{
+  "_cmd": "de b v 9, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de d 11 1`] = `
+{
+  "_cmd": "de b v 9, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de d 12 1`] = `
+{
+  "_cmd": "de b v 9, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de d 13 1`] = `
+{
+  "_cmd": "de b v 9, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de d 14 1`] = `
+{
+  "_cmd": "de b v 9, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de d 15 1`] = `
+{
+  "_cmd": "de b v 9, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 9, de d v 1 1`] = `
+{
+  "_cmd": "de b v 9, de d v 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 9, de d v 2 1`] = `
+{
+  "_cmd": "de b v 9, de d v 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, de d v 3 1`] = `
+{
+  "_cmd": "de b v 9, de d v 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de d v 4 1`] = `
+{
+  "_cmd": "de b v 9, de d v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, de d v 5 1`] = `
+{
+  "_cmd": "de b v 9, de d v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, de d v 6 1`] = `
+{
+  "_cmd": "de b v 9, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de d v 7 1`] = `
+{
+  "_cmd": "de b v 9, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de d v 8 1`] = `
+{
+  "_cmd": "de b v 9, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, de d v 9 1`] = `
+{
+  "_cmd": "de b v 9, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de d v 10 1`] = `
+{
+  "_cmd": "de b v 9, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de d v 11 1`] = `
+{
+  "_cmd": "de b v 9, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de d v 12 1`] = `
+{
+  "_cmd": "de b v 9, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de d v 13 1`] = `
+{
+  "_cmd": "de b v 9, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de d v 14 1`] = `
+{
+  "_cmd": "de b v 9, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de d v 15 1`] = `
+{
+  "_cmd": "de b v 9, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 9, de d v 16 1`] = `
+{
+  "_cmd": "de b v 9, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, de d v 17 1`] = `
+{
+  "_cmd": "de b v 9, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 9, de d v 18 1`] = `
+{
+  "_cmd": "de b v 9, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 9, de d v 19 1`] = `
+{
+  "_cmd": "de b v 9, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 9, de d v 20 1`] = `
+{
+  "_cmd": "de b v 9, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 9, de p 1 1`] = `
+{
+  "_cmd": "de b v 9, de p 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, de p 2 1`] = `
+{
+  "_cmd": "de b v 9, de p 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, de p 3 1`] = `
+{
+  "_cmd": "de b v 9, de p 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, de p 4 1`] = `
+{
+  "_cmd": "de b v 9, de p 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de p 5 1`] = `
+{
+  "_cmd": "de b v 9, de p 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, de p 6 1`] = `
+{
+  "_cmd": "de b v 9, de p 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de p 7 1`] = `
+{
+  "_cmd": "de b v 9, de p 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de p 8 1`] = `
+{
+  "_cmd": "de b v 9, de p 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de p 9 1`] = `
+{
+  "_cmd": "de b v 9, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de p 10 1`] = `
+{
+  "_cmd": "de b v 9, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de p 11 1`] = `
+{
+  "_cmd": "de b v 9, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de p 12 1`] = `
+{
+  "_cmd": "de b v 9, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de p 13 1`] = `
+{
+  "_cmd": "de b v 9, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de p 14 1`] = `
+{
+  "_cmd": "de b v 9, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de p 15 1`] = `
+{
+  "_cmd": "de b v 9, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de p v 1 1`] = `
+{
+  "_cmd": "de b v 9, de p v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, de p v 2 1`] = `
+{
+  "_cmd": "de b v 9, de p v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, de p v 3 1`] = `
+{
+  "_cmd": "de b v 9, de p v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, de p v 4 1`] = `
+{
+  "_cmd": "de b v 9, de p v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de p v 5 1`] = `
+{
+  "_cmd": "de b v 9, de p v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, de p v 6 1`] = `
+{
+  "_cmd": "de b v 9, de p v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de p v 7 1`] = `
+{
+  "_cmd": "de b v 9, de p v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de p v 8 1`] = `
+{
+  "_cmd": "de b v 9, de p v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de p v 9 1`] = `
+{
+  "_cmd": "de b v 9, de p v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, de p v 10 1`] = `
+{
+  "_cmd": "de b v 9, de p v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de p v 11 1`] = `
+{
+  "_cmd": "de b v 9, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de p v 12 1`] = `
+{
+  "_cmd": "de b v 9, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de p v 13 1`] = `
+{
+  "_cmd": "de b v 9, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de p v 14 1`] = `
+{
+  "_cmd": "de b v 9, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de p v 15 1`] = `
+{
+  "_cmd": "de b v 9, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de p v 16 1`] = `
+{
+  "_cmd": "de b v 9, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 9, de p v 17 1`] = `
+{
+  "_cmd": "de b v 9, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, de p v 18 1`] = `
+{
+  "_cmd": "de b v 9, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 9, de p v 19 1`] = `
+{
+  "_cmd": "de b v 9, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 9, de p v 20 1`] = `
+{
+  "_cmd": "de b v 9, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 9, de v 1 1`] = `
+{
+  "_cmd": "de b v 9, de v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, de v 2 1`] = `
+{
+  "_cmd": "de b v 9, de v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, de v 3 1`] = `
+{
+  "_cmd": "de b v 9, de v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, de v 4 1`] = `
+{
+  "_cmd": "de b v 9, de v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de v 5 1`] = `
+{
+  "_cmd": "de b v 9, de v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, de v 6 1`] = `
+{
+  "_cmd": "de b v 9, de v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de v 7 1`] = `
+{
+  "_cmd": "de b v 9, de v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de v 8 1`] = `
+{
+  "_cmd": "de b v 9, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, de v 9 1`] = `
+{
+  "_cmd": "de b v 9, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de v 10 1`] = `
+{
+  "_cmd": "de b v 9, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de v 11 1`] = `
+{
+  "_cmd": "de b v 9, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de v 12 1`] = `
+{
+  "_cmd": "de b v 9, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de v 13 1`] = `
+{
+  "_cmd": "de b v 9, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de v 14 1`] = `
+{
+  "_cmd": "de b v 9, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de v 15 1`] = `
+{
+  "_cmd": "de b v 9, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de v 16 1`] = `
+{
+  "_cmd": "de b v 9, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, de v 17 1`] = `
+{
+  "_cmd": "de b v 9, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 9, de v 18 1`] = `
+{
+  "_cmd": "de b v 9, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 9, de v 19 1`] = `
+{
+  "_cmd": "de b v 9, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 9, de v 20 1`] = `
+{
+  "_cmd": "de b v 9, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 9, de w 1 1`] = `
+{
+  "_cmd": "de b v 9, de w 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, de w 2 1`] = `
+{
+  "_cmd": "de b v 9, de w 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de w 3 1`] = `
+{
+  "_cmd": "de b v 9, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, de w 4 1`] = `
+{
+  "_cmd": "de b v 9, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de w 5 1`] = `
+{
+  "_cmd": "de b v 9, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de w 6 1`] = `
+{
+  "_cmd": "de b v 9, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de w 7 1`] = `
+{
+  "_cmd": "de b v 9, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, de w 8 1`] = `
+{
+  "_cmd": "de b v 9, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de w 9 1`] = `
+{
+  "_cmd": "de b v 9, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de w 10 1`] = `
+{
+  "_cmd": "de b v 9, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de w 11 1`] = `
+{
+  "_cmd": "de b v 9, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de w 12 1`] = `
+{
+  "_cmd": "de b v 9, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de w 13 1`] = `
+{
+  "_cmd": "de b v 9, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de w 14 1`] = `
+{
+  "_cmd": "de b v 9, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 9, de w 15 1`] = `
+{
+  "_cmd": "de b v 9, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, de w v 1 1`] = `
+{
+  "_cmd": "de b v 9, de w v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, de w v 2 1`] = `
+{
+  "_cmd": "de b v 9, de w v 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, de w v 3 1`] = `
+{
+  "_cmd": "de b v 9, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, de w v 4 1`] = `
+{
+  "_cmd": "de b v 9, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, de w v 5 1`] = `
+{
+  "_cmd": "de b v 9, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, de w v 6 1`] = `
+{
+  "_cmd": "de b v 9, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, de w v 7 1`] = `
+{
+  "_cmd": "de b v 9, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, de w v 8 1`] = `
+{
+  "_cmd": "de b v 9, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, de w v 9 1`] = `
+{
+  "_cmd": "de b v 9, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, de w v 10 1`] = `
+{
+  "_cmd": "de b v 9, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, de w v 11 1`] = `
+{
+  "_cmd": "de b v 9, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, de w v 12 1`] = `
+{
+  "_cmd": "de b v 9, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, de w v 13 1`] = `
+{
+  "_cmd": "de b v 9, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, de w v 14 1`] = `
+{
+  "_cmd": "de b v 9, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, de w v 15 1`] = `
+{
+  "_cmd": "de b v 9, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, de w v 16 1`] = `
+{
+  "_cmd": "de b v 9, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 9, de w v 17 1`] = `
+{
+  "_cmd": "de b v 9, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 9, de w v 18 1`] = `
+{
+  "_cmd": "de b v 9, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 9, de w v 19 1`] = `
+{
+  "_cmd": "de b v 9, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 9, de w v 20 1`] = `
+{
+  "_cmd": "de b v 9, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 10, de d 1 1`] = `
+{
+  "_cmd": "de b v 10, de d 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 10, de d 2 1`] = `
+{
+  "_cmd": "de b v 10, de d 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, de d 3 1`] = `
+{
+  "_cmd": "de b v 10, de d 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, de d 4 1`] = `
+{
+  "_cmd": "de b v 10, de d 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, de d 5 1`] = `
+{
+  "_cmd": "de b v 10, de d 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, de d 6 1`] = `
+{
+  "_cmd": "de b v 10, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de d 7 1`] = `
+{
+  "_cmd": "de b v 10, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de d 8 1`] = `
+{
+  "_cmd": "de b v 10, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de d 9 1`] = `
+{
+  "_cmd": "de b v 10, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de d 10 1`] = `
+{
+  "_cmd": "de b v 10, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de d 11 1`] = `
+{
+  "_cmd": "de b v 10, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, de d 12 1`] = `
+{
+  "_cmd": "de b v 10, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de d 13 1`] = `
+{
+  "_cmd": "de b v 10, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de d 14 1`] = `
+{
+  "_cmd": "de b v 10, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de d 15 1`] = `
+{
+  "_cmd": "de b v 10, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de d v 1 1`] = `
+{
+  "_cmd": "de b v 10, de d v 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 10, de d v 2 1`] = `
+{
+  "_cmd": "de b v 10, de d v 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, de d v 3 1`] = `
+{
+  "_cmd": "de b v 10, de d v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, de d v 4 1`] = `
+{
+  "_cmd": "de b v 10, de d v 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, de d v 5 1`] = `
+{
+  "_cmd": "de b v 10, de d v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, de d v 6 1`] = `
+{
+  "_cmd": "de b v 10, de d v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de d v 7 1`] = `
+{
+  "_cmd": "de b v 10, de d v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de d v 8 1`] = `
+{
+  "_cmd": "de b v 10, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de d v 9 1`] = `
+{
+  "_cmd": "de b v 10, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, de d v 10 1`] = `
+{
+  "_cmd": "de b v 10, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de d v 11 1`] = `
+{
+  "_cmd": "de b v 10, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de d v 12 1`] = `
+{
+  "_cmd": "de b v 10, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de d v 13 1`] = `
+{
+  "_cmd": "de b v 10, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de d v 14 1`] = `
+{
+  "_cmd": "de b v 10, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de d v 15 1`] = `
+{
+  "_cmd": "de b v 10, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de d v 16 1`] = `
+{
+  "_cmd": "de b v 10, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 10, de d v 17 1`] = `
+{
+  "_cmd": "de b v 10, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 10, de d v 18 1`] = `
+{
+  "_cmd": "de b v 10, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 10, de d v 19 1`] = `
+{
+  "_cmd": "de b v 10, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 10, de d v 20 1`] = `
+{
+  "_cmd": "de b v 10, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 10, de p 1 1`] = `
+{
+  "_cmd": "de b v 10, de p 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, de p 2 1`] = `
+{
+  "_cmd": "de b v 10, de p 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, de p 3 1`] = `
+{
+  "_cmd": "de b v 10, de p 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, de p 4 1`] = `
+{
+  "_cmd": "de b v 10, de p 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, de p 5 1`] = `
+{
+  "_cmd": "de b v 10, de p 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, de p 6 1`] = `
+{
+  "_cmd": "de b v 10, de p 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, de p 7 1`] = `
+{
+  "_cmd": "de b v 10, de p 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de p 8 1`] = `
+{
+  "_cmd": "de b v 10, de p 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de p 9 1`] = `
+{
+  "_cmd": "de b v 10, de p 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de p 10 1`] = `
+{
+  "_cmd": "de b v 10, de p 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de p 11 1`] = `
+{
+  "_cmd": "de b v 10, de p 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de p 12 1`] = `
+{
+  "_cmd": "de b v 10, de p 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, de p 13 1`] = `
+{
+  "_cmd": "de b v 10, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de p 14 1`] = `
+{
+  "_cmd": "de b v 10, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de p 15 1`] = `
+{
+  "_cmd": "de b v 10, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de p v 1 1`] = `
+{
+  "_cmd": "de b v 10, de p v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, de p v 2 1`] = `
+{
+  "_cmd": "de b v 10, de p v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, de p v 3 1`] = `
+{
+  "_cmd": "de b v 10, de p v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, de p v 4 1`] = `
+{
+  "_cmd": "de b v 10, de p v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, de p v 5 1`] = `
+{
+  "_cmd": "de b v 10, de p v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, de p v 6 1`] = `
+{
+  "_cmd": "de b v 10, de p v 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, de p v 7 1`] = `
+{
+  "_cmd": "de b v 10, de p v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de p v 8 1`] = `
+{
+  "_cmd": "de b v 10, de p v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de p v 9 1`] = `
+{
+  "_cmd": "de b v 10, de p v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de p v 10 1`] = `
+{
+  "_cmd": "de b v 10, de p v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, de p v 11 1`] = `
+{
+  "_cmd": "de b v 10, de p v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de p v 12 1`] = `
+{
+  "_cmd": "de b v 10, de p v 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de p v 13 1`] = `
+{
+  "_cmd": "de b v 10, de p v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de p v 14 1`] = `
+{
+  "_cmd": "de b v 10, de p v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de p v 15 1`] = `
+{
+  "_cmd": "de b v 10, de p v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de p v 16 1`] = `
+{
+  "_cmd": "de b v 10, de p v 16",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de p v 17 1`] = `
+{
+  "_cmd": "de b v 10, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 10, de p v 18 1`] = `
+{
+  "_cmd": "de b v 10, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 10, de p v 19 1`] = `
+{
+  "_cmd": "de b v 10, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 10, de p v 20 1`] = `
+{
+  "_cmd": "de b v 10, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 10, de v 1 1`] = `
+{
+  "_cmd": "de b v 10, de v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, de v 2 1`] = `
+{
+  "_cmd": "de b v 10, de v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, de v 3 1`] = `
+{
+  "_cmd": "de b v 10, de v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, de v 4 1`] = `
+{
+  "_cmd": "de b v 10, de v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, de v 5 1`] = `
+{
+  "_cmd": "de b v 10, de v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, de v 6 1`] = `
+{
+  "_cmd": "de b v 10, de v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, de v 7 1`] = `
+{
+  "_cmd": "de b v 10, de v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de v 8 1`] = `
+{
+  "_cmd": "de b v 10, de v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de v 9 1`] = `
+{
+  "_cmd": "de b v 10, de v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, de v 10 1`] = `
+{
+  "_cmd": "de b v 10, de v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de v 11 1`] = `
+{
+  "_cmd": "de b v 10, de v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de v 12 1`] = `
+{
+  "_cmd": "de b v 10, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, de v 13 1`] = `
+{
+  "_cmd": "de b v 10, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de v 14 1`] = `
+{
+  "_cmd": "de b v 10, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de v 15 1`] = `
+{
+  "_cmd": "de b v 10, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de v 16 1`] = `
+{
+  "_cmd": "de b v 10, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de v 17 1`] = `
+{
+  "_cmd": "de b v 10, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 10, de v 18 1`] = `
+{
+  "_cmd": "de b v 10, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 10, de v 19 1`] = `
+{
+  "_cmd": "de b v 10, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 10, de v 20 1`] = `
+{
+  "_cmd": "de b v 10, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 10, de w 1 1`] = `
+{
+  "_cmd": "de b v 10, de w 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, de w 2 1`] = `
+{
+  "_cmd": "de b v 10, de w 2",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, de w 3 1`] = `
+{
+  "_cmd": "de b v 10, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, de w 4 1`] = `
+{
+  "_cmd": "de b v 10, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, de w 5 1`] = `
+{
+  "_cmd": "de b v 10, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de w 6 1`] = `
+{
+  "_cmd": "de b v 10, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de w 7 1`] = `
+{
+  "_cmd": "de b v 10, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de w 8 1`] = `
+{
+  "_cmd": "de b v 10, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, de w 9 1`] = `
+{
+  "_cmd": "de b v 10, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de w 10 1`] = `
+{
+  "_cmd": "de b v 10, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de w 11 1`] = `
+{
+  "_cmd": "de b v 10, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, de w 12 1`] = `
+{
+  "_cmd": "de b v 10, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de w 13 1`] = `
+{
+  "_cmd": "de b v 10, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de w 14 1`] = `
+{
+  "_cmd": "de b v 10, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de w 15 1`] = `
+{
+  "_cmd": "de b v 10, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 10, de w v 1 1`] = `
+{
+  "_cmd": "de b v 10, de w v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, de w v 2 1`] = `
+{
+  "_cmd": "de b v 10, de w v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, de w v 3 1`] = `
+{
+  "_cmd": "de b v 10, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, de w v 4 1`] = `
+{
+  "_cmd": "de b v 10, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, de w v 5 1`] = `
+{
+  "_cmd": "de b v 10, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, de w v 6 1`] = `
+{
+  "_cmd": "de b v 10, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, de w v 7 1`] = `
+{
+  "_cmd": "de b v 10, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, de w v 8 1`] = `
+{
+  "_cmd": "de b v 10, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, de w v 9 1`] = `
+{
+  "_cmd": "de b v 10, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, de w v 10 1`] = `
+{
+  "_cmd": "de b v 10, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, de w v 11 1`] = `
+{
+  "_cmd": "de b v 10, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, de w v 12 1`] = `
+{
+  "_cmd": "de b v 10, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, de w v 13 1`] = `
+{
+  "_cmd": "de b v 10, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, de w v 14 1`] = `
+{
+  "_cmd": "de b v 10, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, de w v 15 1`] = `
+{
+  "_cmd": "de b v 10, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, de w v 16 1`] = `
+{
+  "_cmd": "de b v 10, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 10, de w v 17 1`] = `
+{
+  "_cmd": "de b v 10, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 10, de w v 18 1`] = `
+{
+  "_cmd": "de b v 10, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 10, de w v 19 1`] = `
+{
+  "_cmd": "de b v 10, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 10, de w v 20 1`] = `
+{
+  "_cmd": "de b v 10, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 11, de d 1 1`] = `
+{
+  "_cmd": "de b v 11, de d 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 11, de d 2 1`] = `
+{
+  "_cmd": "de b v 11, de d 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, de d 3 1`] = `
+{
+  "_cmd": "de b v 11, de d 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, de d 4 1`] = `
+{
+  "_cmd": "de b v 11, de d 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de d 5 1`] = `
+{
+  "_cmd": "de b v 11, de d 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de d 6 1`] = `
+{
+  "_cmd": "de b v 11, de d 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, de d 7 1`] = `
+{
+  "_cmd": "de b v 11, de d 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de d 8 1`] = `
+{
+  "_cmd": "de b v 11, de d 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de d 9 1`] = `
+{
+  "_cmd": "de b v 11, de d 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de d 10 1`] = `
+{
+  "_cmd": "de b v 11, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de d 11 1`] = `
+{
+  "_cmd": "de b v 11, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de d 12 1`] = `
+{
+  "_cmd": "de b v 11, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, de d 13 1`] = `
+{
+  "_cmd": "de b v 11, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de d 14 1`] = `
+{
+  "_cmd": "de b v 11, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de d 15 1`] = `
+{
+  "_cmd": "de b v 11, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de d v 1 1`] = `
+{
+  "_cmd": "de b v 11, de d v 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 11, de d v 2 1`] = `
+{
+  "_cmd": "de b v 11, de d v 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, de d v 3 1`] = `
+{
+  "_cmd": "de b v 11, de d v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, de d v 4 1`] = `
+{
+  "_cmd": "de b v 11, de d v 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de d v 5 1`] = `
+{
+  "_cmd": "de b v 11, de d v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, de d v 6 1`] = `
+{
+  "_cmd": "de b v 11, de d v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de d v 7 1`] = `
+{
+  "_cmd": "de b v 11, de d v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de d v 8 1`] = `
+{
+  "_cmd": "de b v 11, de d v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de d v 9 1`] = `
+{
+  "_cmd": "de b v 11, de d v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de d v 10 1`] = `
+{
+  "_cmd": "de b v 11, de d v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, de d v 11 1`] = `
+{
+  "_cmd": "de b v 11, de d v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de d v 12 1`] = `
+{
+  "_cmd": "de b v 11, de d v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de d v 13 1`] = `
+{
+  "_cmd": "de b v 11, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de d v 14 1`] = `
+{
+  "_cmd": "de b v 11, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de d v 15 1`] = `
+{
+  "_cmd": "de b v 11, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de d v 16 1`] = `
+{
+  "_cmd": "de b v 11, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 11, de d v 17 1`] = `
+{
+  "_cmd": "de b v 11, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 11, de d v 18 1`] = `
+{
+  "_cmd": "de b v 11, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 11, de d v 19 1`] = `
+{
+  "_cmd": "de b v 11, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 11, de d v 20 1`] = `
+{
+  "_cmd": "de b v 11, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 11, de p 1 1`] = `
+{
+  "_cmd": "de b v 11, de p 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, de p 2 1`] = `
+{
+  "_cmd": "de b v 11, de p 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, de p 3 1`] = `
+{
+  "_cmd": "de b v 11, de p 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, de p 4 1`] = `
+{
+  "_cmd": "de b v 11, de p 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, de p 5 1`] = `
+{
+  "_cmd": "de b v 11, de p 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de p 6 1`] = `
+{
+  "_cmd": "de b v 11, de p 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de p 7 1`] = `
+{
+  "_cmd": "de b v 11, de p 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, de p 8 1`] = `
+{
+  "_cmd": "de b v 11, de p 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de p 9 1`] = `
+{
+  "_cmd": "de b v 11, de p 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de p 10 1`] = `
+{
+  "_cmd": "de b v 11, de p 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de p 11 1`] = `
+{
+  "_cmd": "de b v 11, de p 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de p 12 1`] = `
+{
+  "_cmd": "de b v 11, de p 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de p 13 1`] = `
+{
+  "_cmd": "de b v 11, de p 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, de p 14 1`] = `
+{
+  "_cmd": "de b v 11, de p 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de p 15 1`] = `
+{
+  "_cmd": "de b v 11, de p 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de p v 1 1`] = `
+{
+  "_cmd": "de b v 11, de p v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, de p v 2 1`] = `
+{
+  "_cmd": "de b v 11, de p v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, de p v 3 1`] = `
+{
+  "_cmd": "de b v 11, de p v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, de p v 4 1`] = `
+{
+  "_cmd": "de b v 11, de p v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, de p v 5 1`] = `
+{
+  "_cmd": "de b v 11, de p v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de p v 6 1`] = `
+{
+  "_cmd": "de b v 11, de p v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, de p v 7 1`] = `
+{
+  "_cmd": "de b v 11, de p v 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de p v 8 1`] = `
+{
+  "_cmd": "de b v 11, de p v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de p v 9 1`] = `
+{
+  "_cmd": "de b v 11, de p v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de p v 10 1`] = `
+{
+  "_cmd": "de b v 11, de p v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de p v 11 1`] = `
+{
+  "_cmd": "de b v 11, de p v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, de p v 12 1`] = `
+{
+  "_cmd": "de b v 11, de p v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de p v 13 1`] = `
+{
+  "_cmd": "de b v 11, de p v 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de p v 14 1`] = `
+{
+  "_cmd": "de b v 11, de p v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de p v 15 1`] = `
+{
+  "_cmd": "de b v 11, de p v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de p v 16 1`] = `
+{
+  "_cmd": "de b v 11, de p v 16",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de p v 17 1`] = `
+{
+  "_cmd": "de b v 11, de p v 17",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 11, de p v 18 1`] = `
+{
+  "_cmd": "de b v 11, de p v 18",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 11, de p v 19 1`] = `
+{
+  "_cmd": "de b v 11, de p v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 11, de p v 20 1`] = `
+{
+  "_cmd": "de b v 11, de p v 20",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 11, de v 1 1`] = `
+{
+  "_cmd": "de b v 11, de v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, de v 2 1`] = `
+{
+  "_cmd": "de b v 11, de v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, de v 3 1`] = `
+{
+  "_cmd": "de b v 11, de v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, de v 4 1`] = `
+{
+  "_cmd": "de b v 11, de v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, de v 5 1`] = `
+{
+  "_cmd": "de b v 11, de v 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de v 6 1`] = `
+{
+  "_cmd": "de b v 11, de v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de v 7 1`] = `
+{
+  "_cmd": "de b v 11, de v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, de v 8 1`] = `
+{
+  "_cmd": "de b v 11, de v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de v 9 1`] = `
+{
+  "_cmd": "de b v 11, de v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de v 10 1`] = `
+{
+  "_cmd": "de b v 11, de v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, de v 11 1`] = `
+{
+  "_cmd": "de b v 11, de v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de v 12 1`] = `
+{
+  "_cmd": "de b v 11, de v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de v 13 1`] = `
+{
+  "_cmd": "de b v 11, de v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, de v 14 1`] = `
+{
+  "_cmd": "de b v 11, de v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de v 15 1`] = `
+{
+  "_cmd": "de b v 11, de v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de v 16 1`] = `
+{
+  "_cmd": "de b v 11, de v 16",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de v 17 1`] = `
+{
+  "_cmd": "de b v 11, de v 17",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 11, de v 18 1`] = `
+{
+  "_cmd": "de b v 11, de v 18",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 11, de v 19 1`] = `
+{
+  "_cmd": "de b v 11, de v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 11, de v 20 1`] = `
+{
+  "_cmd": "de b v 11, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 11, de w 1 1`] = `
+{
+  "_cmd": "de b v 11, de w 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, de w 2 1`] = `
+{
+  "_cmd": "de b v 11, de w 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, de w 3 1`] = `
+{
+  "_cmd": "de b v 11, de w 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de w 4 1`] = `
+{
+  "_cmd": "de b v 11, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, de w 5 1`] = `
+{
+  "_cmd": "de b v 11, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, de w 6 1`] = `
+{
+  "_cmd": "de b v 11, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de w 7 1`] = `
+{
+  "_cmd": "de b v 11, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de w 8 1`] = `
+{
+  "_cmd": "de b v 11, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de w 9 1`] = `
+{
+  "_cmd": "de b v 11, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, de w 10 1`] = `
+{
+  "_cmd": "de b v 11, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de w 11 1`] = `
+{
+  "_cmd": "de b v 11, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de w 12 1`] = `
+{
+  "_cmd": "de b v 11, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, de w 13 1`] = `
+{
+  "_cmd": "de b v 11, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de w 14 1`] = `
+{
+  "_cmd": "de b v 11, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de w 15 1`] = `
+{
+  "_cmd": "de b v 11, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 11, de w v 1 1`] = `
+{
+  "_cmd": "de b v 11, de w v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, de w v 2 1`] = `
+{
+  "_cmd": "de b v 11, de w v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, de w v 3 1`] = `
+{
+  "_cmd": "de b v 11, de w v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, de w v 4 1`] = `
+{
+  "_cmd": "de b v 11, de w v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, de w v 5 1`] = `
+{
+  "_cmd": "de b v 11, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, de w v 6 1`] = `
+{
+  "_cmd": "de b v 11, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, de w v 7 1`] = `
+{
+  "_cmd": "de b v 11, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, de w v 8 1`] = `
+{
+  "_cmd": "de b v 11, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, de w v 9 1`] = `
+{
+  "_cmd": "de b v 11, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, de w v 10 1`] = `
+{
+  "_cmd": "de b v 11, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, de w v 11 1`] = `
+{
+  "_cmd": "de b v 11, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, de w v 12 1`] = `
+{
+  "_cmd": "de b v 11, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, de w v 13 1`] = `
+{
+  "_cmd": "de b v 11, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, de w v 14 1`] = `
+{
+  "_cmd": "de b v 11, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, de w v 15 1`] = `
+{
+  "_cmd": "de b v 11, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, de w v 16 1`] = `
+{
+  "_cmd": "de b v 11, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 11, de w v 17 1`] = `
+{
+  "_cmd": "de b v 11, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 11, de w v 18 1`] = `
+{
+  "_cmd": "de b v 11, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 11, de w v 19 1`] = `
+{
+  "_cmd": "de b v 11, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 11, de w v 20 1`] = `
+{
+  "_cmd": "de b v 11, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 12, de d 1 1`] = `
+{
+  "_cmd": "de b v 12, de d 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 12, de d 2 1`] = `
+{
+  "_cmd": "de b v 12, de d 2",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, de d 3 1`] = `
+{
+  "_cmd": "de b v 12, de d 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, de d 4 1`] = `
+{
+  "_cmd": "de b v 12, de d 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de d 5 1`] = `
+{
+  "_cmd": "de b v 12, de d 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, de d 6 1`] = `
+{
+  "_cmd": "de b v 12, de d 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, de d 7 1`] = `
+{
+  "_cmd": "de b v 12, de d 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de d 8 1`] = `
+{
+  "_cmd": "de b v 12, de d 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de d 9 1`] = `
+{
+  "_cmd": "de b v 12, de d 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de d 10 1`] = `
+{
+  "_cmd": "de b v 12, de d 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, de d 11 1`] = `
+{
+  "_cmd": "de b v 12, de d 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de d 12 1`] = `
+{
+  "_cmd": "de b v 12, de d 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de d 13 1`] = `
+{
+  "_cmd": "de b v 12, de d 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de d 14 1`] = `
+{
+  "_cmd": "de b v 12, de d 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de d 15 1`] = `
+{
+  "_cmd": "de b v 12, de d 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, de d v 1 1`] = `
+{
+  "_cmd": "de b v 12, de d v 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 12, de d v 2 1`] = `
+{
+  "_cmd": "de b v 12, de d v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de d v 3 1`] = `
+{
+  "_cmd": "de b v 12, de d v 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, de d v 4 1`] = `
+{
+  "_cmd": "de b v 12, de d v 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de d v 5 1`] = `
+{
+  "_cmd": "de b v 12, de d v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, de d v 6 1`] = `
+{
+  "_cmd": "de b v 12, de d v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de d v 7 1`] = `
+{
+  "_cmd": "de b v 12, de d v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de d v 8 1`] = `
+{
+  "_cmd": "de b v 12, de d v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de d v 9 1`] = `
+{
+  "_cmd": "de b v 12, de d v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de d v 10 1`] = `
+{
+  "_cmd": "de b v 12, de d v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, de d v 11 1`] = `
+{
+  "_cmd": "de b v 12, de d v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de d v 12 1`] = `
+{
+  "_cmd": "de b v 12, de d v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de d v 13 1`] = `
+{
+  "_cmd": "de b v 12, de d v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de d v 14 1`] = `
+{
+  "_cmd": "de b v 12, de d v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de d v 15 1`] = `
+{
+  "_cmd": "de b v 12, de d v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, de d v 16 1`] = `
+{
+  "_cmd": "de b v 12, de d v 16",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 12, de d v 17 1`] = `
+{
+  "_cmd": "de b v 12, de d v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 12, de d v 18 1`] = `
+{
+  "_cmd": "de b v 12, de d v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 12, de d v 19 1`] = `
+{
+  "_cmd": "de b v 12, de d v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 12, de d v 20 1`] = `
+{
+  "_cmd": "de b v 12, de d v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 12, de p 1 1`] = `
+{
+  "_cmd": "de b v 12, de p 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, de p 2 1`] = `
+{
+  "_cmd": "de b v 12, de p 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de p 3 1`] = `
+{
+  "_cmd": "de b v 12, de p 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, de p 4 1`] = `
+{
+  "_cmd": "de b v 12, de p 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, de p 5 1`] = `
+{
+  "_cmd": "de b v 12, de p 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de p 6 1`] = `
+{
+  "_cmd": "de b v 12, de p 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de p 7 1`] = `
+{
+  "_cmd": "de b v 12, de p 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, de p 8 1`] = `
+{
+  "_cmd": "de b v 12, de p 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de p 9 1`] = `
+{
+  "_cmd": "de b v 12, de p 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de p 10 1`] = `
+{
+  "_cmd": "de b v 12, de p 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de p 11 1`] = `
+{
+  "_cmd": "de b v 12, de p 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de p 12 1`] = `
+{
+  "_cmd": "de b v 12, de p 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de p 13 1`] = `
+{
+  "_cmd": "de b v 12, de p 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de p 14 1`] = `
+{
+  "_cmd": "de b v 12, de p 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de p 15 1`] = `
+{
+  "_cmd": "de b v 12, de p 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de p v 1 1`] = `
+{
+  "_cmd": "de b v 12, de p v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, de p v 2 1`] = `
+{
+  "_cmd": "de b v 12, de p v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de p v 3 1`] = `
+{
+  "_cmd": "de b v 12, de p v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, de p v 4 1`] = `
+{
+  "_cmd": "de b v 12, de p v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, de p v 5 1`] = `
+{
+  "_cmd": "de b v 12, de p v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de p v 6 1`] = `
+{
+  "_cmd": "de b v 12, de p v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, de p v 7 1`] = `
+{
+  "_cmd": "de b v 12, de p v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de p v 8 1`] = `
+{
+  "_cmd": "de b v 12, de p v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de p v 9 1`] = `
+{
+  "_cmd": "de b v 12, de p v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de p v 10 1`] = `
+{
+  "_cmd": "de b v 12, de p v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de p v 11 1`] = `
+{
+  "_cmd": "de b v 12, de p v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, de p v 12 1`] = `
+{
+  "_cmd": "de b v 12, de p v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de p v 13 1`] = `
+{
+  "_cmd": "de b v 12, de p v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de p v 14 1`] = `
+{
+  "_cmd": "de b v 12, de p v 14",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de p v 15 1`] = `
+{
+  "_cmd": "de b v 12, de p v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de p v 16 1`] = `
+{
+  "_cmd": "de b v 12, de p v 16",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, de p v 17 1`] = `
+{
+  "_cmd": "de b v 12, de p v 17",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 12, de p v 18 1`] = `
+{
+  "_cmd": "de b v 12, de p v 18",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 12, de p v 19 1`] = `
+{
+  "_cmd": "de b v 12, de p v 19",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 12, de p v 20 1`] = `
+{
+  "_cmd": "de b v 12, de p v 20",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 12, de v 1 1`] = `
+{
+  "_cmd": "de b v 12, de v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, de v 2 1`] = `
+{
+  "_cmd": "de b v 12, de v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de v 3 1`] = `
+{
+  "_cmd": "de b v 12, de v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, de v 4 1`] = `
+{
+  "_cmd": "de b v 12, de v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, de v 5 1`] = `
+{
+  "_cmd": "de b v 12, de v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de v 6 1`] = `
+{
+  "_cmd": "de b v 12, de v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de v 7 1`] = `
+{
+  "_cmd": "de b v 12, de v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, de v 8 1`] = `
+{
+  "_cmd": "de b v 12, de v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de v 9 1`] = `
+{
+  "_cmd": "de b v 12, de v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de v 10 1`] = `
+{
+  "_cmd": "de b v 12, de v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de v 11 1`] = `
+{
+  "_cmd": "de b v 12, de v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de v 12 1`] = `
+{
+  "_cmd": "de b v 12, de v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de v 13 1`] = `
+{
+  "_cmd": "de b v 12, de v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de v 14 1`] = `
+{
+  "_cmd": "de b v 12, de v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de v 15 1`] = `
+{
+  "_cmd": "de b v 12, de v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de v 16 1`] = `
+{
+  "_cmd": "de b v 12, de v 16",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, de v 17 1`] = `
+{
+  "_cmd": "de b v 12, de v 17",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 12, de v 18 1`] = `
+{
+  "_cmd": "de b v 12, de v 18",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 12, de v 19 1`] = `
+{
+  "_cmd": "de b v 12, de v 19",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 12, de v 20 1`] = `
+{
+  "_cmd": "de b v 12, de v 20",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 12, de w 1 1`] = `
+{
+  "_cmd": "de b v 12, de w 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de w 2 1`] = `
+{
+  "_cmd": "de b v 12, de w 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, de w 3 1`] = `
+{
+  "_cmd": "de b v 12, de w 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de w 4 1`] = `
+{
+  "_cmd": "de b v 12, de w 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de w 5 1`] = `
+{
+  "_cmd": "de b v 12, de w 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, de w 6 1`] = `
+{
+  "_cmd": "de b v 12, de w 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de w 7 1`] = `
+{
+  "_cmd": "de b v 12, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de w 8 1`] = `
+{
+  "_cmd": "de b v 12, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de w 9 1`] = `
+{
+  "_cmd": "de b v 12, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, de w 10 1`] = `
+{
+  "_cmd": "de b v 12, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de w 11 1`] = `
+{
+  "_cmd": "de b v 12, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de w 12 1`] = `
+{
+  "_cmd": "de b v 12, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de w 13 1`] = `
+{
+  "_cmd": "de b v 12, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de w 14 1`] = `
+{
+  "_cmd": "de b v 12, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de w 15 1`] = `
+{
+  "_cmd": "de b v 12, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 12, de w v 1 1`] = `
+{
+  "_cmd": "de b v 12, de w v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, de w v 2 1`] = `
+{
+  "_cmd": "de b v 12, de w v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, de w v 3 1`] = `
+{
+  "_cmd": "de b v 12, de w v 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, de w v 4 1`] = `
+{
+  "_cmd": "de b v 12, de w v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, de w v 5 1`] = `
+{
+  "_cmd": "de b v 12, de w v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, de w v 6 1`] = `
+{
+  "_cmd": "de b v 12, de w v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, de w v 7 1`] = `
+{
+  "_cmd": "de b v 12, de w v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, de w v 8 1`] = `
+{
+  "_cmd": "de b v 12, de w v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, de w v 9 1`] = `
+{
+  "_cmd": "de b v 12, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, de w v 10 1`] = `
+{
+  "_cmd": "de b v 12, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, de w v 11 1`] = `
+{
+  "_cmd": "de b v 12, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, de w v 12 1`] = `
+{
+  "_cmd": "de b v 12, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, de w v 13 1`] = `
+{
+  "_cmd": "de b v 12, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, de w v 14 1`] = `
+{
+  "_cmd": "de b v 12, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, de w v 15 1`] = `
+{
+  "_cmd": "de b v 12, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, de w v 16 1`] = `
+{
+  "_cmd": "de b v 12, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 12, de w v 17 1`] = `
+{
+  "_cmd": "de b v 12, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 12, de w v 18 1`] = `
+{
+  "_cmd": "de b v 12, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 12, de w v 19 1`] = `
+{
+  "_cmd": "de b v 12, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 12, de w v 20 1`] = `
+{
+  "_cmd": "de b v 12, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de b v 13, de d 1 1`] = `
+{
+  "_cmd": "de b v 13, de d 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 13, de d 2 1`] = `
+{
+  "_cmd": "de b v 13, de d 2",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, de d 3 1`] = `
+{
+  "_cmd": "de b v 13, de d 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, de d 4 1`] = `
+{
+  "_cmd": "de b v 13, de d 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de d 5 1`] = `
+{
+  "_cmd": "de b v 13, de d 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de d 6 1`] = `
+{
+  "_cmd": "de b v 13, de d 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de d 7 1`] = `
+{
+  "_cmd": "de b v 13, de d 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, de d 8 1`] = `
+{
+  "_cmd": "de b v 13, de d 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de d 9 1`] = `
+{
+  "_cmd": "de b v 13, de d 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de d 10 1`] = `
+{
+  "_cmd": "de b v 13, de d 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de d 11 1`] = `
+{
+  "_cmd": "de b v 13, de d 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, de d 12 1`] = `
+{
+  "_cmd": "de b v 13, de d 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de d 13 1`] = `
+{
+  "_cmd": "de b v 13, de d 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de d 14 1`] = `
+{
+  "_cmd": "de b v 13, de d 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de d 15 1`] = `
+{
+  "_cmd": "de b v 13, de d 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, de d v 1 1`] = `
+{
+  "_cmd": "de b v 13, de d v 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 13, de d v 2 1`] = `
+{
+  "_cmd": "de b v 13, de d v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, de d v 3 1`] = `
+{
+  "_cmd": "de b v 13, de d v 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, de d v 4 1`] = `
+{
+  "_cmd": "de b v 13, de d v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, de d v 5 1`] = `
+{
+  "_cmd": "de b v 13, de d v 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de d v 6 1`] = `
+{
+  "_cmd": "de b v 13, de d v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, de d v 7 1`] = `
+{
+  "_cmd": "de b v 13, de d v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de d v 8 1`] = `
+{
+  "_cmd": "de b v 13, de d v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de d v 9 1`] = `
+{
+  "_cmd": "de b v 13, de d v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de d v 10 1`] = `
+{
+  "_cmd": "de b v 13, de d v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de d v 11 1`] = `
+{
+  "_cmd": "de b v 13, de d v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, de d v 12 1`] = `
+{
+  "_cmd": "de b v 13, de d v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de d v 13 1`] = `
+{
+  "_cmd": "de b v 13, de d v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de d v 14 1`] = `
+{
+  "_cmd": "de b v 13, de d v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de d v 15 1`] = `
+{
+  "_cmd": "de b v 13, de d v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de d v 16 1`] = `
+{
+  "_cmd": "de b v 13, de d v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 13, de d v 17 1`] = `
+{
+  "_cmd": "de b v 13, de d v 17",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 13, de d v 18 1`] = `
+{
+  "_cmd": "de b v 13, de d v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 13, de d v 19 1`] = `
+{
+  "_cmd": "de b v 13, de d v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 13, de d v 20 1`] = `
+{
+  "_cmd": "de b v 13, de d v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 13, de p 1 1`] = `
+{
+  "_cmd": "de b v 13, de p 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, de p 2 1`] = `
+{
+  "_cmd": "de b v 13, de p 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, de p 3 1`] = `
+{
+  "_cmd": "de b v 13, de p 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, de p 4 1`] = `
+{
+  "_cmd": "de b v 13, de p 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, de p 5 1`] = `
+{
+  "_cmd": "de b v 13, de p 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de p 6 1`] = `
+{
+  "_cmd": "de b v 13, de p 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de p 7 1`] = `
+{
+  "_cmd": "de b v 13, de p 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de p 8 1`] = `
+{
+  "_cmd": "de b v 13, de p 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, de p 9 1`] = `
+{
+  "_cmd": "de b v 13, de p 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de p 10 1`] = `
+{
+  "_cmd": "de b v 13, de p 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de p 11 1`] = `
+{
+  "_cmd": "de b v 13, de p 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de p 12 1`] = `
+{
+  "_cmd": "de b v 13, de p 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de p 13 1`] = `
+{
+  "_cmd": "de b v 13, de p 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de p 14 1`] = `
+{
+  "_cmd": "de b v 13, de p 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de p 15 1`] = `
+{
+  "_cmd": "de b v 13, de p 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de p v 1 1`] = `
+{
+  "_cmd": "de b v 13, de p v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, de p v 2 1`] = `
+{
+  "_cmd": "de b v 13, de p v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 13, de p v 3 1`] = `
+{
+  "_cmd": "de b v 13, de p v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, de p v 4 1`] = `
+{
+  "_cmd": "de b v 13, de p v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, de p v 5 1`] = `
+{
+  "_cmd": "de b v 13, de p v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de p v 6 1`] = `
+{
+  "_cmd": "de b v 13, de p v 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de p v 7 1`] = `
+{
+  "_cmd": "de b v 13, de p v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, de p v 8 1`] = `
+{
+  "_cmd": "de b v 13, de p v 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de p v 9 1`] = `
+{
+  "_cmd": "de b v 13, de p v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de p v 10 1`] = `
+{
+  "_cmd": "de b v 13, de p v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de p v 11 1`] = `
+{
+  "_cmd": "de b v 13, de p v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de p v 12 1`] = `
+{
+  "_cmd": "de b v 13, de p v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, de p v 13 1`] = `
+{
+  "_cmd": "de b v 13, de p v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de p v 14 1`] = `
+{
+  "_cmd": "de b v 13, de p v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de p v 15 1`] = `
+{
+  "_cmd": "de b v 13, de p v 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de p v 16 1`] = `
+{
+  "_cmd": "de b v 13, de p v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, de p v 17 1`] = `
+{
+  "_cmd": "de b v 13, de p v 17",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 13, de p v 18 1`] = `
+{
+  "_cmd": "de b v 13, de p v 18",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 13, de p v 19 1`] = `
+{
+  "_cmd": "de b v 13, de p v 19",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 13, de p v 20 1`] = `
+{
+  "_cmd": "de b v 13, de p v 20",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 13, de v 1 1`] = `
+{
+  "_cmd": "de b v 13, de v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, de v 2 1`] = `
+{
+  "_cmd": "de b v 13, de v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, de v 3 1`] = `
+{
+  "_cmd": "de b v 13, de v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, de v 4 1`] = `
+{
+  "_cmd": "de b v 13, de v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, de v 5 1`] = `
+{
+  "_cmd": "de b v 13, de v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de v 6 1`] = `
+{
+  "_cmd": "de b v 13, de v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de v 7 1`] = `
+{
+  "_cmd": "de b v 13, de v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de v 8 1`] = `
+{
+  "_cmd": "de b v 13, de v 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, de v 9 1`] = `
+{
+  "_cmd": "de b v 13, de v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de v 10 1`] = `
+{
+  "_cmd": "de b v 13, de v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de v 11 1`] = `
+{
+  "_cmd": "de b v 13, de v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de v 12 1`] = `
+{
+  "_cmd": "de b v 13, de v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de v 13 1`] = `
+{
+  "_cmd": "de b v 13, de v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de v 14 1`] = `
+{
+  "_cmd": "de b v 13, de v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de v 15 1`] = `
+{
+  "_cmd": "de b v 13, de v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de v 16 1`] = `
+{
+  "_cmd": "de b v 13, de v 16",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, de v 17 1`] = `
+{
+  "_cmd": "de b v 13, de v 17",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 13, de v 18 1`] = `
+{
+  "_cmd": "de b v 13, de v 18",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 13, de v 19 1`] = `
+{
+  "_cmd": "de b v 13, de v 19",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 13, de v 20 1`] = `
+{
+  "_cmd": "de b v 13, de v 20",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 13, de w 1 1`] = `
+{
+  "_cmd": "de b v 13, de w 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, de w 2 1`] = `
+{
+  "_cmd": "de b v 13, de w 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, de w 3 1`] = `
+{
+  "_cmd": "de b v 13, de w 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de w 4 1`] = `
+{
+  "_cmd": "de b v 13, de w 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de w 5 1`] = `
+{
+  "_cmd": "de b v 13, de w 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, de w 6 1`] = `
+{
+  "_cmd": "de b v 13, de w 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, de w 7 1`] = `
+{
+  "_cmd": "de b v 13, de w 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de w 8 1`] = `
+{
+  "_cmd": "de b v 13, de w 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de w 9 1`] = `
+{
+  "_cmd": "de b v 13, de w 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de w 10 1`] = `
+{
+  "_cmd": "de b v 13, de w 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, de w 11 1`] = `
+{
+  "_cmd": "de b v 13, de w 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de w 12 1`] = `
+{
+  "_cmd": "de b v 13, de w 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de w 13 1`] = `
+{
+  "_cmd": "de b v 13, de w 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de w 14 1`] = `
+{
+  "_cmd": "de b v 13, de w 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de w 15 1`] = `
+{
+  "_cmd": "de b v 13, de w 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, de w v 1 1`] = `
+{
+  "_cmd": "de b v 13, de w v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, de w v 2 1`] = `
+{
+  "_cmd": "de b v 13, de w v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, de w v 3 1`] = `
+{
+  "_cmd": "de b v 13, de w v 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, de w v 4 1`] = `
+{
+  "_cmd": "de b v 13, de w v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, de w v 5 1`] = `
+{
+  "_cmd": "de b v 13, de w v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, de w v 6 1`] = `
+{
+  "_cmd": "de b v 13, de w v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, de w v 7 1`] = `
+{
+  "_cmd": "de b v 13, de w v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, de w v 8 1`] = `
+{
+  "_cmd": "de b v 13, de w v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, de w v 9 1`] = `
+{
+  "_cmd": "de b v 13, de w v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, de w v 10 1`] = `
+{
+  "_cmd": "de b v 13, de w v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, de w v 11 1`] = `
+{
+  "_cmd": "de b v 13, de w v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, de w v 12 1`] = `
+{
+  "_cmd": "de b v 13, de w v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, de w v 13 1`] = `
+{
+  "_cmd": "de b v 13, de w v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, de w v 14 1`] = `
+{
+  "_cmd": "de b v 13, de w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, de w v 15 1`] = `
+{
+  "_cmd": "de b v 13, de w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, de w v 16 1`] = `
+{
+  "_cmd": "de b v 13, de w v 16",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 13, de w v 17 1`] = `
+{
+  "_cmd": "de b v 13, de w v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 13, de w v 18 1`] = `
+{
+  "_cmd": "de b v 13, de w v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 13, de w v 19 1`] = `
+{
+  "_cmd": "de b v 13, de w v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 13, de w v 20 1`] = `
+{
+  "_cmd": "de b v 13, de w v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 14, de d 1 1`] = `
+{
+  "_cmd": "de b v 14, de d 1",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 14, de d 2 1`] = `
+{
+  "_cmd": "de b v 14, de d 2",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, de d 3 1`] = `
+{
+  "_cmd": "de b v 14, de d 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, de d 4 1`] = `
+{
+  "_cmd": "de b v 14, de d 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, de d 5 1`] = `
+{
+  "_cmd": "de b v 14, de d 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de d 6 1`] = `
+{
+  "_cmd": "de b v 14, de d 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de d 7 1`] = `
+{
+  "_cmd": "de b v 14, de d 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, de d 8 1`] = `
+{
+  "_cmd": "de b v 14, de d 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de d 9 1`] = `
+{
+  "_cmd": "de b v 14, de d 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de d 10 1`] = `
+{
+  "_cmd": "de b v 14, de d 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de d 11 1`] = `
+{
+  "_cmd": "de b v 14, de d 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de d 12 1`] = `
+{
+  "_cmd": "de b v 14, de d 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de d 13 1`] = `
+{
+  "_cmd": "de b v 14, de d 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de d 14 1`] = `
+{
+  "_cmd": "de b v 14, de d 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de d 15 1`] = `
+{
+  "_cmd": "de b v 14, de d 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de d v 1 1`] = `
+{
+  "_cmd": "de b v 14, de d v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, de d v 2 1`] = `
+{
+  "_cmd": "de b v 14, de d v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, de d v 3 1`] = `
+{
+  "_cmd": "de b v 14, de d v 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, de d v 4 1`] = `
+{
+  "_cmd": "de b v 14, de d v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, de d v 5 1`] = `
+{
+  "_cmd": "de b v 14, de d v 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de d v 6 1`] = `
+{
+  "_cmd": "de b v 14, de d v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, de d v 7 1`] = `
+{
+  "_cmd": "de b v 14, de d v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de d v 8 1`] = `
+{
+  "_cmd": "de b v 14, de d v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de d v 9 1`] = `
+{
+  "_cmd": "de b v 14, de d v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de d v 10 1`] = `
+{
+  "_cmd": "de b v 14, de d v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de d v 11 1`] = `
+{
+  "_cmd": "de b v 14, de d v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de d v 12 1`] = `
+{
+  "_cmd": "de b v 14, de d v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de d v 13 1`] = `
+{
+  "_cmd": "de b v 14, de d v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de d v 14 1`] = `
+{
+  "_cmd": "de b v 14, de d v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de d v 15 1`] = `
+{
+  "_cmd": "de b v 14, de d v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de d v 16 1`] = `
+{
+  "_cmd": "de b v 14, de d v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de d v 17 1`] = `
+{
+  "_cmd": "de b v 14, de d v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 14, de d v 18 1`] = `
+{
+  "_cmd": "de b v 14, de d v 18",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 14, de d v 19 1`] = `
+{
+  "_cmd": "de b v 14, de d v 19",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 14, de d v 20 1`] = `
+{
+  "_cmd": "de b v 14, de d v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 14, de p 1 1`] = `
+{
+  "_cmd": "de b v 14, de p 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, de p 2 1`] = `
+{
+  "_cmd": "de b v 14, de p 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, de p 3 1`] = `
+{
+  "_cmd": "de b v 14, de p 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, de p 4 1`] = `
+{
+  "_cmd": "de b v 14, de p 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, de p 5 1`] = `
+{
+  "_cmd": "de b v 14, de p 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, de p 6 1`] = `
+{
+  "_cmd": "de b v 14, de p 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de p 7 1`] = `
+{
+  "_cmd": "de b v 14, de p 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de p 8 1`] = `
+{
+  "_cmd": "de b v 14, de p 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, de p 9 1`] = `
+{
+  "_cmd": "de b v 14, de p 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de p 10 1`] = `
+{
+  "_cmd": "de b v 14, de p 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de p 11 1`] = `
+{
+  "_cmd": "de b v 14, de p 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de p 12 1`] = `
+{
+  "_cmd": "de b v 14, de p 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de p 13 1`] = `
+{
+  "_cmd": "de b v 14, de p 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de p 14 1`] = `
+{
+  "_cmd": "de b v 14, de p 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de p 15 1`] = `
+{
+  "_cmd": "de b v 14, de p 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de p v 1 1`] = `
+{
+  "_cmd": "de b v 14, de p v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, de p v 2 1`] = `
+{
+  "_cmd": "de b v 14, de p v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 14, de p v 3 1`] = `
+{
+  "_cmd": "de b v 14, de p v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, de p v 4 1`] = `
+{
+  "_cmd": "de b v 14, de p v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, de p v 5 1`] = `
+{
+  "_cmd": "de b v 14, de p v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, de p v 6 1`] = `
+{
+  "_cmd": "de b v 14, de p v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de p v 7 1`] = `
+{
+  "_cmd": "de b v 14, de p v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, de p v 8 1`] = `
+{
+  "_cmd": "de b v 14, de p v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de p v 9 1`] = `
+{
+  "_cmd": "de b v 14, de p v 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, de p v 10 1`] = `
+{
+  "_cmd": "de b v 14, de p v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de p v 11 1`] = `
+{
+  "_cmd": "de b v 14, de p v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de p v 12 1`] = `
+{
+  "_cmd": "de b v 14, de p v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de p v 13 1`] = `
+{
+  "_cmd": "de b v 14, de p v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de p v 14 1`] = `
+{
+  "_cmd": "de b v 14, de p v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de p v 15 1`] = `
+{
+  "_cmd": "de b v 14, de p v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de p v 16 1`] = `
+{
+  "_cmd": "de b v 14, de p v 16",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de p v 17 1`] = `
+{
+  "_cmd": "de b v 14, de p v 17",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de p v 18 1`] = `
+{
+  "_cmd": "de b v 14, de p v 18",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 14, de p v 19 1`] = `
+{
+  "_cmd": "de b v 14, de p v 19",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 14, de p v 20 1`] = `
+{
+  "_cmd": "de b v 14, de p v 20",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 14, de v 1 1`] = `
+{
+  "_cmd": "de b v 14, de v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, de v 2 1`] = `
+{
+  "_cmd": "de b v 14, de v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, de v 3 1`] = `
+{
+  "_cmd": "de b v 14, de v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, de v 4 1`] = `
+{
+  "_cmd": "de b v 14, de v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, de v 5 1`] = `
+{
+  "_cmd": "de b v 14, de v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, de v 6 1`] = `
+{
+  "_cmd": "de b v 14, de v 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de v 7 1`] = `
+{
+  "_cmd": "de b v 14, de v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de v 8 1`] = `
+{
+  "_cmd": "de b v 14, de v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, de v 9 1`] = `
+{
+  "_cmd": "de b v 14, de v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de v 10 1`] = `
+{
+  "_cmd": "de b v 14, de v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de v 11 1`] = `
+{
+  "_cmd": "de b v 14, de v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de v 12 1`] = `
+{
+  "_cmd": "de b v 14, de v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de v 13 1`] = `
+{
+  "_cmd": "de b v 14, de v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de v 14 1`] = `
+{
+  "_cmd": "de b v 14, de v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de v 15 1`] = `
+{
+  "_cmd": "de b v 14, de v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de v 16 1`] = `
+{
+  "_cmd": "de b v 14, de v 16",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de v 17 1`] = `
+{
+  "_cmd": "de b v 14, de v 17",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 14, de v 18 1`] = `
+{
+  "_cmd": "de b v 14, de v 18",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 14, de v 19 1`] = `
+{
+  "_cmd": "de b v 14, de v 19",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 14, de v 20 1`] = `
+{
+  "_cmd": "de b v 14, de v 20",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 14, de w 1 1`] = `
+{
+  "_cmd": "de b v 14, de w 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, de w 2 1`] = `
+{
+  "_cmd": "de b v 14, de w 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, de w 3 1`] = `
+{
+  "_cmd": "de b v 14, de w 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, de w 4 1`] = `
+{
+  "_cmd": "de b v 14, de w 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de w 5 1`] = `
+{
+  "_cmd": "de b v 14, de w 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de w 6 1`] = `
+{
+  "_cmd": "de b v 14, de w 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, de w 7 1`] = `
+{
+  "_cmd": "de b v 14, de w 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de w 8 1`] = `
+{
+  "_cmd": "de b v 14, de w 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de w 9 1`] = `
+{
+  "_cmd": "de b v 14, de w 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de w 10 1`] = `
+{
+  "_cmd": "de b v 14, de w 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de w 11 1`] = `
+{
+  "_cmd": "de b v 14, de w 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de w 12 1`] = `
+{
+  "_cmd": "de b v 14, de w 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de w 13 1`] = `
+{
+  "_cmd": "de b v 14, de w 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de w 14 1`] = `
+{
+  "_cmd": "de b v 14, de w 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de w 15 1`] = `
+{
+  "_cmd": "de b v 14, de w 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de w v 1 1`] = `
+{
+  "_cmd": "de b v 14, de w v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, de w v 2 1`] = `
+{
+  "_cmd": "de b v 14, de w v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, de w v 3 1`] = `
+{
+  "_cmd": "de b v 14, de w v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, de w v 4 1`] = `
+{
+  "_cmd": "de b v 14, de w v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, de w v 5 1`] = `
+{
+  "_cmd": "de b v 14, de w v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, de w v 6 1`] = `
+{
+  "_cmd": "de b v 14, de w v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, de w v 7 1`] = `
+{
+  "_cmd": "de b v 14, de w v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, de w v 8 1`] = `
+{
+  "_cmd": "de b v 14, de w v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, de w v 9 1`] = `
+{
+  "_cmd": "de b v 14, de w v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, de w v 10 1`] = `
+{
+  "_cmd": "de b v 14, de w v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, de w v 11 1`] = `
+{
+  "_cmd": "de b v 14, de w v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, de w v 12 1`] = `
+{
+  "_cmd": "de b v 14, de w v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, de w v 13 1`] = `
+{
+  "_cmd": "de b v 14, de w v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, de w v 14 1`] = `
+{
+  "_cmd": "de b v 14, de w v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, de w v 15 1`] = `
+{
+  "_cmd": "de b v 14, de w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, de w v 16 1`] = `
+{
+  "_cmd": "de b v 14, de w v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 14, de w v 17 1`] = `
+{
+  "_cmd": "de b v 14, de w v 17",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 14, de w v 18 1`] = `
+{
+  "_cmd": "de b v 14, de w v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 14, de w v 19 1`] = `
+{
+  "_cmd": "de b v 14, de w v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 14, de w v 20 1`] = `
+{
+  "_cmd": "de b v 14, de w v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 15, de d 1 1`] = `
+{
+  "_cmd": "de b v 15, de d 1",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 15, de d 2 1`] = `
+{
+  "_cmd": "de b v 15, de d 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, de d 3 1`] = `
+{
+  "_cmd": "de b v 15, de d 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de d 4 1`] = `
+{
+  "_cmd": "de b v 15, de d 4",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, de d 5 1`] = `
+{
+  "_cmd": "de b v 15, de d 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de d 6 1`] = `
+{
+  "_cmd": "de b v 15, de d 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, de d 7 1`] = `
+{
+  "_cmd": "de b v 15, de d 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de d 8 1`] = `
+{
+  "_cmd": "de b v 15, de d 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, de d 9 1`] = `
+{
+  "_cmd": "de b v 15, de d 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de d 10 1`] = `
+{
+  "_cmd": "de b v 15, de d 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de d 11 1`] = `
+{
+  "_cmd": "de b v 15, de d 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de d 12 1`] = `
+{
+  "_cmd": "de b v 15, de d 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de d 13 1`] = `
+{
+  "_cmd": "de b v 15, de d 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de d 14 1`] = `
+{
+  "_cmd": "de b v 15, de d 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de d 15 1`] = `
+{
+  "_cmd": "de b v 15, de d 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de d v 1 1`] = `
+{
+  "_cmd": "de b v 15, de d v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, de d v 2 1`] = `
+{
+  "_cmd": "de b v 15, de d v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, de d v 3 1`] = `
+{
+  "_cmd": "de b v 15, de d v 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de d v 4 1`] = `
+{
+  "_cmd": "de b v 15, de d v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, de d v 5 1`] = `
+{
+  "_cmd": "de b v 15, de d v 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de d v 6 1`] = `
+{
+  "_cmd": "de b v 15, de d v 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, de d v 7 1`] = `
+{
+  "_cmd": "de b v 15, de d v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, de d v 8 1`] = `
+{
+  "_cmd": "de b v 15, de d v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de d v 9 1`] = `
+{
+  "_cmd": "de b v 15, de d v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de d v 10 1`] = `
+{
+  "_cmd": "de b v 15, de d v 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de d v 11 1`] = `
+{
+  "_cmd": "de b v 15, de d v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de d v 12 1`] = `
+{
+  "_cmd": "de b v 15, de d v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de d v 13 1`] = `
+{
+  "_cmd": "de b v 15, de d v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de d v 14 1`] = `
+{
+  "_cmd": "de b v 15, de d v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de d v 15 1`] = `
+{
+  "_cmd": "de b v 15, de d v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de d v 16 1`] = `
+{
+  "_cmd": "de b v 15, de d v 16",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de d v 17 1`] = `
+{
+  "_cmd": "de b v 15, de d v 17",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 15, de d v 18 1`] = `
+{
+  "_cmd": "de b v 15, de d v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 15, de d v 19 1`] = `
+{
+  "_cmd": "de b v 15, de d v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 15, de d v 20 1`] = `
+{
+  "_cmd": "de b v 15, de d v 20",
+  "attacker": 4,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 15, de p 1 1`] = `
+{
+  "_cmd": "de b v 15, de p 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, de p 2 1`] = `
+{
+  "_cmd": "de b v 15, de p 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, de p 3 1`] = `
+{
+  "_cmd": "de b v 15, de p 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, de p 4 1`] = `
+{
+  "_cmd": "de b v 15, de p 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de p 5 1`] = `
+{
+  "_cmd": "de b v 15, de p 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, de p 6 1`] = `
+{
+  "_cmd": "de b v 15, de p 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de p 7 1`] = `
+{
+  "_cmd": "de b v 15, de p 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, de p 8 1`] = `
+{
+  "_cmd": "de b v 15, de p 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de p 9 1`] = `
+{
+  "_cmd": "de b v 15, de p 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, de p 10 1`] = `
+{
+  "_cmd": "de b v 15, de p 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de p 11 1`] = `
+{
+  "_cmd": "de b v 15, de p 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de p 12 1`] = `
+{
+  "_cmd": "de b v 15, de p 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de p 13 1`] = `
+{
+  "_cmd": "de b v 15, de p 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de p 14 1`] = `
+{
+  "_cmd": "de b v 15, de p 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de p 15 1`] = `
+{
+  "_cmd": "de b v 15, de p 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de p v 1 1`] = `
+{
+  "_cmd": "de b v 15, de p v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, de p v 2 1`] = `
+{
+  "_cmd": "de b v 15, de p v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 15, de p v 3 1`] = `
+{
+  "_cmd": "de b v 15, de p v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, de p v 4 1`] = `
+{
+  "_cmd": "de b v 15, de p v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de p v 5 1`] = `
+{
+  "_cmd": "de b v 15, de p v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, de p v 6 1`] = `
+{
+  "_cmd": "de b v 15, de p v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de p v 7 1`] = `
+{
+  "_cmd": "de b v 15, de p v 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, de p v 8 1`] = `
+{
+  "_cmd": "de b v 15, de p v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, de p v 9 1`] = `
+{
+  "_cmd": "de b v 15, de p v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de p v 10 1`] = `
+{
+  "_cmd": "de b v 15, de p v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de p v 11 1`] = `
+{
+  "_cmd": "de b v 15, de p v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de p v 12 1`] = `
+{
+  "_cmd": "de b v 15, de p v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de p v 13 1`] = `
+{
+  "_cmd": "de b v 15, de p v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de p v 14 1`] = `
+{
+  "_cmd": "de b v 15, de p v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de p v 15 1`] = `
+{
+  "_cmd": "de b v 15, de p v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de p v 16 1`] = `
+{
+  "_cmd": "de b v 15, de p v 16",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de p v 17 1`] = `
+{
+  "_cmd": "de b v 15, de p v 17",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de p v 18 1`] = `
+{
+  "_cmd": "de b v 15, de p v 18",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 15, de p v 19 1`] = `
+{
+  "_cmd": "de b v 15, de p v 19",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 15, de p v 20 1`] = `
+{
+  "_cmd": "de b v 15, de p v 20",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 15, de v 1 1`] = `
+{
+  "_cmd": "de b v 15, de v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, de v 2 1`] = `
+{
+  "_cmd": "de b v 15, de v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, de v 3 1`] = `
+{
+  "_cmd": "de b v 15, de v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, de v 4 1`] = `
+{
+  "_cmd": "de b v 15, de v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, de v 5 1`] = `
+{
+  "_cmd": "de b v 15, de v 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, de v 6 1`] = `
+{
+  "_cmd": "de b v 15, de v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de v 7 1`] = `
+{
+  "_cmd": "de b v 15, de v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, de v 8 1`] = `
+{
+  "_cmd": "de b v 15, de v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de v 9 1`] = `
+{
+  "_cmd": "de b v 15, de v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, de v 10 1`] = `
+{
+  "_cmd": "de b v 15, de v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de v 11 1`] = `
+{
+  "_cmd": "de b v 15, de v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de v 12 1`] = `
+{
+  "_cmd": "de b v 15, de v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de v 13 1`] = `
+{
+  "_cmd": "de b v 15, de v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de v 14 1`] = `
+{
+  "_cmd": "de b v 15, de v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de v 15 1`] = `
+{
+  "_cmd": "de b v 15, de v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de v 16 1`] = `
+{
+  "_cmd": "de b v 15, de v 16",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de v 17 1`] = `
+{
+  "_cmd": "de b v 15, de v 17",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 15, de v 18 1`] = `
+{
+  "_cmd": "de b v 15, de v 18",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 15, de v 19 1`] = `
+{
+  "_cmd": "de b v 15, de v 19",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 15, de v 20 1`] = `
+{
+  "_cmd": "de b v 15, de v 20",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 15, de w 1 1`] = `
+{
+  "_cmd": "de b v 15, de w 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, de w 2 1`] = `
+{
+  "_cmd": "de b v 15, de w 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de w 3 1`] = `
+{
+  "_cmd": "de b v 15, de w 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, de w 4 1`] = `
+{
+  "_cmd": "de b v 15, de w 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de w 5 1`] = `
+{
+  "_cmd": "de b v 15, de w 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, de w 6 1`] = `
+{
+  "_cmd": "de b v 15, de w 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, de w 7 1`] = `
+{
+  "_cmd": "de b v 15, de w 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, de w 8 1`] = `
+{
+  "_cmd": "de b v 15, de w 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de w 9 1`] = `
+{
+  "_cmd": "de b v 15, de w 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de w 10 1`] = `
+{
+  "_cmd": "de b v 15, de w 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de w 11 1`] = `
+{
+  "_cmd": "de b v 15, de w 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de w 12 1`] = `
+{
+  "_cmd": "de b v 15, de w 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de w 13 1`] = `
+{
+  "_cmd": "de b v 15, de w 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de w 14 1`] = `
+{
+  "_cmd": "de b v 15, de w 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de w 15 1`] = `
+{
+  "_cmd": "de b v 15, de w 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de w v 1 1`] = `
+{
+  "_cmd": "de b v 15, de w v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, de w v 2 1`] = `
+{
+  "_cmd": "de b v 15, de w v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, de w v 3 1`] = `
+{
+  "_cmd": "de b v 15, de w v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, de w v 4 1`] = `
+{
+  "_cmd": "de b v 15, de w v 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, de w v 5 1`] = `
+{
+  "_cmd": "de b v 15, de w v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, de w v 6 1`] = `
+{
+  "_cmd": "de b v 15, de w v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, de w v 7 1`] = `
+{
+  "_cmd": "de b v 15, de w v 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, de w v 8 1`] = `
+{
+  "_cmd": "de b v 15, de w v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, de w v 9 1`] = `
+{
+  "_cmd": "de b v 15, de w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, de w v 10 1`] = `
+{
+  "_cmd": "de b v 15, de w v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, de w v 11 1`] = `
+{
+  "_cmd": "de b v 15, de w v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, de w v 12 1`] = `
+{
+  "_cmd": "de b v 15, de w v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, de w v 13 1`] = `
+{
+  "_cmd": "de b v 15, de w v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, de w v 14 1`] = `
+{
+  "_cmd": "de b v 15, de w v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, de w v 15 1`] = `
+{
+  "_cmd": "de b v 15, de w v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, de w v 16 1`] = `
+{
+  "_cmd": "de b v 15, de w v 16",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 15, de w v 17 1`] = `
+{
+  "_cmd": "de b v 15, de w v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 15, de w v 18 1`] = `
+{
+  "_cmd": "de b v 15, de w v 18",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 15, de w v 19 1`] = `
+{
+  "_cmd": "de b v 15, de w v 19",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 15, de w v 20 1`] = `
+{
+  "_cmd": "de b v 15, de w v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 16, de d 1 1`] = `
+{
+  "_cmd": "de b v 16, de d 1",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, de d 2 1`] = `
+{
+  "_cmd": "de b v 16, de d 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, de d 3 1`] = `
+{
+  "_cmd": "de b v 16, de d 3",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de d 4 1`] = `
+{
+  "_cmd": "de b v 16, de d 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, de d 5 1`] = `
+{
+  "_cmd": "de b v 16, de d 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de d 6 1`] = `
+{
+  "_cmd": "de b v 16, de d 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de d 7 1`] = `
+{
+  "_cmd": "de b v 16, de d 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de d 8 1`] = `
+{
+  "_cmd": "de b v 16, de d 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de d 9 1`] = `
+{
+  "_cmd": "de b v 16, de d 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, de d 10 1`] = `
+{
+  "_cmd": "de b v 16, de d 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de d 11 1`] = `
+{
+  "_cmd": "de b v 16, de d 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de d 12 1`] = `
+{
+  "_cmd": "de b v 16, de d 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de d 13 1`] = `
+{
+  "_cmd": "de b v 16, de d 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de d 14 1`] = `
+{
+  "_cmd": "de b v 16, de d 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de d 15 1`] = `
+{
+  "_cmd": "de b v 16, de d 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de d v 1 1`] = `
+{
+  "_cmd": "de b v 16, de d v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, de d v 2 1`] = `
+{
+  "_cmd": "de b v 16, de d v 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, de d v 3 1`] = `
+{
+  "_cmd": "de b v 16, de d v 3",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de d v 4 1`] = `
+{
+  "_cmd": "de b v 16, de d v 4",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, de d v 5 1`] = `
+{
+  "_cmd": "de b v 16, de d v 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de d v 6 1`] = `
+{
+  "_cmd": "de b v 16, de d v 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de d v 7 1`] = `
+{
+  "_cmd": "de b v 16, de d v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, de d v 8 1`] = `
+{
+  "_cmd": "de b v 16, de d v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de d v 9 1`] = `
+{
+  "_cmd": "de b v 16, de d v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de d v 10 1`] = `
+{
+  "_cmd": "de b v 16, de d v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de d v 11 1`] = `
+{
+  "_cmd": "de b v 16, de d v 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de d v 12 1`] = `
+{
+  "_cmd": "de b v 16, de d v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de d v 13 1`] = `
+{
+  "_cmd": "de b v 16, de d v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de d v 14 1`] = `
+{
+  "_cmd": "de b v 16, de d v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de d v 15 1`] = `
+{
+  "_cmd": "de b v 16, de d v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de d v 16 1`] = `
+{
+  "_cmd": "de b v 16, de d v 16",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de d v 17 1`] = `
+{
+  "_cmd": "de b v 16, de d v 17",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 16, de d v 18 1`] = `
+{
+  "_cmd": "de b v 16, de d v 18",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 16, de d v 19 1`] = `
+{
+  "_cmd": "de b v 16, de d v 19",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 16, de d v 20 1`] = `
+{
+  "_cmd": "de b v 16, de d v 20",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 16, de p 1 1`] = `
+{
+  "_cmd": "de b v 16, de p 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, de p 2 1`] = `
+{
+  "_cmd": "de b v 16, de p 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, de p 3 1`] = `
+{
+  "_cmd": "de b v 16, de p 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, de p 4 1`] = `
+{
+  "_cmd": "de b v 16, de p 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de p 5 1`] = `
+{
+  "_cmd": "de b v 16, de p 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, de p 6 1`] = `
+{
+  "_cmd": "de b v 16, de p 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de p 7 1`] = `
+{
+  "_cmd": "de b v 16, de p 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de p 8 1`] = `
+{
+  "_cmd": "de b v 16, de p 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de p 9 1`] = `
+{
+  "_cmd": "de b v 16, de p 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de p 10 1`] = `
+{
+  "_cmd": "de b v 16, de p 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, de p 11 1`] = `
+{
+  "_cmd": "de b v 16, de p 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de p 12 1`] = `
+{
+  "_cmd": "de b v 16, de p 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de p 13 1`] = `
+{
+  "_cmd": "de b v 16, de p 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de p 14 1`] = `
+{
+  "_cmd": "de b v 16, de p 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de p 15 1`] = `
+{
+  "_cmd": "de b v 16, de p 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de p v 1 1`] = `
+{
+  "_cmd": "de b v 16, de p v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, de p v 2 1`] = `
+{
+  "_cmd": "de b v 16, de p v 2",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, de p v 3 1`] = `
+{
+  "_cmd": "de b v 16, de p v 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, de p v 4 1`] = `
+{
+  "_cmd": "de b v 16, de p v 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de p v 5 1`] = `
+{
+  "_cmd": "de b v 16, de p v 5",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, de p v 6 1`] = `
+{
+  "_cmd": "de b v 16, de p v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de p v 7 1`] = `
+{
+  "_cmd": "de b v 16, de p v 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de p v 8 1`] = `
+{
+  "_cmd": "de b v 16, de p v 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, de p v 9 1`] = `
+{
+  "_cmd": "de b v 16, de p v 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de p v 10 1`] = `
+{
+  "_cmd": "de b v 16, de p v 10",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de p v 11 1`] = `
+{
+  "_cmd": "de b v 16, de p v 11",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de p v 12 1`] = `
+{
+  "_cmd": "de b v 16, de p v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de p v 13 1`] = `
+{
+  "_cmd": "de b v 16, de p v 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de p v 14 1`] = `
+{
+  "_cmd": "de b v 16, de p v 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de p v 15 1`] = `
+{
+  "_cmd": "de b v 16, de p v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de p v 16 1`] = `
+{
+  "_cmd": "de b v 16, de p v 16",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de p v 17 1`] = `
+{
+  "_cmd": "de b v 16, de p v 17",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de p v 18 1`] = `
+{
+  "_cmd": "de b v 16, de p v 18",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 16, de p v 19 1`] = `
+{
+  "_cmd": "de b v 16, de p v 19",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 16, de p v 20 1`] = `
+{
+  "_cmd": "de b v 16, de p v 20",
+  "attacker": 7,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 16, de v 1 1`] = `
+{
+  "_cmd": "de b v 16, de v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, de v 2 1`] = `
+{
+  "_cmd": "de b v 16, de v 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, de v 3 1`] = `
+{
+  "_cmd": "de b v 16, de v 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, de v 4 1`] = `
+{
+  "_cmd": "de b v 16, de v 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de v 5 1`] = `
+{
+  "_cmd": "de b v 16, de v 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, de v 6 1`] = `
+{
+  "_cmd": "de b v 16, de v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de v 7 1`] = `
+{
+  "_cmd": "de b v 16, de v 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de v 8 1`] = `
+{
+  "_cmd": "de b v 16, de v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de v 9 1`] = `
+{
+  "_cmd": "de b v 16, de v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de v 10 1`] = `
+{
+  "_cmd": "de b v 16, de v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, de v 11 1`] = `
+{
+  "_cmd": "de b v 16, de v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de v 12 1`] = `
+{
+  "_cmd": "de b v 16, de v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de v 13 1`] = `
+{
+  "_cmd": "de b v 16, de v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de v 14 1`] = `
+{
+  "_cmd": "de b v 16, de v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de v 15 1`] = `
+{
+  "_cmd": "de b v 16, de v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de v 16 1`] = `
+{
+  "_cmd": "de b v 16, de v 16",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de v 17 1`] = `
+{
+  "_cmd": "de b v 16, de v 17",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 16, de v 18 1`] = `
+{
+  "_cmd": "de b v 16, de v 18",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 16, de v 19 1`] = `
+{
+  "_cmd": "de b v 16, de v 19",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 16, de v 20 1`] = `
+{
+  "_cmd": "de b v 16, de v 20",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 16, de w 1 1`] = `
+{
+  "_cmd": "de b v 16, de w 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, de w 2 1`] = `
+{
+  "_cmd": "de b v 16, de w 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de w 3 1`] = `
+{
+  "_cmd": "de b v 16, de w 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, de w 4 1`] = `
+{
+  "_cmd": "de b v 16, de w 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de w 5 1`] = `
+{
+  "_cmd": "de b v 16, de w 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de w 6 1`] = `
+{
+  "_cmd": "de b v 16, de w 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de w 7 1`] = `
+{
+  "_cmd": "de b v 16, de w 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, de w 8 1`] = `
+{
+  "_cmd": "de b v 16, de w 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, de w 9 1`] = `
+{
+  "_cmd": "de b v 16, de w 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de w 10 1`] = `
+{
+  "_cmd": "de b v 16, de w 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de w 11 1`] = `
+{
+  "_cmd": "de b v 16, de w 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de w 12 1`] = `
+{
+  "_cmd": "de b v 16, de w 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de w 13 1`] = `
+{
+  "_cmd": "de b v 16, de w 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de w 14 1`] = `
+{
+  "_cmd": "de b v 16, de w 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de w 15 1`] = `
+{
+  "_cmd": "de b v 16, de w 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de w v 1 1`] = `
+{
+  "_cmd": "de b v 16, de w v 1",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, de w v 2 1`] = `
+{
+  "_cmd": "de b v 16, de w v 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, de w v 3 1`] = `
+{
+  "_cmd": "de b v 16, de w v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, de w v 4 1`] = `
+{
+  "_cmd": "de b v 16, de w v 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, de w v 5 1`] = `
+{
+  "_cmd": "de b v 16, de w v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, de w v 6 1`] = `
+{
+  "_cmd": "de b v 16, de w v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, de w v 7 1`] = `
+{
+  "_cmd": "de b v 16, de w v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, de w v 8 1`] = `
+{
+  "_cmd": "de b v 16, de w v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, de w v 9 1`] = `
+{
+  "_cmd": "de b v 16, de w v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, de w v 10 1`] = `
+{
+  "_cmd": "de b v 16, de w v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, de w v 11 1`] = `
+{
+  "_cmd": "de b v 16, de w v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, de w v 12 1`] = `
+{
+  "_cmd": "de b v 16, de w v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, de w v 13 1`] = `
+{
+  "_cmd": "de b v 16, de w v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, de w v 14 1`] = `
+{
+  "_cmd": "de b v 16, de w v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, de w v 15 1`] = `
+{
+  "_cmd": "de b v 16, de w v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, de w v 16 1`] = `
+{
+  "_cmd": "de b v 16, de w v 16",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 16, de w v 17 1`] = `
+{
+  "_cmd": "de b v 16, de w v 17",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 16, de w v 18 1`] = `
+{
+  "_cmd": "de b v 16, de w v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 16, de w v 19 1`] = `
+{
+  "_cmd": "de b v 16, de w v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 16, de w v 20 1`] = `
+{
+  "_cmd": "de b v 16, de w v 20",
+  "attacker": 4,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 17, de d 1 1`] = `
+{
+  "_cmd": "de b v 17, de d 1",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, de d 2 1`] = `
+{
+  "_cmd": "de b v 17, de d 2",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, de d 3 1`] = `
+{
+  "_cmd": "de b v 17, de d 3",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de d 4 1`] = `
+{
+  "_cmd": "de b v 17, de d 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de d 5 1`] = `
+{
+  "_cmd": "de b v 17, de d 5",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, de d 6 1`] = `
+{
+  "_cmd": "de b v 17, de d 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de d 7 1`] = `
+{
+  "_cmd": "de b v 17, de d 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, de d 8 1`] = `
+{
+  "_cmd": "de b v 17, de d 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de d 9 1`] = `
+{
+  "_cmd": "de b v 17, de d 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de d 10 1`] = `
+{
+  "_cmd": "de b v 17, de d 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de d 11 1`] = `
+{
+  "_cmd": "de b v 17, de d 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de d 12 1`] = `
+{
+  "_cmd": "de b v 17, de d 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de d 13 1`] = `
+{
+  "_cmd": "de b v 17, de d 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de d 14 1`] = `
+{
+  "_cmd": "de b v 17, de d 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de d 15 1`] = `
+{
+  "_cmd": "de b v 17, de d 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de d v 1 1`] = `
+{
+  "_cmd": "de b v 17, de d v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, de d v 2 1`] = `
+{
+  "_cmd": "de b v 17, de d v 2",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, de d v 3 1`] = `
+{
+  "_cmd": "de b v 17, de d v 3",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de d v 4 1`] = `
+{
+  "_cmd": "de b v 17, de d v 4",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, de d v 5 1`] = `
+{
+  "_cmd": "de b v 17, de d v 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de d v 6 1`] = `
+{
+  "_cmd": "de b v 17, de d v 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de d v 7 1`] = `
+{
+  "_cmd": "de b v 17, de d v 7",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, de d v 8 1`] = `
+{
+  "_cmd": "de b v 17, de d v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, de d v 9 1`] = `
+{
+  "_cmd": "de b v 17, de d v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de d v 10 1`] = `
+{
+  "_cmd": "de b v 17, de d v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de d v 11 1`] = `
+{
+  "_cmd": "de b v 17, de d v 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de d v 12 1`] = `
+{
+  "_cmd": "de b v 17, de d v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de d v 13 1`] = `
+{
+  "_cmd": "de b v 17, de d v 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de d v 14 1`] = `
+{
+  "_cmd": "de b v 17, de d v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de d v 15 1`] = `
+{
+  "_cmd": "de b v 17, de d v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, de d v 16 1`] = `
+{
+  "_cmd": "de b v 17, de d v 16",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de d v 17 1`] = `
+{
+  "_cmd": "de b v 17, de d v 17",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 17, de d v 18 1`] = `
+{
+  "_cmd": "de b v 17, de d v 18",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 17, de d v 19 1`] = `
+{
+  "_cmd": "de b v 17, de d v 19",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 17, de d v 20 1`] = `
+{
+  "_cmd": "de b v 17, de d v 20",
+  "attacker": 6,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 17, de p 1 1`] = `
+{
+  "_cmd": "de b v 17, de p 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, de p 2 1`] = `
+{
+  "_cmd": "de b v 17, de p 2",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, de p 3 1`] = `
+{
+  "_cmd": "de b v 17, de p 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, de p 4 1`] = `
+{
+  "_cmd": "de b v 17, de p 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de p 5 1`] = `
+{
+  "_cmd": "de b v 17, de p 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de p 6 1`] = `
+{
+  "_cmd": "de b v 17, de p 6",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, de p 7 1`] = `
+{
+  "_cmd": "de b v 17, de p 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de p 8 1`] = `
+{
+  "_cmd": "de b v 17, de p 8",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, de p 9 1`] = `
+{
+  "_cmd": "de b v 17, de p 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de p 10 1`] = `
+{
+  "_cmd": "de b v 17, de p 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de p 11 1`] = `
+{
+  "_cmd": "de b v 17, de p 11",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de p 12 1`] = `
+{
+  "_cmd": "de b v 17, de p 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de p 13 1`] = `
+{
+  "_cmd": "de b v 17, de p 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de p 14 1`] = `
+{
+  "_cmd": "de b v 17, de p 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de p 15 1`] = `
+{
+  "_cmd": "de b v 17, de p 15",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de p v 1 1`] = `
+{
+  "_cmd": "de b v 17, de p v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, de p v 2 1`] = `
+{
+  "_cmd": "de b v 17, de p v 2",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, de p v 3 1`] = `
+{
+  "_cmd": "de b v 17, de p v 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, de p v 4 1`] = `
+{
+  "_cmd": "de b v 17, de p v 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de p v 5 1`] = `
+{
+  "_cmd": "de b v 17, de p v 5",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, de p v 6 1`] = `
+{
+  "_cmd": "de b v 17, de p v 6",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de p v 7 1`] = `
+{
+  "_cmd": "de b v 17, de p v 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de p v 8 1`] = `
+{
+  "_cmd": "de b v 17, de p v 8",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, de p v 9 1`] = `
+{
+  "_cmd": "de b v 17, de p v 9",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, de p v 10 1`] = `
+{
+  "_cmd": "de b v 17, de p v 10",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de p v 11 1`] = `
+{
+  "_cmd": "de b v 17, de p v 11",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de p v 12 1`] = `
+{
+  "_cmd": "de b v 17, de p v 12",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de p v 13 1`] = `
+{
+  "_cmd": "de b v 17, de p v 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de p v 14 1`] = `
+{
+  "_cmd": "de b v 17, de p v 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de p v 15 1`] = `
+{
+  "_cmd": "de b v 17, de p v 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de p v 16 1`] = `
+{
+  "_cmd": "de b v 17, de p v 16",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, de p v 17 1`] = `
+{
+  "_cmd": "de b v 17, de p v 17",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de p v 18 1`] = `
+{
+  "_cmd": "de b v 17, de p v 18",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 17, de p v 19 1`] = `
+{
+  "_cmd": "de b v 17, de p v 19",
+  "attacker": 9,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 17, de p v 20 1`] = `
+{
+  "_cmd": "de b v 17, de p v 20",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 17, de v 1 1`] = `
+{
+  "_cmd": "de b v 17, de v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, de v 2 1`] = `
+{
+  "_cmd": "de b v 17, de v 2",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, de v 3 1`] = `
+{
+  "_cmd": "de b v 17, de v 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, de v 4 1`] = `
+{
+  "_cmd": "de b v 17, de v 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de v 5 1`] = `
+{
+  "_cmd": "de b v 17, de v 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de v 6 1`] = `
+{
+  "_cmd": "de b v 17, de v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, de v 7 1`] = `
+{
+  "_cmd": "de b v 17, de v 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de v 8 1`] = `
+{
+  "_cmd": "de b v 17, de v 8",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, de v 9 1`] = `
+{
+  "_cmd": "de b v 17, de v 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de v 10 1`] = `
+{
+  "_cmd": "de b v 17, de v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de v 11 1`] = `
+{
+  "_cmd": "de b v 17, de v 11",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de v 12 1`] = `
+{
+  "_cmd": "de b v 17, de v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de v 13 1`] = `
+{
+  "_cmd": "de b v 17, de v 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de v 14 1`] = `
+{
+  "_cmd": "de b v 17, de v 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de v 15 1`] = `
+{
+  "_cmd": "de b v 17, de v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, de v 16 1`] = `
+{
+  "_cmd": "de b v 17, de v 16",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de v 17 1`] = `
+{
+  "_cmd": "de b v 17, de v 17",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 17, de v 18 1`] = `
+{
+  "_cmd": "de b v 17, de v 18",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 17, de v 19 1`] = `
+{
+  "_cmd": "de b v 17, de v 19",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 17, de v 20 1`] = `
+{
+  "_cmd": "de b v 17, de v 20",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 17, de w 1 1`] = `
+{
+  "_cmd": "de b v 17, de w 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, de w 2 1`] = `
+{
+  "_cmd": "de b v 17, de w 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de w 3 1`] = `
+{
+  "_cmd": "de b v 17, de w 3",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, de w 4 1`] = `
+{
+  "_cmd": "de b v 17, de w 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, de w 5 1`] = `
+{
+  "_cmd": "de b v 17, de w 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de w 6 1`] = `
+{
+  "_cmd": "de b v 17, de w 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, de w 7 1`] = `
+{
+  "_cmd": "de b v 17, de w 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, de w 8 1`] = `
+{
+  "_cmd": "de b v 17, de w 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de w 9 1`] = `
+{
+  "_cmd": "de b v 17, de w 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de w 10 1`] = `
+{
+  "_cmd": "de b v 17, de w 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de w 11 1`] = `
+{
+  "_cmd": "de b v 17, de w 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de w 12 1`] = `
+{
+  "_cmd": "de b v 17, de w 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de w 13 1`] = `
+{
+  "_cmd": "de b v 17, de w 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de w 14 1`] = `
+{
+  "_cmd": "de b v 17, de w 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, de w 15 1`] = `
+{
+  "_cmd": "de b v 17, de w 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de w v 1 1`] = `
+{
+  "_cmd": "de b v 17, de w v 1",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, de w v 2 1`] = `
+{
+  "_cmd": "de b v 17, de w v 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, de w v 3 1`] = `
+{
+  "_cmd": "de b v 17, de w v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, de w v 4 1`] = `
+{
+  "_cmd": "de b v 17, de w v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, de w v 5 1`] = `
+{
+  "_cmd": "de b v 17, de w v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, de w v 6 1`] = `
+{
+  "_cmd": "de b v 17, de w v 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, de w v 7 1`] = `
+{
+  "_cmd": "de b v 17, de w v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, de w v 8 1`] = `
+{
+  "_cmd": "de b v 17, de w v 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, de w v 9 1`] = `
+{
+  "_cmd": "de b v 17, de w v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, de w v 10 1`] = `
+{
+  "_cmd": "de b v 17, de w v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, de w v 11 1`] = `
+{
+  "_cmd": "de b v 17, de w v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, de w v 12 1`] = `
+{
+  "_cmd": "de b v 17, de w v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, de w v 13 1`] = `
+{
+  "_cmd": "de b v 17, de w v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, de w v 14 1`] = `
+{
+  "_cmd": "de b v 17, de w v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, de w v 15 1`] = `
+{
+  "_cmd": "de b v 17, de w v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, de w v 16 1`] = `
+{
+  "_cmd": "de b v 17, de w v 16",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 17, de w v 17 1`] = `
+{
+  "_cmd": "de b v 17, de w v 17",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 17, de w v 18 1`] = `
+{
+  "_cmd": "de b v 17, de w v 18",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 17, de w v 19 1`] = `
+{
+  "_cmd": "de b v 17, de w v 19",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 17, de w v 20 1`] = `
+{
+  "_cmd": "de b v 17, de w v 20",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 18, de d 1 1`] = `
+{
+  "_cmd": "de b v 18, de d 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, de d 2 1`] = `
+{
+  "_cmd": "de b v 18, de d 2",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, de d 3 1`] = `
+{
+  "_cmd": "de b v 18, de d 3",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, de d 4 1`] = `
+{
+  "_cmd": "de b v 18, de d 4",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, de d 5 1`] = `
+{
+  "_cmd": "de b v 18, de d 5",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, de d 6 1`] = `
+{
+  "_cmd": "de b v 18, de d 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de d 7 1`] = `
+{
+  "_cmd": "de b v 18, de d 7",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de d 8 1`] = `
+{
+  "_cmd": "de b v 18, de d 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de d 9 1`] = `
+{
+  "_cmd": "de b v 18, de d 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de d 10 1`] = `
+{
+  "_cmd": "de b v 18, de d 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, de d 11 1`] = `
+{
+  "_cmd": "de b v 18, de d 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de d 12 1`] = `
+{
+  "_cmd": "de b v 18, de d 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de d 13 1`] = `
+{
+  "_cmd": "de b v 18, de d 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de d 14 1`] = `
+{
+  "_cmd": "de b v 18, de d 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de d 15 1`] = `
+{
+  "_cmd": "de b v 18, de d 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, de d v 1 1`] = `
+{
+  "_cmd": "de b v 18, de d v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, de d v 2 1`] = `
+{
+  "_cmd": "de b v 18, de d v 2",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, de d v 3 1`] = `
+{
+  "_cmd": "de b v 18, de d v 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, de d v 4 1`] = `
+{
+  "_cmd": "de b v 18, de d v 4",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, de d v 5 1`] = `
+{
+  "_cmd": "de b v 18, de d v 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, de d v 6 1`] = `
+{
+  "_cmd": "de b v 18, de d v 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de d v 7 1`] = `
+{
+  "_cmd": "de b v 18, de d v 7",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de d v 8 1`] = `
+{
+  "_cmd": "de b v 18, de d v 8",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, de d v 9 1`] = `
+{
+  "_cmd": "de b v 18, de d v 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de d v 10 1`] = `
+{
+  "_cmd": "de b v 18, de d v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de d v 11 1`] = `
+{
+  "_cmd": "de b v 18, de d v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de d v 12 1`] = `
+{
+  "_cmd": "de b v 18, de d v 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de d v 13 1`] = `
+{
+  "_cmd": "de b v 18, de d v 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de d v 14 1`] = `
+{
+  "_cmd": "de b v 18, de d v 14",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de d v 15 1`] = `
+{
+  "_cmd": "de b v 18, de d v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, de d v 16 1`] = `
+{
+  "_cmd": "de b v 18, de d v 16",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, de d v 17 1`] = `
+{
+  "_cmd": "de b v 18, de d v 17",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 18, de d v 18 1`] = `
+{
+  "_cmd": "de b v 18, de d v 18",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 18, de d v 19 1`] = `
+{
+  "_cmd": "de b v 18, de d v 19",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 18, de d v 20 1`] = `
+{
+  "_cmd": "de b v 18, de d v 20",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 18, de p 1 1`] = `
+{
+  "_cmd": "de b v 18, de p 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, de p 2 1`] = `
+{
+  "_cmd": "de b v 18, de p 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, de p 3 1`] = `
+{
+  "_cmd": "de b v 18, de p 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, de p 4 1`] = `
+{
+  "_cmd": "de b v 18, de p 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, de p 5 1`] = `
+{
+  "_cmd": "de b v 18, de p 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, de p 6 1`] = `
+{
+  "_cmd": "de b v 18, de p 6",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, de p 7 1`] = `
+{
+  "_cmd": "de b v 18, de p 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de p 8 1`] = `
+{
+  "_cmd": "de b v 18, de p 8",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de p 9 1`] = `
+{
+  "_cmd": "de b v 18, de p 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de p 10 1`] = `
+{
+  "_cmd": "de b v 18, de p 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de p 11 1`] = `
+{
+  "_cmd": "de b v 18, de p 11",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, de p 12 1`] = `
+{
+  "_cmd": "de b v 18, de p 12",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de p 13 1`] = `
+{
+  "_cmd": "de b v 18, de p 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de p 14 1`] = `
+{
+  "_cmd": "de b v 18, de p 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de p 15 1`] = `
+{
+  "_cmd": "de b v 18, de p 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de p v 1 1`] = `
+{
+  "_cmd": "de b v 18, de p v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, de p v 2 1`] = `
+{
+  "_cmd": "de b v 18, de p v 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, de p v 3 1`] = `
+{
+  "_cmd": "de b v 18, de p v 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, de p v 4 1`] = `
+{
+  "_cmd": "de b v 18, de p v 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, de p v 5 1`] = `
+{
+  "_cmd": "de b v 18, de p v 5",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, de p v 6 1`] = `
+{
+  "_cmd": "de b v 18, de p v 6",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, de p v 7 1`] = `
+{
+  "_cmd": "de b v 18, de p v 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de p v 8 1`] = `
+{
+  "_cmd": "de b v 18, de p v 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de p v 9 1`] = `
+{
+  "_cmd": "de b v 18, de p v 9",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, de p v 10 1`] = `
+{
+  "_cmd": "de b v 18, de p v 10",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de p v 11 1`] = `
+{
+  "_cmd": "de b v 18, de p v 11",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de p v 12 1`] = `
+{
+  "_cmd": "de b v 18, de p v 12",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de p v 13 1`] = `
+{
+  "_cmd": "de b v 18, de p v 13",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de p v 14 1`] = `
+{
+  "_cmd": "de b v 18, de p v 14",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de p v 15 1`] = `
+{
+  "_cmd": "de b v 18, de p v 15",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de p v 16 1`] = `
+{
+  "_cmd": "de b v 18, de p v 16",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, de p v 17 1`] = `
+{
+  "_cmd": "de b v 18, de p v 17",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, de p v 18 1`] = `
+{
+  "_cmd": "de b v 18, de p v 18",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 18, de p v 19 1`] = `
+{
+  "_cmd": "de b v 18, de p v 19",
+  "attacker": 10,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 18, de p v 20 1`] = `
+{
+  "_cmd": "de b v 18, de p v 20",
+  "attacker": 10,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 18, de v 1 1`] = `
+{
+  "_cmd": "de b v 18, de v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, de v 2 1`] = `
+{
+  "_cmd": "de b v 18, de v 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, de v 3 1`] = `
+{
+  "_cmd": "de b v 18, de v 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, de v 4 1`] = `
+{
+  "_cmd": "de b v 18, de v 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, de v 5 1`] = `
+{
+  "_cmd": "de b v 18, de v 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, de v 6 1`] = `
+{
+  "_cmd": "de b v 18, de v 6",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, de v 7 1`] = `
+{
+  "_cmd": "de b v 18, de v 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de v 8 1`] = `
+{
+  "_cmd": "de b v 18, de v 8",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de v 9 1`] = `
+{
+  "_cmd": "de b v 18, de v 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de v 10 1`] = `
+{
+  "_cmd": "de b v 18, de v 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de v 11 1`] = `
+{
+  "_cmd": "de b v 18, de v 11",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, de v 12 1`] = `
+{
+  "_cmd": "de b v 18, de v 12",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de v 13 1`] = `
+{
+  "_cmd": "de b v 18, de v 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de v 14 1`] = `
+{
+  "_cmd": "de b v 18, de v 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de v 15 1`] = `
+{
+  "_cmd": "de b v 18, de v 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de v 16 1`] = `
+{
+  "_cmd": "de b v 18, de v 16",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, de v 17 1`] = `
+{
+  "_cmd": "de b v 18, de v 17",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 18, de v 18 1`] = `
+{
+  "_cmd": "de b v 18, de v 18",
+  "attacker": 9,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 18, de v 19 1`] = `
+{
+  "_cmd": "de b v 18, de v 19",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 18, de v 20 1`] = `
+{
+  "_cmd": "de b v 18, de v 20",
+  "attacker": 9,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 18, de w 1 1`] = `
+{
+  "_cmd": "de b v 18, de w 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, de w 2 1`] = `
+{
+  "_cmd": "de b v 18, de w 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, de w 3 1`] = `
+{
+  "_cmd": "de b v 18, de w 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, de w 4 1`] = `
+{
+  "_cmd": "de b v 18, de w 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, de w 5 1`] = `
+{
+  "_cmd": "de b v 18, de w 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de w 6 1`] = `
+{
+  "_cmd": "de b v 18, de w 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, de w 7 1`] = `
+{
+  "_cmd": "de b v 18, de w 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, de w 8 1`] = `
+{
+  "_cmd": "de b v 18, de w 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de w 9 1`] = `
+{
+  "_cmd": "de b v 18, de w 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, de w 10 1`] = `
+{
+  "_cmd": "de b v 18, de w 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de w 11 1`] = `
+{
+  "_cmd": "de b v 18, de w 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de w 12 1`] = `
+{
+  "_cmd": "de b v 18, de w 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de w 13 1`] = `
+{
+  "_cmd": "de b v 18, de w 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de w 14 1`] = `
+{
+  "_cmd": "de b v 18, de w 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, de w 15 1`] = `
+{
+  "_cmd": "de b v 18, de w 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, de w v 1 1`] = `
+{
+  "_cmd": "de b v 18, de w v 1",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, de w v 2 1`] = `
+{
+  "_cmd": "de b v 18, de w v 2",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, de w v 3 1`] = `
+{
+  "_cmd": "de b v 18, de w v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, de w v 4 1`] = `
+{
+  "_cmd": "de b v 18, de w v 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, de w v 5 1`] = `
+{
+  "_cmd": "de b v 18, de w v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, de w v 6 1`] = `
+{
+  "_cmd": "de b v 18, de w v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, de w v 7 1`] = `
+{
+  "_cmd": "de b v 18, de w v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, de w v 8 1`] = `
+{
+  "_cmd": "de b v 18, de w v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, de w v 9 1`] = `
+{
+  "_cmd": "de b v 18, de w v 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, de w v 10 1`] = `
+{
+  "_cmd": "de b v 18, de w v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, de w v 11 1`] = `
+{
+  "_cmd": "de b v 18, de w v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, de w v 12 1`] = `
+{
+  "_cmd": "de b v 18, de w v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, de w v 13 1`] = `
+{
+  "_cmd": "de b v 18, de w v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, de w v 14 1`] = `
+{
+  "_cmd": "de b v 18, de w v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, de w v 15 1`] = `
+{
+  "_cmd": "de b v 18, de w v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, de w v 16 1`] = `
+{
+  "_cmd": "de b v 18, de w v 16",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 18, de w v 17 1`] = `
+{
+  "_cmd": "de b v 18, de w v 17",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 18, de w v 18 1`] = `
+{
+  "_cmd": "de b v 18, de w v 18",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 18, de w v 19 1`] = `
+{
+  "_cmd": "de b v 18, de w v 19",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 18, de w v 20 1`] = `
+{
+  "_cmd": "de b v 18, de w v 20",
+  "attacker": 6,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 19, de d 1 1`] = `
+{
+  "_cmd": "de b v 19, de d 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, de d 2 1`] = `
+{
+  "_cmd": "de b v 19, de d 2",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, de d 3 1`] = `
+{
+  "_cmd": "de b v 19, de d 3",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, de d 4 1`] = `
+{
+  "_cmd": "de b v 19, de d 4",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de d 5 1`] = `
+{
+  "_cmd": "de b v 19, de d 5",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, de d 6 1`] = `
+{
+  "_cmd": "de b v 19, de d 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de d 7 1`] = `
+{
+  "_cmd": "de b v 19, de d 7",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de d 8 1`] = `
+{
+  "_cmd": "de b v 19, de d 8",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, de d 9 1`] = `
+{
+  "_cmd": "de b v 19, de d 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de d 10 1`] = `
+{
+  "_cmd": "de b v 19, de d 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de d 11 1`] = `
+{
+  "_cmd": "de b v 19, de d 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de d 12 1`] = `
+{
+  "_cmd": "de b v 19, de d 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de d 13 1`] = `
+{
+  "_cmd": "de b v 19, de d 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de d 14 1`] = `
+{
+  "_cmd": "de b v 19, de d 14",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de d 15 1`] = `
+{
+  "_cmd": "de b v 19, de d 15",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de d v 1 1`] = `
+{
+  "_cmd": "de b v 19, de d v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, de d v 2 1`] = `
+{
+  "_cmd": "de b v 19, de d v 2",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, de d v 3 1`] = `
+{
+  "_cmd": "de b v 19, de d v 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, de d v 4 1`] = `
+{
+  "_cmd": "de b v 19, de d v 4",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de d v 5 1`] = `
+{
+  "_cmd": "de b v 19, de d v 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, de d v 6 1`] = `
+{
+  "_cmd": "de b v 19, de d v 6",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de d v 7 1`] = `
+{
+  "_cmd": "de b v 19, de d v 7",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de d v 8 1`] = `
+{
+  "_cmd": "de b v 19, de d v 8",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, de d v 9 1`] = `
+{
+  "_cmd": "de b v 19, de d v 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, de d v 10 1`] = `
+{
+  "_cmd": "de b v 19, de d v 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de d v 11 1`] = `
+{
+  "_cmd": "de b v 19, de d v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de d v 12 1`] = `
+{
+  "_cmd": "de b v 19, de d v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de d v 13 1`] = `
+{
+  "_cmd": "de b v 19, de d v 13",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de d v 14 1`] = `
+{
+  "_cmd": "de b v 19, de d v 14",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de d v 15 1`] = `
+{
+  "_cmd": "de b v 19, de d v 15",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de d v 16 1`] = `
+{
+  "_cmd": "de b v 19, de d v 16",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 19, de d v 17 1`] = `
+{
+  "_cmd": "de b v 19, de d v 17",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 19, de d v 18 1`] = `
+{
+  "_cmd": "de b v 19, de d v 18",
+  "attacker": 9,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 19, de d v 19 1`] = `
+{
+  "_cmd": "de b v 19, de d v 19",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 19, de d v 20 1`] = `
+{
+  "_cmd": "de b v 19, de d v 20",
+  "attacker": 9,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 19, de p 1 1`] = `
+{
+  "_cmd": "de b v 19, de p 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, de p 2 1`] = `
+{
+  "_cmd": "de b v 19, de p 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, de p 3 1`] = `
+{
+  "_cmd": "de b v 19, de p 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, de p 4 1`] = `
+{
+  "_cmd": "de b v 19, de p 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, de p 5 1`] = `
+{
+  "_cmd": "de b v 19, de p 5",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de p 6 1`] = `
+{
+  "_cmd": "de b v 19, de p 6",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, de p 7 1`] = `
+{
+  "_cmd": "de b v 19, de p 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de p 8 1`] = `
+{
+  "_cmd": "de b v 19, de p 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de p 9 1`] = `
+{
+  "_cmd": "de b v 19, de p 9",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, de p 10 1`] = `
+{
+  "_cmd": "de b v 19, de p 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de p 11 1`] = `
+{
+  "_cmd": "de b v 19, de p 11",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de p 12 1`] = `
+{
+  "_cmd": "de b v 19, de p 12",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de p 13 1`] = `
+{
+  "_cmd": "de b v 19, de p 13",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de p 14 1`] = `
+{
+  "_cmd": "de b v 19, de p 14",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de p 15 1`] = `
+{
+  "_cmd": "de b v 19, de p 15",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de p v 1 1`] = `
+{
+  "_cmd": "de b v 19, de p v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, de p v 2 1`] = `
+{
+  "_cmd": "de b v 19, de p v 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, de p v 3 1`] = `
+{
+  "_cmd": "de b v 19, de p v 3",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, de p v 4 1`] = `
+{
+  "_cmd": "de b v 19, de p v 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, de p v 5 1`] = `
+{
+  "_cmd": "de b v 19, de p v 5",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de p v 6 1`] = `
+{
+  "_cmd": "de b v 19, de p v 6",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, de p v 7 1`] = `
+{
+  "_cmd": "de b v 19, de p v 7",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de p v 8 1`] = `
+{
+  "_cmd": "de b v 19, de p v 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de p v 9 1`] = `
+{
+  "_cmd": "de b v 19, de p v 9",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, de p v 10 1`] = `
+{
+  "_cmd": "de b v 19, de p v 10",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, de p v 11 1`] = `
+{
+  "_cmd": "de b v 19, de p v 11",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de p v 12 1`] = `
+{
+  "_cmd": "de b v 19, de p v 12",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de p v 13 1`] = `
+{
+  "_cmd": "de b v 19, de p v 13",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de p v 14 1`] = `
+{
+  "_cmd": "de b v 19, de p v 14",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de p v 15 1`] = `
+{
+  "_cmd": "de b v 19, de p v 15",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de p v 16 1`] = `
+{
+  "_cmd": "de b v 19, de p v 16",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de p v 17 1`] = `
+{
+  "_cmd": "de b v 19, de p v 17",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 19, de p v 18 1`] = `
+{
+  "_cmd": "de b v 19, de p v 18",
+  "attacker": 11,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 19, de p v 19 1`] = `
+{
+  "_cmd": "de b v 19, de p v 19",
+  "attacker": 11,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 19, de p v 20 1`] = `
+{
+  "_cmd": "de b v 19, de p v 20",
+  "attacker": 11,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 19, de v 1 1`] = `
+{
+  "_cmd": "de b v 19, de v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, de v 2 1`] = `
+{
+  "_cmd": "de b v 19, de v 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, de v 3 1`] = `
+{
+  "_cmd": "de b v 19, de v 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, de v 4 1`] = `
+{
+  "_cmd": "de b v 19, de v 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, de v 5 1`] = `
+{
+  "_cmd": "de b v 19, de v 5",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, de v 6 1`] = `
+{
+  "_cmd": "de b v 19, de v 6",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, de v 7 1`] = `
+{
+  "_cmd": "de b v 19, de v 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de v 8 1`] = `
+{
+  "_cmd": "de b v 19, de v 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de v 9 1`] = `
+{
+  "_cmd": "de b v 19, de v 9",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, de v 10 1`] = `
+{
+  "_cmd": "de b v 19, de v 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de v 11 1`] = `
+{
+  "_cmd": "de b v 19, de v 11",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de v 12 1`] = `
+{
+  "_cmd": "de b v 19, de v 12",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de v 13 1`] = `
+{
+  "_cmd": "de b v 19, de v 13",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de v 14 1`] = `
+{
+  "_cmd": "de b v 19, de v 14",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de v 15 1`] = `
+{
+  "_cmd": "de b v 19, de v 15",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de v 16 1`] = `
+{
+  "_cmd": "de b v 19, de v 16",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de v 17 1`] = `
+{
+  "_cmd": "de b v 19, de v 17",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 19, de v 18 1`] = `
+{
+  "_cmd": "de b v 19, de v 18",
+  "attacker": 10,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 19, de v 19 1`] = `
+{
+  "_cmd": "de b v 19, de v 19",
+  "attacker": 10,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 19, de v 20 1`] = `
+{
+  "_cmd": "de b v 19, de v 20",
+  "attacker": 10,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 19, de w 1 1`] = `
+{
+  "_cmd": "de b v 19, de w 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, de w 2 1`] = `
+{
+  "_cmd": "de b v 19, de w 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, de w 3 1`] = `
+{
+  "_cmd": "de b v 19, de w 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de w 4 1`] = `
+{
+  "_cmd": "de b v 19, de w 4",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, de w 5 1`] = `
+{
+  "_cmd": "de b v 19, de w 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de w 6 1`] = `
+{
+  "_cmd": "de b v 19, de w 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de w 7 1`] = `
+{
+  "_cmd": "de b v 19, de w 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, de w 8 1`] = `
+{
+  "_cmd": "de b v 19, de w 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, de w 9 1`] = `
+{
+  "_cmd": "de b v 19, de w 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de w 10 1`] = `
+{
+  "_cmd": "de b v 19, de w 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de w 11 1`] = `
+{
+  "_cmd": "de b v 19, de w 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de w 12 1`] = `
+{
+  "_cmd": "de b v 19, de w 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de w 13 1`] = `
+{
+  "_cmd": "de b v 19, de w 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de w 14 1`] = `
+{
+  "_cmd": "de b v 19, de w 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de w 15 1`] = `
+{
+  "_cmd": "de b v 19, de w 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 19, de w v 1 1`] = `
+{
+  "_cmd": "de b v 19, de w v 1",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, de w v 2 1`] = `
+{
+  "_cmd": "de b v 19, de w v 2",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, de w v 3 1`] = `
+{
+  "_cmd": "de b v 19, de w v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, de w v 4 1`] = `
+{
+  "_cmd": "de b v 19, de w v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, de w v 5 1`] = `
+{
+  "_cmd": "de b v 19, de w v 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, de w v 6 1`] = `
+{
+  "_cmd": "de b v 19, de w v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, de w v 7 1`] = `
+{
+  "_cmd": "de b v 19, de w v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, de w v 8 1`] = `
+{
+  "_cmd": "de b v 19, de w v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, de w v 9 1`] = `
+{
+  "_cmd": "de b v 19, de w v 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, de w v 10 1`] = `
+{
+  "_cmd": "de b v 19, de w v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, de w v 11 1`] = `
+{
+  "_cmd": "de b v 19, de w v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, de w v 12 1`] = `
+{
+  "_cmd": "de b v 19, de w v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, de w v 13 1`] = `
+{
+  "_cmd": "de b v 19, de w v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, de w v 14 1`] = `
+{
+  "_cmd": "de b v 19, de w v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, de w v 15 1`] = `
+{
+  "_cmd": "de b v 19, de w v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 19, de w v 16 1`] = `
+{
+  "_cmd": "de b v 19, de w v 16",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 19, de w v 17 1`] = `
+{
+  "_cmd": "de b v 19, de w v 17",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 19, de w v 18 1`] = `
+{
+  "_cmd": "de b v 19, de w v 18",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 19, de w v 19 1`] = `
+{
+  "_cmd": "de b v 19, de w v 19",
+  "attacker": 7,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 19, de w v 20 1`] = `
+{
+  "_cmd": "de b v 19, de w v 20",
+  "attacker": 7,
+  "defender": 19,
+}
+`;
+
+exports[`de b v 20, de d 1 1`] = `
+{
+  "_cmd": "de b v 20, de d 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, de d 2 1`] = `
+{
+  "_cmd": "de b v 20, de d 2",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, de d 3 1`] = `
+{
+  "_cmd": "de b v 20, de d 3",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, de d 4 1`] = `
+{
+  "_cmd": "de b v 20, de d 4",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de d 5 1`] = `
+{
+  "_cmd": "de b v 20, de d 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de d 6 1`] = `
+{
+  "_cmd": "de b v 20, de d 6",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, de d 7 1`] = `
+{
+  "_cmd": "de b v 20, de d 7",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de d 8 1`] = `
+{
+  "_cmd": "de b v 20, de d 8",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de d 9 1`] = `
+{
+  "_cmd": "de b v 20, de d 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de d 10 1`] = `
+{
+  "_cmd": "de b v 20, de d 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de d 11 1`] = `
+{
+  "_cmd": "de b v 20, de d 11",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de d 12 1`] = `
+{
+  "_cmd": "de b v 20, de d 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de d 13 1`] = `
+{
+  "_cmd": "de b v 20, de d 13",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de d 14 1`] = `
+{
+  "_cmd": "de b v 20, de d 14",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de d 15 1`] = `
+{
+  "_cmd": "de b v 20, de d 15",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de d v 1 1`] = `
+{
+  "_cmd": "de b v 20, de d v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, de d v 2 1`] = `
+{
+  "_cmd": "de b v 20, de d v 2",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, de d v 3 1`] = `
+{
+  "_cmd": "de b v 20, de d v 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, de d v 4 1`] = `
+{
+  "_cmd": "de b v 20, de d v 4",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de d v 5 1`] = `
+{
+  "_cmd": "de b v 20, de d v 5",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, de d v 6 1`] = `
+{
+  "_cmd": "de b v 20, de d v 6",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de d v 7 1`] = `
+{
+  "_cmd": "de b v 20, de d v 7",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de d v 8 1`] = `
+{
+  "_cmd": "de b v 20, de d v 8",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de d v 9 1`] = `
+{
+  "_cmd": "de b v 20, de d v 9",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, de d v 10 1`] = `
+{
+  "_cmd": "de b v 20, de d v 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de d v 11 1`] = `
+{
+  "_cmd": "de b v 20, de d v 11",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de d v 12 1`] = `
+{
+  "_cmd": "de b v 20, de d v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de d v 13 1`] = `
+{
+  "_cmd": "de b v 20, de d v 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de d v 14 1`] = `
+{
+  "_cmd": "de b v 20, de d v 14",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de d v 15 1`] = `
+{
+  "_cmd": "de b v 20, de d v 15",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de d v 16 1`] = `
+{
+  "_cmd": "de b v 20, de d v 16",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, de d v 17 1`] = `
+{
+  "_cmd": "de b v 20, de d v 17",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 20, de d v 18 1`] = `
+{
+  "_cmd": "de b v 20, de d v 18",
+  "attacker": 10,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 20, de d v 19 1`] = `
+{
+  "_cmd": "de b v 20, de d v 19",
+  "attacker": 10,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 20, de d v 20 1`] = `
+{
+  "_cmd": "de b v 20, de d v 20",
+  "attacker": 10,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 20, de p 1 1`] = `
+{
+  "_cmd": "de b v 20, de p 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, de p 2 1`] = `
+{
+  "_cmd": "de b v 20, de p 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, de p 3 1`] = `
+{
+  "_cmd": "de b v 20, de p 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, de p 4 1`] = `
+{
+  "_cmd": "de b v 20, de p 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, de p 5 1`] = `
+{
+  "_cmd": "de b v 20, de p 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de p 6 1`] = `
+{
+  "_cmd": "de b v 20, de p 6",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de p 7 1`] = `
+{
+  "_cmd": "de b v 20, de p 7",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, de p 8 1`] = `
+{
+  "_cmd": "de b v 20, de p 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de p 9 1`] = `
+{
+  "_cmd": "de b v 20, de p 9",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de p 10 1`] = `
+{
+  "_cmd": "de b v 20, de p 10",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de p 11 1`] = `
+{
+  "_cmd": "de b v 20, de p 11",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de p 12 1`] = `
+{
+  "_cmd": "de b v 20, de p 12",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de p 13 1`] = `
+{
+  "_cmd": "de b v 20, de p 13",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de p 14 1`] = `
+{
+  "_cmd": "de b v 20, de p 14",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de p 15 1`] = `
+{
+  "_cmd": "de b v 20, de p 15",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de p v 1 1`] = `
+{
+  "_cmd": "de b v 20, de p v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, de p v 2 1`] = `
+{
+  "_cmd": "de b v 20, de p v 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, de p v 3 1`] = `
+{
+  "_cmd": "de b v 20, de p v 3",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, de p v 4 1`] = `
+{
+  "_cmd": "de b v 20, de p v 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, de p v 5 1`] = `
+{
+  "_cmd": "de b v 20, de p v 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de p v 6 1`] = `
+{
+  "_cmd": "de b v 20, de p v 6",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, de p v 7 1`] = `
+{
+  "_cmd": "de b v 20, de p v 7",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de p v 8 1`] = `
+{
+  "_cmd": "de b v 20, de p v 8",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de p v 9 1`] = `
+{
+  "_cmd": "de b v 20, de p v 9",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de p v 10 1`] = `
+{
+  "_cmd": "de b v 20, de p v 10",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, de p v 11 1`] = `
+{
+  "_cmd": "de b v 20, de p v 11",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de p v 12 1`] = `
+{
+  "_cmd": "de b v 20, de p v 12",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de p v 13 1`] = `
+{
+  "_cmd": "de b v 20, de p v 13",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de p v 14 1`] = `
+{
+  "_cmd": "de b v 20, de p v 14",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de p v 15 1`] = `
+{
+  "_cmd": "de b v 20, de p v 15",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de p v 16 1`] = `
+{
+  "_cmd": "de b v 20, de p v 16",
+  "attacker": 13,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de p v 17 1`] = `
+{
+  "_cmd": "de b v 20, de p v 17",
+  "attacker": 13,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, de p v 18 1`] = `
+{
+  "_cmd": "de b v 20, de p v 18",
+  "attacker": 12,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 20, de p v 19 1`] = `
+{
+  "_cmd": "de b v 20, de p v 19",
+  "attacker": 12,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 20, de p v 20 1`] = `
+{
+  "_cmd": "de b v 20, de p v 20",
+  "attacker": 12,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 20, de v 1 1`] = `
+{
+  "_cmd": "de b v 20, de v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, de v 2 1`] = `
+{
+  "_cmd": "de b v 20, de v 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, de v 3 1`] = `
+{
+  "_cmd": "de b v 20, de v 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, de v 4 1`] = `
+{
+  "_cmd": "de b v 20, de v 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, de v 5 1`] = `
+{
+  "_cmd": "de b v 20, de v 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de v 6 1`] = `
+{
+  "_cmd": "de b v 20, de v 6",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de v 7 1`] = `
+{
+  "_cmd": "de b v 20, de v 7",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, de v 8 1`] = `
+{
+  "_cmd": "de b v 20, de v 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de v 9 1`] = `
+{
+  "_cmd": "de b v 20, de v 9",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de v 10 1`] = `
+{
+  "_cmd": "de b v 20, de v 10",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de v 11 1`] = `
+{
+  "_cmd": "de b v 20, de v 11",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de v 12 1`] = `
+{
+  "_cmd": "de b v 20, de v 12",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de v 13 1`] = `
+{
+  "_cmd": "de b v 20, de v 13",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de v 14 1`] = `
+{
+  "_cmd": "de b v 20, de v 14",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de v 15 1`] = `
+{
+  "_cmd": "de b v 20, de v 15",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de v 16 1`] = `
+{
+  "_cmd": "de b v 20, de v 16",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de v 17 1`] = `
+{
+  "_cmd": "de b v 20, de v 17",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, de v 18 1`] = `
+{
+  "_cmd": "de b v 20, de v 18",
+  "attacker": 11,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 20, de v 19 1`] = `
+{
+  "_cmd": "de b v 20, de v 19",
+  "attacker": 11,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 20, de v 20 1`] = `
+{
+  "_cmd": "de b v 20, de v 20",
+  "attacker": 11,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 20, de w 1 1`] = `
+{
+  "_cmd": "de b v 20, de w 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, de w 2 1`] = `
+{
+  "_cmd": "de b v 20, de w 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, de w 3 1`] = `
+{
+  "_cmd": "de b v 20, de w 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de w 4 1`] = `
+{
+  "_cmd": "de b v 20, de w 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, de w 5 1`] = `
+{
+  "_cmd": "de b v 20, de w 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, de w 6 1`] = `
+{
+  "_cmd": "de b v 20, de w 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de w 7 1`] = `
+{
+  "_cmd": "de b v 20, de w 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, de w 8 1`] = `
+{
+  "_cmd": "de b v 20, de w 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, de w 9 1`] = `
+{
+  "_cmd": "de b v 20, de w 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de w 10 1`] = `
+{
+  "_cmd": "de b v 20, de w 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de w 11 1`] = `
+{
+  "_cmd": "de b v 20, de w 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de w 12 1`] = `
+{
+  "_cmd": "de b v 20, de w 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de w 13 1`] = `
+{
+  "_cmd": "de b v 20, de w 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de w 14 1`] = `
+{
+  "_cmd": "de b v 20, de w 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de w 15 1`] = `
+{
+  "_cmd": "de b v 20, de w 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, de w v 1 1`] = `
+{
+  "_cmd": "de b v 20, de w v 1",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, de w v 2 1`] = `
+{
+  "_cmd": "de b v 20, de w v 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, de w v 3 1`] = `
+{
+  "_cmd": "de b v 20, de w v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, de w v 4 1`] = `
+{
+  "_cmd": "de b v 20, de w v 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, de w v 5 1`] = `
+{
+  "_cmd": "de b v 20, de w v 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, de w v 6 1`] = `
+{
+  "_cmd": "de b v 20, de w v 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, de w v 7 1`] = `
+{
+  "_cmd": "de b v 20, de w v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, de w v 8 1`] = `
+{
+  "_cmd": "de b v 20, de w v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, de w v 9 1`] = `
+{
+  "_cmd": "de b v 20, de w v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, de w v 10 1`] = `
+{
+  "_cmd": "de b v 20, de w v 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, de w v 11 1`] = `
+{
+  "_cmd": "de b v 20, de w v 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, de w v 12 1`] = `
+{
+  "_cmd": "de b v 20, de w v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, de w v 13 1`] = `
+{
+  "_cmd": "de b v 20, de w v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, de w v 14 1`] = `
+{
+  "_cmd": "de b v 20, de w v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, de w v 15 1`] = `
+{
+  "_cmd": "de b v 20, de w v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, de w v 16 1`] = `
+{
+  "_cmd": "de b v 20, de w v 16",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 20, de w v 17 1`] = `
+{
+  "_cmd": "de b v 20, de w v 17",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de b v 20, de w v 18 1`] = `
+{
+  "_cmd": "de b v 20, de w v 18",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de b v 20, de w v 19 1`] = `
+{
+  "_cmd": "de b v 20, de w v 19",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de b v 20, de w v 20 1`] = `
+{
+  "_cmd": "de b v 20, de w v 20",
+  "attacker": 8,
+  "defender": 19,
+}
+`;
+
+exports[`de v 1, de d 1 1`] = `
+{
+  "_cmd": "de v 1, de d 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, de d 2 1`] = `
+{
+  "_cmd": "de v 1, de d 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, de d 3 1`] = `
+{
+  "_cmd": "de v 1, de d 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de d 4 1`] = `
+{
+  "_cmd": "de v 1, de d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de d 5 1`] = `
+{
+  "_cmd": "de v 1, de d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de d 6 1`] = `
+{
+  "_cmd": "de v 1, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de d 7 1`] = `
+{
+  "_cmd": "de v 1, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de d 8 1`] = `
+{
+  "_cmd": "de v 1, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de d 9 1`] = `
+{
+  "_cmd": "de v 1, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de d 10 1`] = `
+{
+  "_cmd": "de v 1, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de d 11 1`] = `
+{
+  "_cmd": "de v 1, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de d 12 1`] = `
+{
+  "_cmd": "de v 1, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de d 13 1`] = `
+{
+  "_cmd": "de v 1, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de d 14 1`] = `
+{
+  "_cmd": "de v 1, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de d 15 1`] = `
+{
+  "_cmd": "de v 1, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de d v 1 1`] = `
+{
+  "_cmd": "de v 1, de d v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, de d v 2 1`] = `
+{
+  "_cmd": "de v 1, de d v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, de d v 3 1`] = `
+{
+  "_cmd": "de v 1, de d v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de d v 4 1`] = `
+{
+  "_cmd": "de v 1, de d v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de d v 5 1`] = `
+{
+  "_cmd": "de v 1, de d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de d v 6 1`] = `
+{
+  "_cmd": "de v 1, de d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de d v 7 1`] = `
+{
+  "_cmd": "de v 1, de d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de d v 8 1`] = `
+{
+  "_cmd": "de v 1, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de d v 9 1`] = `
+{
+  "_cmd": "de v 1, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de d v 10 1`] = `
+{
+  "_cmd": "de v 1, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de d v 11 1`] = `
+{
+  "_cmd": "de v 1, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de d v 12 1`] = `
+{
+  "_cmd": "de v 1, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de d v 13 1`] = `
+{
+  "_cmd": "de v 1, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de d v 14 1`] = `
+{
+  "_cmd": "de v 1, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de d v 15 1`] = `
+{
+  "_cmd": "de v 1, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de d v 16 1`] = `
+{
+  "_cmd": "de v 1, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 1, de d v 17 1`] = `
+{
+  "_cmd": "de v 1, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 1, de d v 18 1`] = `
+{
+  "_cmd": "de v 1, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 1, de d v 19 1`] = `
+{
+  "_cmd": "de v 1, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 1, de d v 20 1`] = `
+{
+  "_cmd": "de v 1, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 1, de p 1 1`] = `
+{
+  "_cmd": "de v 1, de p 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, de p 2 1`] = `
+{
+  "_cmd": "de v 1, de p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, de p 3 1`] = `
+{
+  "_cmd": "de v 1, de p 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de p 4 1`] = `
+{
+  "_cmd": "de v 1, de p 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de p 5 1`] = `
+{
+  "_cmd": "de v 1, de p 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de p 6 1`] = `
+{
+  "_cmd": "de v 1, de p 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de p 7 1`] = `
+{
+  "_cmd": "de v 1, de p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de p 8 1`] = `
+{
+  "_cmd": "de v 1, de p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de p 9 1`] = `
+{
+  "_cmd": "de v 1, de p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de p 10 1`] = `
+{
+  "_cmd": "de v 1, de p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de p 11 1`] = `
+{
+  "_cmd": "de v 1, de p 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de p 12 1`] = `
+{
+  "_cmd": "de v 1, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de p 13 1`] = `
+{
+  "_cmd": "de v 1, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de p 14 1`] = `
+{
+  "_cmd": "de v 1, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de p 15 1`] = `
+{
+  "_cmd": "de v 1, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de p v 1 1`] = `
+{
+  "_cmd": "de v 1, de p v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, de p v 2 1`] = `
+{
+  "_cmd": "de v 1, de p v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, de p v 3 1`] = `
+{
+  "_cmd": "de v 1, de p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, de p v 4 1`] = `
+{
+  "_cmd": "de v 1, de p v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de p v 5 1`] = `
+{
+  "_cmd": "de v 1, de p v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de p v 6 1`] = `
+{
+  "_cmd": "de v 1, de p v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de p v 7 1`] = `
+{
+  "_cmd": "de v 1, de p v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de p v 8 1`] = `
+{
+  "_cmd": "de v 1, de p v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de p v 9 1`] = `
+{
+  "_cmd": "de v 1, de p v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de p v 10 1`] = `
+{
+  "_cmd": "de v 1, de p v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de p v 11 1`] = `
+{
+  "_cmd": "de v 1, de p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de p v 12 1`] = `
+{
+  "_cmd": "de v 1, de p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de p v 13 1`] = `
+{
+  "_cmd": "de v 1, de p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de p v 14 1`] = `
+{
+  "_cmd": "de v 1, de p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de p v 15 1`] = `
+{
+  "_cmd": "de v 1, de p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de p v 16 1`] = `
+{
+  "_cmd": "de v 1, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 1, de p v 17 1`] = `
+{
+  "_cmd": "de v 1, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 1, de p v 18 1`] = `
+{
+  "_cmd": "de v 1, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 1, de p v 19 1`] = `
+{
+  "_cmd": "de v 1, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 1, de p v 20 1`] = `
+{
+  "_cmd": "de v 1, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 1, de v 1 1`] = `
+{
+  "_cmd": "de v 1, de v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, de v 2 1`] = `
+{
+  "_cmd": "de v 1, de v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, de v 3 1`] = `
+{
+  "_cmd": "de v 1, de v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de v 4 1`] = `
+{
+  "_cmd": "de v 1, de v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de v 5 1`] = `
+{
+  "_cmd": "de v 1, de v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de v 6 1`] = `
+{
+  "_cmd": "de v 1, de v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de v 7 1`] = `
+{
+  "_cmd": "de v 1, de v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de v 8 1`] = `
+{
+  "_cmd": "de v 1, de v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de v 9 1`] = `
+{
+  "_cmd": "de v 1, de v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de v 10 1`] = `
+{
+  "_cmd": "de v 1, de v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de v 11 1`] = `
+{
+  "_cmd": "de v 1, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de v 12 1`] = `
+{
+  "_cmd": "de v 1, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de v 13 1`] = `
+{
+  "_cmd": "de v 1, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de v 14 1`] = `
+{
+  "_cmd": "de v 1, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de v 15 1`] = `
+{
+  "_cmd": "de v 1, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de v 16 1`] = `
+{
+  "_cmd": "de v 1, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 1, de v 17 1`] = `
+{
+  "_cmd": "de v 1, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 1, de v 18 1`] = `
+{
+  "_cmd": "de v 1, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 1, de v 19 1`] = `
+{
+  "_cmd": "de v 1, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 1, de v 20 1`] = `
+{
+  "_cmd": "de v 1, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 1, de w 1 1`] = `
+{
+  "_cmd": "de v 1, de w 1",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, de w 2 1`] = `
+{
+  "_cmd": "de v 1, de w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, de w 3 1`] = `
+{
+  "_cmd": "de v 1, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de w 4 1`] = `
+{
+  "_cmd": "de v 1, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de w 5 1`] = `
+{
+  "_cmd": "de v 1, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de w 6 1`] = `
+{
+  "_cmd": "de v 1, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de w 7 1`] = `
+{
+  "_cmd": "de v 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de w 8 1`] = `
+{
+  "_cmd": "de v 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de w 9 1`] = `
+{
+  "_cmd": "de v 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de w 10 1`] = `
+{
+  "_cmd": "de v 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de w 11 1`] = `
+{
+  "_cmd": "de v 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de w 12 1`] = `
+{
+  "_cmd": "de v 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de w 13 1`] = `
+{
+  "_cmd": "de v 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de w 14 1`] = `
+{
+  "_cmd": "de v 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de w 15 1`] = `
+{
+  "_cmd": "de v 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de w v 1 1`] = `
+{
+  "_cmd": "de v 1, de w v 1",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, de w v 2 1`] = `
+{
+  "_cmd": "de v 1, de w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, de w v 3 1`] = `
+{
+  "_cmd": "de v 1, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, de w v 4 1`] = `
+{
+  "_cmd": "de v 1, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, de w v 5 1`] = `
+{
+  "_cmd": "de v 1, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, de w v 6 1`] = `
+{
+  "_cmd": "de v 1, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, de w v 7 1`] = `
+{
+  "_cmd": "de v 1, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, de w v 8 1`] = `
+{
+  "_cmd": "de v 1, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, de w v 9 1`] = `
+{
+  "_cmd": "de v 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, de w v 10 1`] = `
+{
+  "_cmd": "de v 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, de w v 11 1`] = `
+{
+  "_cmd": "de v 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, de w v 12 1`] = `
+{
+  "_cmd": "de v 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, de w v 13 1`] = `
+{
+  "_cmd": "de v 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, de w v 14 1`] = `
+{
+  "_cmd": "de v 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, de w v 15 1`] = `
+{
+  "_cmd": "de v 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, de w v 16 1`] = `
+{
+  "_cmd": "de v 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 1, de w v 17 1`] = `
+{
+  "_cmd": "de v 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 1, de w v 18 1`] = `
+{
+  "_cmd": "de v 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 1, de w v 19 1`] = `
+{
+  "_cmd": "de v 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 1, de w v 20 1`] = `
+{
+  "_cmd": "de v 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 2, de d 1 1`] = `
+{
+  "_cmd": "de v 2, de d 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, de d 2 1`] = `
+{
+  "_cmd": "de v 2, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, de d 3 1`] = `
+{
+  "_cmd": "de v 2, de d 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de d 4 1`] = `
+{
+  "_cmd": "de v 2, de d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de d 5 1`] = `
+{
+  "_cmd": "de v 2, de d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, de d 6 1`] = `
+{
+  "_cmd": "de v 2, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de d 7 1`] = `
+{
+  "_cmd": "de v 2, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de d 8 1`] = `
+{
+  "_cmd": "de v 2, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de d 9 1`] = `
+{
+  "_cmd": "de v 2, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de d 10 1`] = `
+{
+  "_cmd": "de v 2, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de d 11 1`] = `
+{
+  "_cmd": "de v 2, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de d 12 1`] = `
+{
+  "_cmd": "de v 2, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de d 13 1`] = `
+{
+  "_cmd": "de v 2, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de d 14 1`] = `
+{
+  "_cmd": "de v 2, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de d 15 1`] = `
+{
+  "_cmd": "de v 2, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de d v 1 1`] = `
+{
+  "_cmd": "de v 2, de d v 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, de d v 2 1`] = `
+{
+  "_cmd": "de v 2, de d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, de d v 3 1`] = `
+{
+  "_cmd": "de v 2, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de d v 4 1`] = `
+{
+  "_cmd": "de v 2, de d v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de d v 5 1`] = `
+{
+  "_cmd": "de v 2, de d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, de d v 6 1`] = `
+{
+  "_cmd": "de v 2, de d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de d v 7 1`] = `
+{
+  "_cmd": "de v 2, de d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de d v 8 1`] = `
+{
+  "_cmd": "de v 2, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de d v 9 1`] = `
+{
+  "_cmd": "de v 2, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de d v 10 1`] = `
+{
+  "_cmd": "de v 2, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de d v 11 1`] = `
+{
+  "_cmd": "de v 2, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de d v 12 1`] = `
+{
+  "_cmd": "de v 2, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de d v 13 1`] = `
+{
+  "_cmd": "de v 2, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de d v 14 1`] = `
+{
+  "_cmd": "de v 2, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de d v 15 1`] = `
+{
+  "_cmd": "de v 2, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de d v 16 1`] = `
+{
+  "_cmd": "de v 2, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 2, de d v 17 1`] = `
+{
+  "_cmd": "de v 2, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 2, de d v 18 1`] = `
+{
+  "_cmd": "de v 2, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 2, de d v 19 1`] = `
+{
+  "_cmd": "de v 2, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 2, de d v 20 1`] = `
+{
+  "_cmd": "de v 2, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 2, de p 1 1`] = `
+{
+  "_cmd": "de v 2, de p 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, de p 2 1`] = `
+{
+  "_cmd": "de v 2, de p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, de p 3 1`] = `
+{
+  "_cmd": "de v 2, de p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de p 4 1`] = `
+{
+  "_cmd": "de v 2, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de p 5 1`] = `
+{
+  "_cmd": "de v 2, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de p 6 1`] = `
+{
+  "_cmd": "de v 2, de p 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de p 7 1`] = `
+{
+  "_cmd": "de v 2, de p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de p 8 1`] = `
+{
+  "_cmd": "de v 2, de p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de p 9 1`] = `
+{
+  "_cmd": "de v 2, de p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de p 10 1`] = `
+{
+  "_cmd": "de v 2, de p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de p 11 1`] = `
+{
+  "_cmd": "de v 2, de p 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de p 12 1`] = `
+{
+  "_cmd": "de v 2, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de p 13 1`] = `
+{
+  "_cmd": "de v 2, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de p 14 1`] = `
+{
+  "_cmd": "de v 2, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de p 15 1`] = `
+{
+  "_cmd": "de v 2, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de p v 1 1`] = `
+{
+  "_cmd": "de v 2, de p v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, de p v 2 1`] = `
+{
+  "_cmd": "de v 2, de p v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, de p v 3 1`] = `
+{
+  "_cmd": "de v 2, de p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de p v 4 1`] = `
+{
+  "_cmd": "de v 2, de p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de p v 5 1`] = `
+{
+  "_cmd": "de v 2, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de p v 6 1`] = `
+{
+  "_cmd": "de v 2, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, de p v 7 1`] = `
+{
+  "_cmd": "de v 2, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de p v 8 1`] = `
+{
+  "_cmd": "de v 2, de p v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de p v 9 1`] = `
+{
+  "_cmd": "de v 2, de p v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de p v 10 1`] = `
+{
+  "_cmd": "de v 2, de p v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de p v 11 1`] = `
+{
+  "_cmd": "de v 2, de p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de p v 12 1`] = `
+{
+  "_cmd": "de v 2, de p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de p v 13 1`] = `
+{
+  "_cmd": "de v 2, de p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de p v 14 1`] = `
+{
+  "_cmd": "de v 2, de p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de p v 15 1`] = `
+{
+  "_cmd": "de v 2, de p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de p v 16 1`] = `
+{
+  "_cmd": "de v 2, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 2, de p v 17 1`] = `
+{
+  "_cmd": "de v 2, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 2, de p v 18 1`] = `
+{
+  "_cmd": "de v 2, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 2, de p v 19 1`] = `
+{
+  "_cmd": "de v 2, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 2, de p v 20 1`] = `
+{
+  "_cmd": "de v 2, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 2, de v 1 1`] = `
+{
+  "_cmd": "de v 2, de v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, de v 2 1`] = `
+{
+  "_cmd": "de v 2, de v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, de v 3 1`] = `
+{
+  "_cmd": "de v 2, de v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de v 4 1`] = `
+{
+  "_cmd": "de v 2, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de v 5 1`] = `
+{
+  "_cmd": "de v 2, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de v 6 1`] = `
+{
+  "_cmd": "de v 2, de v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de v 7 1`] = `
+{
+  "_cmd": "de v 2, de v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de v 8 1`] = `
+{
+  "_cmd": "de v 2, de v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de v 9 1`] = `
+{
+  "_cmd": "de v 2, de v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de v 10 1`] = `
+{
+  "_cmd": "de v 2, de v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de v 11 1`] = `
+{
+  "_cmd": "de v 2, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de v 12 1`] = `
+{
+  "_cmd": "de v 2, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de v 13 1`] = `
+{
+  "_cmd": "de v 2, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de v 14 1`] = `
+{
+  "_cmd": "de v 2, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de v 15 1`] = `
+{
+  "_cmd": "de v 2, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de v 16 1`] = `
+{
+  "_cmd": "de v 2, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 2, de v 17 1`] = `
+{
+  "_cmd": "de v 2, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 2, de v 18 1`] = `
+{
+  "_cmd": "de v 2, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 2, de v 19 1`] = `
+{
+  "_cmd": "de v 2, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 2, de v 20 1`] = `
+{
+  "_cmd": "de v 2, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 2, de w 1 1`] = `
+{
+  "_cmd": "de v 2, de w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, de w 2 1`] = `
+{
+  "_cmd": "de v 2, de w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de w 3 1`] = `
+{
+  "_cmd": "de v 2, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de w 4 1`] = `
+{
+  "_cmd": "de v 2, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de w 5 1`] = `
+{
+  "_cmd": "de v 2, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, de w 6 1`] = `
+{
+  "_cmd": "de v 2, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de w 7 1`] = `
+{
+  "_cmd": "de v 2, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de w 8 1`] = `
+{
+  "_cmd": "de v 2, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de w 9 1`] = `
+{
+  "_cmd": "de v 2, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de w 10 1`] = `
+{
+  "_cmd": "de v 2, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de w 11 1`] = `
+{
+  "_cmd": "de v 2, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de w 12 1`] = `
+{
+  "_cmd": "de v 2, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de w 13 1`] = `
+{
+  "_cmd": "de v 2, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de w 14 1`] = `
+{
+  "_cmd": "de v 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de w 15 1`] = `
+{
+  "_cmd": "de v 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de w v 1 1`] = `
+{
+  "_cmd": "de v 2, de w v 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, de w v 2 1`] = `
+{
+  "_cmd": "de v 2, de w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, de w v 3 1`] = `
+{
+  "_cmd": "de v 2, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, de w v 4 1`] = `
+{
+  "_cmd": "de v 2, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, de w v 5 1`] = `
+{
+  "_cmd": "de v 2, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, de w v 6 1`] = `
+{
+  "_cmd": "de v 2, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, de w v 7 1`] = `
+{
+  "_cmd": "de v 2, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, de w v 8 1`] = `
+{
+  "_cmd": "de v 2, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, de w v 9 1`] = `
+{
+  "_cmd": "de v 2, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, de w v 10 1`] = `
+{
+  "_cmd": "de v 2, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, de w v 11 1`] = `
+{
+  "_cmd": "de v 2, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, de w v 12 1`] = `
+{
+  "_cmd": "de v 2, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, de w v 13 1`] = `
+{
+  "_cmd": "de v 2, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, de w v 14 1`] = `
+{
+  "_cmd": "de v 2, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, de w v 15 1`] = `
+{
+  "_cmd": "de v 2, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, de w v 16 1`] = `
+{
+  "_cmd": "de v 2, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 2, de w v 17 1`] = `
+{
+  "_cmd": "de v 2, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 2, de w v 18 1`] = `
+{
+  "_cmd": "de v 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 2, de w v 19 1`] = `
+{
+  "_cmd": "de v 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 2, de w v 20 1`] = `
+{
+  "_cmd": "de v 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 3, de d 1 1`] = `
+{
+  "_cmd": "de v 3, de d 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, de d 2 1`] = `
+{
+  "_cmd": "de v 3, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, de d 3 1`] = `
+{
+  "_cmd": "de v 3, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de d 4 1`] = `
+{
+  "_cmd": "de v 3, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de d 5 1`] = `
+{
+  "_cmd": "de v 3, de d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de d 6 1`] = `
+{
+  "_cmd": "de v 3, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de d 7 1`] = `
+{
+  "_cmd": "de v 3, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de d 8 1`] = `
+{
+  "_cmd": "de v 3, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, de d 9 1`] = `
+{
+  "_cmd": "de v 3, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de d 10 1`] = `
+{
+  "_cmd": "de v 3, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de d 11 1`] = `
+{
+  "_cmd": "de v 3, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de d 12 1`] = `
+{
+  "_cmd": "de v 3, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de d 13 1`] = `
+{
+  "_cmd": "de v 3, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de d 14 1`] = `
+{
+  "_cmd": "de v 3, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de d 15 1`] = `
+{
+  "_cmd": "de v 3, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de d v 1 1`] = `
+{
+  "_cmd": "de v 3, de d v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, de d v 2 1`] = `
+{
+  "_cmd": "de v 3, de d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, de d v 3 1`] = `
+{
+  "_cmd": "de v 3, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de d v 4 1`] = `
+{
+  "_cmd": "de v 3, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de d v 5 1`] = `
+{
+  "_cmd": "de v 3, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de d v 6 1`] = `
+{
+  "_cmd": "de v 3, de d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de d v 7 1`] = `
+{
+  "_cmd": "de v 3, de d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de d v 8 1`] = `
+{
+  "_cmd": "de v 3, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, de d v 9 1`] = `
+{
+  "_cmd": "de v 3, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de d v 10 1`] = `
+{
+  "_cmd": "de v 3, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de d v 11 1`] = `
+{
+  "_cmd": "de v 3, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de d v 12 1`] = `
+{
+  "_cmd": "de v 3, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de d v 13 1`] = `
+{
+  "_cmd": "de v 3, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de d v 14 1`] = `
+{
+  "_cmd": "de v 3, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de d v 15 1`] = `
+{
+  "_cmd": "de v 3, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de d v 16 1`] = `
+{
+  "_cmd": "de v 3, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 3, de d v 17 1`] = `
+{
+  "_cmd": "de v 3, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 3, de d v 18 1`] = `
+{
+  "_cmd": "de v 3, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 3, de d v 19 1`] = `
+{
+  "_cmd": "de v 3, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 3, de d v 20 1`] = `
+{
+  "_cmd": "de v 3, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 3, de p 1 1`] = `
+{
+  "_cmd": "de v 3, de p 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, de p 2 1`] = `
+{
+  "_cmd": "de v 3, de p 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, de p 3 1`] = `
+{
+  "_cmd": "de v 3, de p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de p 4 1`] = `
+{
+  "_cmd": "de v 3, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de p 5 1`] = `
+{
+  "_cmd": "de v 3, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de p 6 1`] = `
+{
+  "_cmd": "de v 3, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de p 7 1`] = `
+{
+  "_cmd": "de v 3, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de p 8 1`] = `
+{
+  "_cmd": "de v 3, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de p 9 1`] = `
+{
+  "_cmd": "de v 3, de p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de p 10 1`] = `
+{
+  "_cmd": "de v 3, de p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de p 11 1`] = `
+{
+  "_cmd": "de v 3, de p 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de p 12 1`] = `
+{
+  "_cmd": "de v 3, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de p 13 1`] = `
+{
+  "_cmd": "de v 3, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de p 14 1`] = `
+{
+  "_cmd": "de v 3, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de p 15 1`] = `
+{
+  "_cmd": "de v 3, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de p v 1 1`] = `
+{
+  "_cmd": "de v 3, de p v 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de v 3, de p v 2 1`] = `
+{
+  "_cmd": "de v 3, de p v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, de p v 3 1`] = `
+{
+  "_cmd": "de v 3, de p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de p v 4 1`] = `
+{
+  "_cmd": "de v 3, de p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de p v 5 1`] = `
+{
+  "_cmd": "de v 3, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de p v 6 1`] = `
+{
+  "_cmd": "de v 3, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de p v 7 1`] = `
+{
+  "_cmd": "de v 3, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de p v 8 1`] = `
+{
+  "_cmd": "de v 3, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de p v 9 1`] = `
+{
+  "_cmd": "de v 3, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, de p v 10 1`] = `
+{
+  "_cmd": "de v 3, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de p v 11 1`] = `
+{
+  "_cmd": "de v 3, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de p v 12 1`] = `
+{
+  "_cmd": "de v 3, de p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de p v 13 1`] = `
+{
+  "_cmd": "de v 3, de p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de p v 14 1`] = `
+{
+  "_cmd": "de v 3, de p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de p v 15 1`] = `
+{
+  "_cmd": "de v 3, de p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de p v 16 1`] = `
+{
+  "_cmd": "de v 3, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 3, de p v 17 1`] = `
+{
+  "_cmd": "de v 3, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 3, de p v 18 1`] = `
+{
+  "_cmd": "de v 3, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 3, de p v 19 1`] = `
+{
+  "_cmd": "de v 3, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 3, de p v 20 1`] = `
+{
+  "_cmd": "de v 3, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 3, de v 1 1`] = `
+{
+  "_cmd": "de v 3, de v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, de v 2 1`] = `
+{
+  "_cmd": "de v 3, de v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, de v 3 1`] = `
+{
+  "_cmd": "de v 3, de v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de v 4 1`] = `
+{
+  "_cmd": "de v 3, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de v 5 1`] = `
+{
+  "_cmd": "de v 3, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de v 6 1`] = `
+{
+  "_cmd": "de v 3, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de v 7 1`] = `
+{
+  "_cmd": "de v 3, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de v 8 1`] = `
+{
+  "_cmd": "de v 3, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de v 9 1`] = `
+{
+  "_cmd": "de v 3, de v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de v 10 1`] = `
+{
+  "_cmd": "de v 3, de v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de v 11 1`] = `
+{
+  "_cmd": "de v 3, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de v 12 1`] = `
+{
+  "_cmd": "de v 3, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de v 13 1`] = `
+{
+  "_cmd": "de v 3, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de v 14 1`] = `
+{
+  "_cmd": "de v 3, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de v 15 1`] = `
+{
+  "_cmd": "de v 3, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de v 16 1`] = `
+{
+  "_cmd": "de v 3, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 3, de v 17 1`] = `
+{
+  "_cmd": "de v 3, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 3, de v 18 1`] = `
+{
+  "_cmd": "de v 3, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 3, de v 19 1`] = `
+{
+  "_cmd": "de v 3, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 3, de v 20 1`] = `
+{
+  "_cmd": "de v 3, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 3, de w 1 1`] = `
+{
+  "_cmd": "de v 3, de w 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, de w 2 1`] = `
+{
+  "_cmd": "de v 3, de w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, de w 3 1`] = `
+{
+  "_cmd": "de v 3, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de w 4 1`] = `
+{
+  "_cmd": "de v 3, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de w 5 1`] = `
+{
+  "_cmd": "de v 3, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de w 6 1`] = `
+{
+  "_cmd": "de v 3, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de w 7 1`] = `
+{
+  "_cmd": "de v 3, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de w 8 1`] = `
+{
+  "_cmd": "de v 3, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, de w 9 1`] = `
+{
+  "_cmd": "de v 3, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de w 10 1`] = `
+{
+  "_cmd": "de v 3, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de w 11 1`] = `
+{
+  "_cmd": "de v 3, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de w 12 1`] = `
+{
+  "_cmd": "de v 3, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de w 13 1`] = `
+{
+  "_cmd": "de v 3, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de w 14 1`] = `
+{
+  "_cmd": "de v 3, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de w 15 1`] = `
+{
+  "_cmd": "de v 3, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de w v 1 1`] = `
+{
+  "_cmd": "de v 3, de w v 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, de w v 2 1`] = `
+{
+  "_cmd": "de v 3, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, de w v 3 1`] = `
+{
+  "_cmd": "de v 3, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, de w v 4 1`] = `
+{
+  "_cmd": "de v 3, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, de w v 5 1`] = `
+{
+  "_cmd": "de v 3, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, de w v 6 1`] = `
+{
+  "_cmd": "de v 3, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, de w v 7 1`] = `
+{
+  "_cmd": "de v 3, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, de w v 8 1`] = `
+{
+  "_cmd": "de v 3, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, de w v 9 1`] = `
+{
+  "_cmd": "de v 3, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, de w v 10 1`] = `
+{
+  "_cmd": "de v 3, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, de w v 11 1`] = `
+{
+  "_cmd": "de v 3, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, de w v 12 1`] = `
+{
+  "_cmd": "de v 3, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, de w v 13 1`] = `
+{
+  "_cmd": "de v 3, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, de w v 14 1`] = `
+{
+  "_cmd": "de v 3, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, de w v 15 1`] = `
+{
+  "_cmd": "de v 3, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, de w v 16 1`] = `
+{
+  "_cmd": "de v 3, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 3, de w v 17 1`] = `
+{
+  "_cmd": "de v 3, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 3, de w v 18 1`] = `
+{
+  "_cmd": "de v 3, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 3, de w v 19 1`] = `
+{
+  "_cmd": "de v 3, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 3, de w v 20 1`] = `
+{
+  "_cmd": "de v 3, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 4, de d 1 1`] = `
+{
+  "_cmd": "de v 4, de d 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de v 4, de d 2 1`] = `
+{
+  "_cmd": "de v 4, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, de d 3 1`] = `
+{
+  "_cmd": "de v 4, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, de d 4 1`] = `
+{
+  "_cmd": "de v 4, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de d 5 1`] = `
+{
+  "_cmd": "de v 4, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de d 6 1`] = `
+{
+  "_cmd": "de v 4, de d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de d 7 1`] = `
+{
+  "_cmd": "de v 4, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de d 8 1`] = `
+{
+  "_cmd": "de v 4, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de d 9 1`] = `
+{
+  "_cmd": "de v 4, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de d 10 1`] = `
+{
+  "_cmd": "de v 4, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de d 11 1`] = `
+{
+  "_cmd": "de v 4, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de d 12 1`] = `
+{
+  "_cmd": "de v 4, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de d 13 1`] = `
+{
+  "_cmd": "de v 4, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de d 14 1`] = `
+{
+  "_cmd": "de v 4, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de d 15 1`] = `
+{
+  "_cmd": "de v 4, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de d v 1 1`] = `
+{
+  "_cmd": "de v 4, de d v 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de v 4, de d v 2 1`] = `
+{
+  "_cmd": "de v 4, de d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, de d v 3 1`] = `
+{
+  "_cmd": "de v 4, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, de d v 4 1`] = `
+{
+  "_cmd": "de v 4, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de d v 5 1`] = `
+{
+  "_cmd": "de v 4, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de d v 6 1`] = `
+{
+  "_cmd": "de v 4, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de d v 7 1`] = `
+{
+  "_cmd": "de v 4, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de d v 8 1`] = `
+{
+  "_cmd": "de v 4, de d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de d v 9 1`] = `
+{
+  "_cmd": "de v 4, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de d v 10 1`] = `
+{
+  "_cmd": "de v 4, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de d v 11 1`] = `
+{
+  "_cmd": "de v 4, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de d v 12 1`] = `
+{
+  "_cmd": "de v 4, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de d v 13 1`] = `
+{
+  "_cmd": "de v 4, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de d v 14 1`] = `
+{
+  "_cmd": "de v 4, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de d v 15 1`] = `
+{
+  "_cmd": "de v 4, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de d v 16 1`] = `
+{
+  "_cmd": "de v 4, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 4, de d v 17 1`] = `
+{
+  "_cmd": "de v 4, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 4, de d v 18 1`] = `
+{
+  "_cmd": "de v 4, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 4, de d v 19 1`] = `
+{
+  "_cmd": "de v 4, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 4, de d v 20 1`] = `
+{
+  "_cmd": "de v 4, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 4, de p 1 1`] = `
+{
+  "_cmd": "de v 4, de p 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, de p 2 1`] = `
+{
+  "_cmd": "de v 4, de p 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, de p 3 1`] = `
+{
+  "_cmd": "de v 4, de p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, de p 4 1`] = `
+{
+  "_cmd": "de v 4, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de p 5 1`] = `
+{
+  "_cmd": "de v 4, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de p 6 1`] = `
+{
+  "_cmd": "de v 4, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de p 7 1`] = `
+{
+  "_cmd": "de v 4, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de p 8 1`] = `
+{
+  "_cmd": "de v 4, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de p 9 1`] = `
+{
+  "_cmd": "de v 4, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de p 10 1`] = `
+{
+  "_cmd": "de v 4, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de p 11 1`] = `
+{
+  "_cmd": "de v 4, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de p 12 1`] = `
+{
+  "_cmd": "de v 4, de p 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de p 13 1`] = `
+{
+  "_cmd": "de v 4, de p 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de p 14 1`] = `
+{
+  "_cmd": "de v 4, de p 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de p 15 1`] = `
+{
+  "_cmd": "de v 4, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de p v 1 1`] = `
+{
+  "_cmd": "de v 4, de p v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, de p v 2 1`] = `
+{
+  "_cmd": "de v 4, de p v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, de p v 3 1`] = `
+{
+  "_cmd": "de v 4, de p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, de p v 4 1`] = `
+{
+  "_cmd": "de v 4, de p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de p v 5 1`] = `
+{
+  "_cmd": "de v 4, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de p v 6 1`] = `
+{
+  "_cmd": "de v 4, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de p v 7 1`] = `
+{
+  "_cmd": "de v 4, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de p v 8 1`] = `
+{
+  "_cmd": "de v 4, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de p v 9 1`] = `
+{
+  "_cmd": "de v 4, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de p v 10 1`] = `
+{
+  "_cmd": "de v 4, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de p v 11 1`] = `
+{
+  "_cmd": "de v 4, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de p v 12 1`] = `
+{
+  "_cmd": "de v 4, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de p v 13 1`] = `
+{
+  "_cmd": "de v 4, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de p v 14 1`] = `
+{
+  "_cmd": "de v 4, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de p v 15 1`] = `
+{
+  "_cmd": "de v 4, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de p v 16 1`] = `
+{
+  "_cmd": "de v 4, de p v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 4, de p v 17 1`] = `
+{
+  "_cmd": "de v 4, de p v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 4, de p v 18 1`] = `
+{
+  "_cmd": "de v 4, de p v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 4, de p v 19 1`] = `
+{
+  "_cmd": "de v 4, de p v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 4, de p v 20 1`] = `
+{
+  "_cmd": "de v 4, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 4, de v 1 1`] = `
+{
+  "_cmd": "de v 4, de v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, de v 2 1`] = `
+{
+  "_cmd": "de v 4, de v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, de v 3 1`] = `
+{
+  "_cmd": "de v 4, de v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, de v 4 1`] = `
+{
+  "_cmd": "de v 4, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de v 5 1`] = `
+{
+  "_cmd": "de v 4, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de v 6 1`] = `
+{
+  "_cmd": "de v 4, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de v 7 1`] = `
+{
+  "_cmd": "de v 4, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de v 8 1`] = `
+{
+  "_cmd": "de v 4, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de v 9 1`] = `
+{
+  "_cmd": "de v 4, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de v 10 1`] = `
+{
+  "_cmd": "de v 4, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de v 11 1`] = `
+{
+  "_cmd": "de v 4, de v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de v 12 1`] = `
+{
+  "_cmd": "de v 4, de v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de v 13 1`] = `
+{
+  "_cmd": "de v 4, de v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de v 14 1`] = `
+{
+  "_cmd": "de v 4, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de v 15 1`] = `
+{
+  "_cmd": "de v 4, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de v 16 1`] = `
+{
+  "_cmd": "de v 4, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 4, de v 17 1`] = `
+{
+  "_cmd": "de v 4, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 4, de v 18 1`] = `
+{
+  "_cmd": "de v 4, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 4, de v 19 1`] = `
+{
+  "_cmd": "de v 4, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 4, de v 20 1`] = `
+{
+  "_cmd": "de v 4, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 4, de w 1 1`] = `
+{
+  "_cmd": "de v 4, de w 1",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, de w 2 1`] = `
+{
+  "_cmd": "de v 4, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, de w 3 1`] = `
+{
+  "_cmd": "de v 4, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de w 4 1`] = `
+{
+  "_cmd": "de v 4, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de w 5 1`] = `
+{
+  "_cmd": "de v 4, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de w 6 1`] = `
+{
+  "_cmd": "de v 4, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de w 7 1`] = `
+{
+  "_cmd": "de v 4, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de w 8 1`] = `
+{
+  "_cmd": "de v 4, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de w 9 1`] = `
+{
+  "_cmd": "de v 4, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de w 10 1`] = `
+{
+  "_cmd": "de v 4, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de w 11 1`] = `
+{
+  "_cmd": "de v 4, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de w 12 1`] = `
+{
+  "_cmd": "de v 4, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de w 13 1`] = `
+{
+  "_cmd": "de v 4, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de w 14 1`] = `
+{
+  "_cmd": "de v 4, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de w 15 1`] = `
+{
+  "_cmd": "de v 4, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de w v 1 1`] = `
+{
+  "_cmd": "de v 4, de w v 1",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, de w v 2 1`] = `
+{
+  "_cmd": "de v 4, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, de w v 3 1`] = `
+{
+  "_cmd": "de v 4, de w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, de w v 4 1`] = `
+{
+  "_cmd": "de v 4, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, de w v 5 1`] = `
+{
+  "_cmd": "de v 4, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, de w v 6 1`] = `
+{
+  "_cmd": "de v 4, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, de w v 7 1`] = `
+{
+  "_cmd": "de v 4, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, de w v 8 1`] = `
+{
+  "_cmd": "de v 4, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, de w v 9 1`] = `
+{
+  "_cmd": "de v 4, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, de w v 10 1`] = `
+{
+  "_cmd": "de v 4, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, de w v 11 1`] = `
+{
+  "_cmd": "de v 4, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, de w v 12 1`] = `
+{
+  "_cmd": "de v 4, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, de w v 13 1`] = `
+{
+  "_cmd": "de v 4, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, de w v 14 1`] = `
+{
+  "_cmd": "de v 4, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, de w v 15 1`] = `
+{
+  "_cmd": "de v 4, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, de w v 16 1`] = `
+{
+  "_cmd": "de v 4, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 4, de w v 17 1`] = `
+{
+  "_cmd": "de v 4, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 4, de w v 18 1`] = `
+{
+  "_cmd": "de v 4, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 4, de w v 19 1`] = `
+{
+  "_cmd": "de v 4, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 4, de w v 20 1`] = `
+{
+  "_cmd": "de v 4, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 5, de d 1 1`] = `
+{
+  "_cmd": "de v 5, de d 1",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de v 5, de d 2 1`] = `
+{
+  "_cmd": "de v 5, de d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de d 3 1`] = `
+{
+  "_cmd": "de v 5, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, de d 4 1`] = `
+{
+  "_cmd": "de v 5, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, de d 5 1`] = `
+{
+  "_cmd": "de v 5, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de d 6 1`] = `
+{
+  "_cmd": "de v 5, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de d 7 1`] = `
+{
+  "_cmd": "de v 5, de d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de d 8 1`] = `
+{
+  "_cmd": "de v 5, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de d 9 1`] = `
+{
+  "_cmd": "de v 5, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de d 10 1`] = `
+{
+  "_cmd": "de v 5, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de d 11 1`] = `
+{
+  "_cmd": "de v 5, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de d 12 1`] = `
+{
+  "_cmd": "de v 5, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de d 13 1`] = `
+{
+  "_cmd": "de v 5, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de d 14 1`] = `
+{
+  "_cmd": "de v 5, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de d 15 1`] = `
+{
+  "_cmd": "de v 5, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de d v 1 1`] = `
+{
+  "_cmd": "de v 5, de d v 1",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de v 5, de d v 2 1`] = `
+{
+  "_cmd": "de v 5, de d v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de d v 3 1`] = `
+{
+  "_cmd": "de v 5, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, de d v 4 1`] = `
+{
+  "_cmd": "de v 5, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, de d v 5 1`] = `
+{
+  "_cmd": "de v 5, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de d v 6 1`] = `
+{
+  "_cmd": "de v 5, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de d v 7 1`] = `
+{
+  "_cmd": "de v 5, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de d v 8 1`] = `
+{
+  "_cmd": "de v 5, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de d v 9 1`] = `
+{
+  "_cmd": "de v 5, de d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de d v 10 1`] = `
+{
+  "_cmd": "de v 5, de d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de d v 11 1`] = `
+{
+  "_cmd": "de v 5, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de d v 12 1`] = `
+{
+  "_cmd": "de v 5, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de d v 13 1`] = `
+{
+  "_cmd": "de v 5, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de d v 14 1`] = `
+{
+  "_cmd": "de v 5, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de d v 15 1`] = `
+{
+  "_cmd": "de v 5, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de d v 16 1`] = `
+{
+  "_cmd": "de v 5, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 5, de d v 17 1`] = `
+{
+  "_cmd": "de v 5, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 5, de d v 18 1`] = `
+{
+  "_cmd": "de v 5, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 5, de d v 19 1`] = `
+{
+  "_cmd": "de v 5, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 5, de d v 20 1`] = `
+{
+  "_cmd": "de v 5, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 5, de p 1 1`] = `
+{
+  "_cmd": "de v 5, de p 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, de p 2 1`] = `
+{
+  "_cmd": "de v 5, de p 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de p 3 1`] = `
+{
+  "_cmd": "de v 5, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de p 4 1`] = `
+{
+  "_cmd": "de v 5, de p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, de p 5 1`] = `
+{
+  "_cmd": "de v 5, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de p 6 1`] = `
+{
+  "_cmd": "de v 5, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de p 7 1`] = `
+{
+  "_cmd": "de v 5, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de p 8 1`] = `
+{
+  "_cmd": "de v 5, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de p 9 1`] = `
+{
+  "_cmd": "de v 5, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de p 10 1`] = `
+{
+  "_cmd": "de v 5, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de p 11 1`] = `
+{
+  "_cmd": "de v 5, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de p 12 1`] = `
+{
+  "_cmd": "de v 5, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de p 13 1`] = `
+{
+  "_cmd": "de v 5, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de p 14 1`] = `
+{
+  "_cmd": "de v 5, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de p 15 1`] = `
+{
+  "_cmd": "de v 5, de p 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de p v 1 1`] = `
+{
+  "_cmd": "de v 5, de p v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, de p v 2 1`] = `
+{
+  "_cmd": "de v 5, de p v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de p v 3 1`] = `
+{
+  "_cmd": "de v 5, de p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de p v 4 1`] = `
+{
+  "_cmd": "de v 5, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, de p v 5 1`] = `
+{
+  "_cmd": "de v 5, de p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de p v 6 1`] = `
+{
+  "_cmd": "de v 5, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de p v 7 1`] = `
+{
+  "_cmd": "de v 5, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de p v 8 1`] = `
+{
+  "_cmd": "de v 5, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de p v 9 1`] = `
+{
+  "_cmd": "de v 5, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de p v 10 1`] = `
+{
+  "_cmd": "de v 5, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de p v 11 1`] = `
+{
+  "_cmd": "de v 5, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de p v 12 1`] = `
+{
+  "_cmd": "de v 5, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de p v 13 1`] = `
+{
+  "_cmd": "de v 5, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de p v 14 1`] = `
+{
+  "_cmd": "de v 5, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de p v 15 1`] = `
+{
+  "_cmd": "de v 5, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de p v 16 1`] = `
+{
+  "_cmd": "de v 5, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de p v 17 1`] = `
+{
+  "_cmd": "de v 5, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 5, de p v 18 1`] = `
+{
+  "_cmd": "de v 5, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 5, de p v 19 1`] = `
+{
+  "_cmd": "de v 5, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 5, de p v 20 1`] = `
+{
+  "_cmd": "de v 5, de p v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 5, de v 1 1`] = `
+{
+  "_cmd": "de v 5, de v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, de v 2 1`] = `
+{
+  "_cmd": "de v 5, de v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de v 3 1`] = `
+{
+  "_cmd": "de v 5, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de v 4 1`] = `
+{
+  "_cmd": "de v 5, de v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, de v 5 1`] = `
+{
+  "_cmd": "de v 5, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de v 6 1`] = `
+{
+  "_cmd": "de v 5, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de v 7 1`] = `
+{
+  "_cmd": "de v 5, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de v 8 1`] = `
+{
+  "_cmd": "de v 5, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de v 9 1`] = `
+{
+  "_cmd": "de v 5, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de v 10 1`] = `
+{
+  "_cmd": "de v 5, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de v 11 1`] = `
+{
+  "_cmd": "de v 5, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de v 12 1`] = `
+{
+  "_cmd": "de v 5, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de v 13 1`] = `
+{
+  "_cmd": "de v 5, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de v 14 1`] = `
+{
+  "_cmd": "de v 5, de v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de v 15 1`] = `
+{
+  "_cmd": "de v 5, de v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de v 16 1`] = `
+{
+  "_cmd": "de v 5, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 5, de v 17 1`] = `
+{
+  "_cmd": "de v 5, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 5, de v 18 1`] = `
+{
+  "_cmd": "de v 5, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 5, de v 19 1`] = `
+{
+  "_cmd": "de v 5, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 5, de v 20 1`] = `
+{
+  "_cmd": "de v 5, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 5, de w 1 1`] = `
+{
+  "_cmd": "de v 5, de w 1",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de w 2 1`] = `
+{
+  "_cmd": "de v 5, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de w 3 1`] = `
+{
+  "_cmd": "de v 5, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, de w 4 1`] = `
+{
+  "_cmd": "de v 5, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de w 5 1`] = `
+{
+  "_cmd": "de v 5, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de w 6 1`] = `
+{
+  "_cmd": "de v 5, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de w 7 1`] = `
+{
+  "_cmd": "de v 5, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de w 8 1`] = `
+{
+  "_cmd": "de v 5, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de w 9 1`] = `
+{
+  "_cmd": "de v 5, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de w 10 1`] = `
+{
+  "_cmd": "de v 5, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de w 11 1`] = `
+{
+  "_cmd": "de v 5, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de w 12 1`] = `
+{
+  "_cmd": "de v 5, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de w 13 1`] = `
+{
+  "_cmd": "de v 5, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de w 14 1`] = `
+{
+  "_cmd": "de v 5, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de w 15 1`] = `
+{
+  "_cmd": "de v 5, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de w v 1 1`] = `
+{
+  "_cmd": "de v 5, de w v 1",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, de w v 2 1`] = `
+{
+  "_cmd": "de v 5, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, de w v 3 1`] = `
+{
+  "_cmd": "de v 5, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, de w v 4 1`] = `
+{
+  "_cmd": "de v 5, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, de w v 5 1`] = `
+{
+  "_cmd": "de v 5, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, de w v 6 1`] = `
+{
+  "_cmd": "de v 5, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, de w v 7 1`] = `
+{
+  "_cmd": "de v 5, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, de w v 8 1`] = `
+{
+  "_cmd": "de v 5, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, de w v 9 1`] = `
+{
+  "_cmd": "de v 5, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, de w v 10 1`] = `
+{
+  "_cmd": "de v 5, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, de w v 11 1`] = `
+{
+  "_cmd": "de v 5, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, de w v 12 1`] = `
+{
+  "_cmd": "de v 5, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, de w v 13 1`] = `
+{
+  "_cmd": "de v 5, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, de w v 14 1`] = `
+{
+  "_cmd": "de v 5, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, de w v 15 1`] = `
+{
+  "_cmd": "de v 5, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, de w v 16 1`] = `
+{
+  "_cmd": "de v 5, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 5, de w v 17 1`] = `
+{
+  "_cmd": "de v 5, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 5, de w v 18 1`] = `
+{
+  "_cmd": "de v 5, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 5, de w v 19 1`] = `
+{
+  "_cmd": "de v 5, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 5, de w v 20 1`] = `
+{
+  "_cmd": "de v 5, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 6, de d 1 1`] = `
+{
+  "_cmd": "de v 6, de d 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, de d 2 1`] = `
+{
+  "_cmd": "de v 6, de d 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, de d 3 1`] = `
+{
+  "_cmd": "de v 6, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de d 4 1`] = `
+{
+  "_cmd": "de v 6, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, de d 5 1`] = `
+{
+  "_cmd": "de v 6, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, de d 6 1`] = `
+{
+  "_cmd": "de v 6, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de d 7 1`] = `
+{
+  "_cmd": "de v 6, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de d 8 1`] = `
+{
+  "_cmd": "de v 6, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de d 9 1`] = `
+{
+  "_cmd": "de v 6, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de d 10 1`] = `
+{
+  "_cmd": "de v 6, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de d 11 1`] = `
+{
+  "_cmd": "de v 6, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de d 12 1`] = `
+{
+  "_cmd": "de v 6, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de d 13 1`] = `
+{
+  "_cmd": "de v 6, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de d 14 1`] = `
+{
+  "_cmd": "de v 6, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de d 15 1`] = `
+{
+  "_cmd": "de v 6, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de d v 1 1`] = `
+{
+  "_cmd": "de v 6, de d v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, de d v 2 1`] = `
+{
+  "_cmd": "de v 6, de d v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, de d v 3 1`] = `
+{
+  "_cmd": "de v 6, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de d v 4 1`] = `
+{
+  "_cmd": "de v 6, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, de d v 5 1`] = `
+{
+  "_cmd": "de v 6, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, de d v 6 1`] = `
+{
+  "_cmd": "de v 6, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de d v 7 1`] = `
+{
+  "_cmd": "de v 6, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de d v 8 1`] = `
+{
+  "_cmd": "de v 6, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de d v 9 1`] = `
+{
+  "_cmd": "de v 6, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de d v 10 1`] = `
+{
+  "_cmd": "de v 6, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de d v 11 1`] = `
+{
+  "_cmd": "de v 6, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de d v 12 1`] = `
+{
+  "_cmd": "de v 6, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de d v 13 1`] = `
+{
+  "_cmd": "de v 6, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de d v 14 1`] = `
+{
+  "_cmd": "de v 6, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de d v 15 1`] = `
+{
+  "_cmd": "de v 6, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de d v 16 1`] = `
+{
+  "_cmd": "de v 6, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 6, de d v 17 1`] = `
+{
+  "_cmd": "de v 6, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 6, de d v 18 1`] = `
+{
+  "_cmd": "de v 6, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 6, de d v 19 1`] = `
+{
+  "_cmd": "de v 6, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 6, de d v 20 1`] = `
+{
+  "_cmd": "de v 6, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 6, de p 1 1`] = `
+{
+  "_cmd": "de v 6, de p 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, de p 2 1`] = `
+{
+  "_cmd": "de v 6, de p 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, de p 3 1`] = `
+{
+  "_cmd": "de v 6, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, de p 4 1`] = `
+{
+  "_cmd": "de v 6, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de p 5 1`] = `
+{
+  "_cmd": "de v 6, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, de p 6 1`] = `
+{
+  "_cmd": "de v 6, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de p 7 1`] = `
+{
+  "_cmd": "de v 6, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de p 8 1`] = `
+{
+  "_cmd": "de v 6, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de p 9 1`] = `
+{
+  "_cmd": "de v 6, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de p 10 1`] = `
+{
+  "_cmd": "de v 6, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de p 11 1`] = `
+{
+  "_cmd": "de v 6, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de p 12 1`] = `
+{
+  "_cmd": "de v 6, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de p 13 1`] = `
+{
+  "_cmd": "de v 6, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de p 14 1`] = `
+{
+  "_cmd": "de v 6, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de p 15 1`] = `
+{
+  "_cmd": "de v 6, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de p v 1 1`] = `
+{
+  "_cmd": "de v 6, de p v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, de p v 2 1`] = `
+{
+  "_cmd": "de v 6, de p v 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, de p v 3 1`] = `
+{
+  "_cmd": "de v 6, de p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, de p v 4 1`] = `
+{
+  "_cmd": "de v 6, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de p v 5 1`] = `
+{
+  "_cmd": "de v 6, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, de p v 6 1`] = `
+{
+  "_cmd": "de v 6, de p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de p v 7 1`] = `
+{
+  "_cmd": "de v 6, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de p v 8 1`] = `
+{
+  "_cmd": "de v 6, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de p v 9 1`] = `
+{
+  "_cmd": "de v 6, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de p v 10 1`] = `
+{
+  "_cmd": "de v 6, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de p v 11 1`] = `
+{
+  "_cmd": "de v 6, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de p v 12 1`] = `
+{
+  "_cmd": "de v 6, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de p v 13 1`] = `
+{
+  "_cmd": "de v 6, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de p v 14 1`] = `
+{
+  "_cmd": "de v 6, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de p v 15 1`] = `
+{
+  "_cmd": "de v 6, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de p v 16 1`] = `
+{
+  "_cmd": "de v 6, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de p v 17 1`] = `
+{
+  "_cmd": "de v 6, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 6, de p v 18 1`] = `
+{
+  "_cmd": "de v 6, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 6, de p v 19 1`] = `
+{
+  "_cmd": "de v 6, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 6, de p v 20 1`] = `
+{
+  "_cmd": "de v 6, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 6, de v 1 1`] = `
+{
+  "_cmd": "de v 6, de v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, de v 2 1`] = `
+{
+  "_cmd": "de v 6, de v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, de v 3 1`] = `
+{
+  "_cmd": "de v 6, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, de v 4 1`] = `
+{
+  "_cmd": "de v 6, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de v 5 1`] = `
+{
+  "_cmd": "de v 6, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, de v 6 1`] = `
+{
+  "_cmd": "de v 6, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de v 7 1`] = `
+{
+  "_cmd": "de v 6, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de v 8 1`] = `
+{
+  "_cmd": "de v 6, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de v 9 1`] = `
+{
+  "_cmd": "de v 6, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de v 10 1`] = `
+{
+  "_cmd": "de v 6, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de v 11 1`] = `
+{
+  "_cmd": "de v 6, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de v 12 1`] = `
+{
+  "_cmd": "de v 6, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de v 13 1`] = `
+{
+  "_cmd": "de v 6, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de v 14 1`] = `
+{
+  "_cmd": "de v 6, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de v 15 1`] = `
+{
+  "_cmd": "de v 6, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de v 16 1`] = `
+{
+  "_cmd": "de v 6, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de v 17 1`] = `
+{
+  "_cmd": "de v 6, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 6, de v 18 1`] = `
+{
+  "_cmd": "de v 6, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 6, de v 19 1`] = `
+{
+  "_cmd": "de v 6, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 6, de v 20 1`] = `
+{
+  "_cmd": "de v 6, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 6, de w 1 1`] = `
+{
+  "_cmd": "de v 6, de w 1",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, de w 2 1`] = `
+{
+  "_cmd": "de v 6, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, de w 3 1`] = `
+{
+  "_cmd": "de v 6, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de w 4 1`] = `
+{
+  "_cmd": "de v 6, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, de w 5 1`] = `
+{
+  "_cmd": "de v 6, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de w 6 1`] = `
+{
+  "_cmd": "de v 6, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de w 7 1`] = `
+{
+  "_cmd": "de v 6, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de w 8 1`] = `
+{
+  "_cmd": "de v 6, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de w 9 1`] = `
+{
+  "_cmd": "de v 6, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de w 10 1`] = `
+{
+  "_cmd": "de v 6, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de w 11 1`] = `
+{
+  "_cmd": "de v 6, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de w 12 1`] = `
+{
+  "_cmd": "de v 6, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de w 13 1`] = `
+{
+  "_cmd": "de v 6, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de w 14 1`] = `
+{
+  "_cmd": "de v 6, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de w 15 1`] = `
+{
+  "_cmd": "de v 6, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de w v 1 1`] = `
+{
+  "_cmd": "de v 6, de w v 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, de w v 2 1`] = `
+{
+  "_cmd": "de v 6, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, de w v 3 1`] = `
+{
+  "_cmd": "de v 6, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, de w v 4 1`] = `
+{
+  "_cmd": "de v 6, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, de w v 5 1`] = `
+{
+  "_cmd": "de v 6, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, de w v 6 1`] = `
+{
+  "_cmd": "de v 6, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, de w v 7 1`] = `
+{
+  "_cmd": "de v 6, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, de w v 8 1`] = `
+{
+  "_cmd": "de v 6, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, de w v 9 1`] = `
+{
+  "_cmd": "de v 6, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, de w v 10 1`] = `
+{
+  "_cmd": "de v 6, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, de w v 11 1`] = `
+{
+  "_cmd": "de v 6, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, de w v 12 1`] = `
+{
+  "_cmd": "de v 6, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, de w v 13 1`] = `
+{
+  "_cmd": "de v 6, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, de w v 14 1`] = `
+{
+  "_cmd": "de v 6, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, de w v 15 1`] = `
+{
+  "_cmd": "de v 6, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, de w v 16 1`] = `
+{
+  "_cmd": "de v 6, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 6, de w v 17 1`] = `
+{
+  "_cmd": "de v 6, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 6, de w v 18 1`] = `
+{
+  "_cmd": "de v 6, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 6, de w v 19 1`] = `
+{
+  "_cmd": "de v 6, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 6, de w v 20 1`] = `
+{
+  "_cmd": "de v 6, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 7, de d 1 1`] = `
+{
+  "_cmd": "de v 7, de d 1",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, de d 2 1`] = `
+{
+  "_cmd": "de v 7, de d 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, de d 3 1`] = `
+{
+  "_cmd": "de v 7, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de d 4 1`] = `
+{
+  "_cmd": "de v 7, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, de d 5 1`] = `
+{
+  "_cmd": "de v 7, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, de d 6 1`] = `
+{
+  "_cmd": "de v 7, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de d 7 1`] = `
+{
+  "_cmd": "de v 7, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de d 8 1`] = `
+{
+  "_cmd": "de v 7, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de d 9 1`] = `
+{
+  "_cmd": "de v 7, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de d 10 1`] = `
+{
+  "_cmd": "de v 7, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de d 11 1`] = `
+{
+  "_cmd": "de v 7, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de d 12 1`] = `
+{
+  "_cmd": "de v 7, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de d 13 1`] = `
+{
+  "_cmd": "de v 7, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de d 14 1`] = `
+{
+  "_cmd": "de v 7, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de d 15 1`] = `
+{
+  "_cmd": "de v 7, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de d v 1 1`] = `
+{
+  "_cmd": "de v 7, de d v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, de d v 2 1`] = `
+{
+  "_cmd": "de v 7, de d v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, de d v 3 1`] = `
+{
+  "_cmd": "de v 7, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de d v 4 1`] = `
+{
+  "_cmd": "de v 7, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, de d v 5 1`] = `
+{
+  "_cmd": "de v 7, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, de d v 6 1`] = `
+{
+  "_cmd": "de v 7, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de d v 7 1`] = `
+{
+  "_cmd": "de v 7, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de d v 8 1`] = `
+{
+  "_cmd": "de v 7, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de d v 9 1`] = `
+{
+  "_cmd": "de v 7, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de d v 10 1`] = `
+{
+  "_cmd": "de v 7, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de d v 11 1`] = `
+{
+  "_cmd": "de v 7, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de d v 12 1`] = `
+{
+  "_cmd": "de v 7, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de d v 13 1`] = `
+{
+  "_cmd": "de v 7, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de d v 14 1`] = `
+{
+  "_cmd": "de v 7, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de d v 15 1`] = `
+{
+  "_cmd": "de v 7, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de d v 16 1`] = `
+{
+  "_cmd": "de v 7, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 7, de d v 17 1`] = `
+{
+  "_cmd": "de v 7, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 7, de d v 18 1`] = `
+{
+  "_cmd": "de v 7, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 7, de d v 19 1`] = `
+{
+  "_cmd": "de v 7, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 7, de d v 20 1`] = `
+{
+  "_cmd": "de v 7, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 7, de p 1 1`] = `
+{
+  "_cmd": "de v 7, de p 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, de p 2 1`] = `
+{
+  "_cmd": "de v 7, de p 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, de p 3 1`] = `
+{
+  "_cmd": "de v 7, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de p 4 1`] = `
+{
+  "_cmd": "de v 7, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de p 5 1`] = `
+{
+  "_cmd": "de v 7, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, de p 6 1`] = `
+{
+  "_cmd": "de v 7, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de p 7 1`] = `
+{
+  "_cmd": "de v 7, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de p 8 1`] = `
+{
+  "_cmd": "de v 7, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de p 9 1`] = `
+{
+  "_cmd": "de v 7, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de p 10 1`] = `
+{
+  "_cmd": "de v 7, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de p 11 1`] = `
+{
+  "_cmd": "de v 7, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de p 12 1`] = `
+{
+  "_cmd": "de v 7, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de p 13 1`] = `
+{
+  "_cmd": "de v 7, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de p 14 1`] = `
+{
+  "_cmd": "de v 7, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de p 15 1`] = `
+{
+  "_cmd": "de v 7, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de p v 1 1`] = `
+{
+  "_cmd": "de v 7, de p v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, de p v 2 1`] = `
+{
+  "_cmd": "de v 7, de p v 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, de p v 3 1`] = `
+{
+  "_cmd": "de v 7, de p v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de p v 4 1`] = `
+{
+  "_cmd": "de v 7, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de p v 5 1`] = `
+{
+  "_cmd": "de v 7, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, de p v 6 1`] = `
+{
+  "_cmd": "de v 7, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, de p v 7 1`] = `
+{
+  "_cmd": "de v 7, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de p v 8 1`] = `
+{
+  "_cmd": "de v 7, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de p v 9 1`] = `
+{
+  "_cmd": "de v 7, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de p v 10 1`] = `
+{
+  "_cmd": "de v 7, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de p v 11 1`] = `
+{
+  "_cmd": "de v 7, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de p v 12 1`] = `
+{
+  "_cmd": "de v 7, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de p v 13 1`] = `
+{
+  "_cmd": "de v 7, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de p v 14 1`] = `
+{
+  "_cmd": "de v 7, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de p v 15 1`] = `
+{
+  "_cmd": "de v 7, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de p v 16 1`] = `
+{
+  "_cmd": "de v 7, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de p v 17 1`] = `
+{
+  "_cmd": "de v 7, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 7, de p v 18 1`] = `
+{
+  "_cmd": "de v 7, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 7, de p v 19 1`] = `
+{
+  "_cmd": "de v 7, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 7, de p v 20 1`] = `
+{
+  "_cmd": "de v 7, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 7, de v 1 1`] = `
+{
+  "_cmd": "de v 7, de v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, de v 2 1`] = `
+{
+  "_cmd": "de v 7, de v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, de v 3 1`] = `
+{
+  "_cmd": "de v 7, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de v 4 1`] = `
+{
+  "_cmd": "de v 7, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de v 5 1`] = `
+{
+  "_cmd": "de v 7, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, de v 6 1`] = `
+{
+  "_cmd": "de v 7, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de v 7 1`] = `
+{
+  "_cmd": "de v 7, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de v 8 1`] = `
+{
+  "_cmd": "de v 7, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de v 9 1`] = `
+{
+  "_cmd": "de v 7, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de v 10 1`] = `
+{
+  "_cmd": "de v 7, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de v 11 1`] = `
+{
+  "_cmd": "de v 7, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de v 12 1`] = `
+{
+  "_cmd": "de v 7, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de v 13 1`] = `
+{
+  "_cmd": "de v 7, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de v 14 1`] = `
+{
+  "_cmd": "de v 7, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de v 15 1`] = `
+{
+  "_cmd": "de v 7, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de v 16 1`] = `
+{
+  "_cmd": "de v 7, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de v 17 1`] = `
+{
+  "_cmd": "de v 7, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 7, de v 18 1`] = `
+{
+  "_cmd": "de v 7, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 7, de v 19 1`] = `
+{
+  "_cmd": "de v 7, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 7, de v 20 1`] = `
+{
+  "_cmd": "de v 7, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 7, de w 1 1`] = `
+{
+  "_cmd": "de v 7, de w 1",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, de w 2 1`] = `
+{
+  "_cmd": "de v 7, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de w 3 1`] = `
+{
+  "_cmd": "de v 7, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de w 4 1`] = `
+{
+  "_cmd": "de v 7, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, de w 5 1`] = `
+{
+  "_cmd": "de v 7, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de w 6 1`] = `
+{
+  "_cmd": "de v 7, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de w 7 1`] = `
+{
+  "_cmd": "de v 7, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de w 8 1`] = `
+{
+  "_cmd": "de v 7, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de w 9 1`] = `
+{
+  "_cmd": "de v 7, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de w 10 1`] = `
+{
+  "_cmd": "de v 7, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de w 11 1`] = `
+{
+  "_cmd": "de v 7, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de w 12 1`] = `
+{
+  "_cmd": "de v 7, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de w 13 1`] = `
+{
+  "_cmd": "de v 7, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de w 14 1`] = `
+{
+  "_cmd": "de v 7, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de w 15 1`] = `
+{
+  "_cmd": "de v 7, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de w v 1 1`] = `
+{
+  "_cmd": "de v 7, de w v 1",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, de w v 2 1`] = `
+{
+  "_cmd": "de v 7, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, de w v 3 1`] = `
+{
+  "_cmd": "de v 7, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, de w v 4 1`] = `
+{
+  "_cmd": "de v 7, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, de w v 5 1`] = `
+{
+  "_cmd": "de v 7, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, de w v 6 1`] = `
+{
+  "_cmd": "de v 7, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, de w v 7 1`] = `
+{
+  "_cmd": "de v 7, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, de w v 8 1`] = `
+{
+  "_cmd": "de v 7, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, de w v 9 1`] = `
+{
+  "_cmd": "de v 7, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, de w v 10 1`] = `
+{
+  "_cmd": "de v 7, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, de w v 11 1`] = `
+{
+  "_cmd": "de v 7, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, de w v 12 1`] = `
+{
+  "_cmd": "de v 7, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, de w v 13 1`] = `
+{
+  "_cmd": "de v 7, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, de w v 14 1`] = `
+{
+  "_cmd": "de v 7, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, de w v 15 1`] = `
+{
+  "_cmd": "de v 7, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, de w v 16 1`] = `
+{
+  "_cmd": "de v 7, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 7, de w v 17 1`] = `
+{
+  "_cmd": "de v 7, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 7, de w v 18 1`] = `
+{
+  "_cmd": "de v 7, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 7, de w v 19 1`] = `
+{
+  "_cmd": "de v 7, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 7, de w v 20 1`] = `
+{
+  "_cmd": "de v 7, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 8, de d 1 1`] = `
+{
+  "_cmd": "de v 8, de d 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, de d 2 1`] = `
+{
+  "_cmd": "de v 8, de d 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, de d 3 1`] = `
+{
+  "_cmd": "de v 8, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de d 4 1`] = `
+{
+  "_cmd": "de v 8, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de d 5 1`] = `
+{
+  "_cmd": "de v 8, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, de d 6 1`] = `
+{
+  "_cmd": "de v 8, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de d 7 1`] = `
+{
+  "_cmd": "de v 8, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de d 8 1`] = `
+{
+  "_cmd": "de v 8, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de d 9 1`] = `
+{
+  "_cmd": "de v 8, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de d 10 1`] = `
+{
+  "_cmd": "de v 8, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de d 11 1`] = `
+{
+  "_cmd": "de v 8, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de d 12 1`] = `
+{
+  "_cmd": "de v 8, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de d 13 1`] = `
+{
+  "_cmd": "de v 8, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de d 14 1`] = `
+{
+  "_cmd": "de v 8, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de d 15 1`] = `
+{
+  "_cmd": "de v 8, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de d v 1 1`] = `
+{
+  "_cmd": "de v 8, de d v 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, de d v 2 1`] = `
+{
+  "_cmd": "de v 8, de d v 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, de d v 3 1`] = `
+{
+  "_cmd": "de v 8, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, de d v 4 1`] = `
+{
+  "_cmd": "de v 8, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de d v 5 1`] = `
+{
+  "_cmd": "de v 8, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, de d v 6 1`] = `
+{
+  "_cmd": "de v 8, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de d v 7 1`] = `
+{
+  "_cmd": "de v 8, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de d v 8 1`] = `
+{
+  "_cmd": "de v 8, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de d v 9 1`] = `
+{
+  "_cmd": "de v 8, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de d v 10 1`] = `
+{
+  "_cmd": "de v 8, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de d v 11 1`] = `
+{
+  "_cmd": "de v 8, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de d v 12 1`] = `
+{
+  "_cmd": "de v 8, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de d v 13 1`] = `
+{
+  "_cmd": "de v 8, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de d v 14 1`] = `
+{
+  "_cmd": "de v 8, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de d v 15 1`] = `
+{
+  "_cmd": "de v 8, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de d v 16 1`] = `
+{
+  "_cmd": "de v 8, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 8, de d v 17 1`] = `
+{
+  "_cmd": "de v 8, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 8, de d v 18 1`] = `
+{
+  "_cmd": "de v 8, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 8, de d v 19 1`] = `
+{
+  "_cmd": "de v 8, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 8, de d v 20 1`] = `
+{
+  "_cmd": "de v 8, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 8, de p 1 1`] = `
+{
+  "_cmd": "de v 8, de p 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, de p 2 1`] = `
+{
+  "_cmd": "de v 8, de p 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, de p 3 1`] = `
+{
+  "_cmd": "de v 8, de p 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, de p 4 1`] = `
+{
+  "_cmd": "de v 8, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de p 5 1`] = `
+{
+  "_cmd": "de v 8, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de p 6 1`] = `
+{
+  "_cmd": "de v 8, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de p 7 1`] = `
+{
+  "_cmd": "de v 8, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de p 8 1`] = `
+{
+  "_cmd": "de v 8, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de p 9 1`] = `
+{
+  "_cmd": "de v 8, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de p 10 1`] = `
+{
+  "_cmd": "de v 8, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de p 11 1`] = `
+{
+  "_cmd": "de v 8, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de p 12 1`] = `
+{
+  "_cmd": "de v 8, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de p 13 1`] = `
+{
+  "_cmd": "de v 8, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de p 14 1`] = `
+{
+  "_cmd": "de v 8, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de p 15 1`] = `
+{
+  "_cmd": "de v 8, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de p v 1 1`] = `
+{
+  "_cmd": "de v 8, de p v 1",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de v 8, de p v 2 1`] = `
+{
+  "_cmd": "de v 8, de p v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, de p v 3 1`] = `
+{
+  "_cmd": "de v 8, de p v 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, de p v 4 1`] = `
+{
+  "_cmd": "de v 8, de p v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de p v 5 1`] = `
+{
+  "_cmd": "de v 8, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de p v 6 1`] = `
+{
+  "_cmd": "de v 8, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, de p v 7 1`] = `
+{
+  "_cmd": "de v 8, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de p v 8 1`] = `
+{
+  "_cmd": "de v 8, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de p v 9 1`] = `
+{
+  "_cmd": "de v 8, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de p v 10 1`] = `
+{
+  "_cmd": "de v 8, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de p v 11 1`] = `
+{
+  "_cmd": "de v 8, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de p v 12 1`] = `
+{
+  "_cmd": "de v 8, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de p v 13 1`] = `
+{
+  "_cmd": "de v 8, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de p v 14 1`] = `
+{
+  "_cmd": "de v 8, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de p v 15 1`] = `
+{
+  "_cmd": "de v 8, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de p v 16 1`] = `
+{
+  "_cmd": "de v 8, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de p v 17 1`] = `
+{
+  "_cmd": "de v 8, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 8, de p v 18 1`] = `
+{
+  "_cmd": "de v 8, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 8, de p v 19 1`] = `
+{
+  "_cmd": "de v 8, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 8, de p v 20 1`] = `
+{
+  "_cmd": "de v 8, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 8, de v 1 1`] = `
+{
+  "_cmd": "de v 8, de v 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, de v 2 1`] = `
+{
+  "_cmd": "de v 8, de v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, de v 3 1`] = `
+{
+  "_cmd": "de v 8, de v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, de v 4 1`] = `
+{
+  "_cmd": "de v 8, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de v 5 1`] = `
+{
+  "_cmd": "de v 8, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de v 6 1`] = `
+{
+  "_cmd": "de v 8, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de v 7 1`] = `
+{
+  "_cmd": "de v 8, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de v 8 1`] = `
+{
+  "_cmd": "de v 8, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de v 9 1`] = `
+{
+  "_cmd": "de v 8, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de v 10 1`] = `
+{
+  "_cmd": "de v 8, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de v 11 1`] = `
+{
+  "_cmd": "de v 8, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de v 12 1`] = `
+{
+  "_cmd": "de v 8, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de v 13 1`] = `
+{
+  "_cmd": "de v 8, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de v 14 1`] = `
+{
+  "_cmd": "de v 8, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de v 15 1`] = `
+{
+  "_cmd": "de v 8, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de v 16 1`] = `
+{
+  "_cmd": "de v 8, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de v 17 1`] = `
+{
+  "_cmd": "de v 8, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 8, de v 18 1`] = `
+{
+  "_cmd": "de v 8, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 8, de v 19 1`] = `
+{
+  "_cmd": "de v 8, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 8, de v 20 1`] = `
+{
+  "_cmd": "de v 8, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 8, de w 1 1`] = `
+{
+  "_cmd": "de v 8, de w 1",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, de w 2 1`] = `
+{
+  "_cmd": "de v 8, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, de w 3 1`] = `
+{
+  "_cmd": "de v 8, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de w 4 1`] = `
+{
+  "_cmd": "de v 8, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de w 5 1`] = `
+{
+  "_cmd": "de v 8, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, de w 6 1`] = `
+{
+  "_cmd": "de v 8, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de w 7 1`] = `
+{
+  "_cmd": "de v 8, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de w 8 1`] = `
+{
+  "_cmd": "de v 8, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de w 9 1`] = `
+{
+  "_cmd": "de v 8, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de w 10 1`] = `
+{
+  "_cmd": "de v 8, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de w 11 1`] = `
+{
+  "_cmd": "de v 8, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de w 12 1`] = `
+{
+  "_cmd": "de v 8, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de w 13 1`] = `
+{
+  "_cmd": "de v 8, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de w 14 1`] = `
+{
+  "_cmd": "de v 8, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de w 15 1`] = `
+{
+  "_cmd": "de v 8, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de w v 1 1`] = `
+{
+  "_cmd": "de v 8, de w v 1",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, de w v 2 1`] = `
+{
+  "_cmd": "de v 8, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, de w v 3 1`] = `
+{
+  "_cmd": "de v 8, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, de w v 4 1`] = `
+{
+  "_cmd": "de v 8, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, de w v 5 1`] = `
+{
+  "_cmd": "de v 8, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, de w v 6 1`] = `
+{
+  "_cmd": "de v 8, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, de w v 7 1`] = `
+{
+  "_cmd": "de v 8, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, de w v 8 1`] = `
+{
+  "_cmd": "de v 8, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, de w v 9 1`] = `
+{
+  "_cmd": "de v 8, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, de w v 10 1`] = `
+{
+  "_cmd": "de v 8, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, de w v 11 1`] = `
+{
+  "_cmd": "de v 8, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, de w v 12 1`] = `
+{
+  "_cmd": "de v 8, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, de w v 13 1`] = `
+{
+  "_cmd": "de v 8, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, de w v 14 1`] = `
+{
+  "_cmd": "de v 8, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, de w v 15 1`] = `
+{
+  "_cmd": "de v 8, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, de w v 16 1`] = `
+{
+  "_cmd": "de v 8, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 8, de w v 17 1`] = `
+{
+  "_cmd": "de v 8, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 8, de w v 18 1`] = `
+{
+  "_cmd": "de v 8, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 8, de w v 19 1`] = `
+{
+  "_cmd": "de v 8, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 8, de w v 20 1`] = `
+{
+  "_cmd": "de v 8, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 9, de d 1 1`] = `
+{
+  "_cmd": "de v 9, de d 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, de d 2 1`] = `
+{
+  "_cmd": "de v 9, de d 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, de d 3 1`] = `
+{
+  "_cmd": "de v 9, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de d 4 1`] = `
+{
+  "_cmd": "de v 9, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de d 5 1`] = `
+{
+  "_cmd": "de v 9, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de d 6 1`] = `
+{
+  "_cmd": "de v 9, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, de d 7 1`] = `
+{
+  "_cmd": "de v 9, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de d 8 1`] = `
+{
+  "_cmd": "de v 9, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de d 9 1`] = `
+{
+  "_cmd": "de v 9, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de d 10 1`] = `
+{
+  "_cmd": "de v 9, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de d 11 1`] = `
+{
+  "_cmd": "de v 9, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de d 12 1`] = `
+{
+  "_cmd": "de v 9, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de d 13 1`] = `
+{
+  "_cmd": "de v 9, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de d 14 1`] = `
+{
+  "_cmd": "de v 9, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de d 15 1`] = `
+{
+  "_cmd": "de v 9, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de d v 1 1`] = `
+{
+  "_cmd": "de v 9, de d v 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, de d v 2 1`] = `
+{
+  "_cmd": "de v 9, de d v 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, de d v 3 1`] = `
+{
+  "_cmd": "de v 9, de d v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de d v 4 1`] = `
+{
+  "_cmd": "de v 9, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de d v 5 1`] = `
+{
+  "_cmd": "de v 9, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de d v 6 1`] = `
+{
+  "_cmd": "de v 9, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, de d v 7 1`] = `
+{
+  "_cmd": "de v 9, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de d v 8 1`] = `
+{
+  "_cmd": "de v 9, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de d v 9 1`] = `
+{
+  "_cmd": "de v 9, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de d v 10 1`] = `
+{
+  "_cmd": "de v 9, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de d v 11 1`] = `
+{
+  "_cmd": "de v 9, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de d v 12 1`] = `
+{
+  "_cmd": "de v 9, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de d v 13 1`] = `
+{
+  "_cmd": "de v 9, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de d v 14 1`] = `
+{
+  "_cmd": "de v 9, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de d v 15 1`] = `
+{
+  "_cmd": "de v 9, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de d v 16 1`] = `
+{
+  "_cmd": "de v 9, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de d v 17 1`] = `
+{
+  "_cmd": "de v 9, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 9, de d v 18 1`] = `
+{
+  "_cmd": "de v 9, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 9, de d v 19 1`] = `
+{
+  "_cmd": "de v 9, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 9, de d v 20 1`] = `
+{
+  "_cmd": "de v 9, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 9, de p 1 1`] = `
+{
+  "_cmd": "de v 9, de p 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, de p 2 1`] = `
+{
+  "_cmd": "de v 9, de p 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, de p 3 1`] = `
+{
+  "_cmd": "de v 9, de p 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de p 4 1`] = `
+{
+  "_cmd": "de v 9, de p 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de p 5 1`] = `
+{
+  "_cmd": "de v 9, de p 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de p 6 1`] = `
+{
+  "_cmd": "de v 9, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de p 7 1`] = `
+{
+  "_cmd": "de v 9, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de p 8 1`] = `
+{
+  "_cmd": "de v 9, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de p 9 1`] = `
+{
+  "_cmd": "de v 9, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de p 10 1`] = `
+{
+  "_cmd": "de v 9, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de p 11 1`] = `
+{
+  "_cmd": "de v 9, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de p 12 1`] = `
+{
+  "_cmd": "de v 9, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de p 13 1`] = `
+{
+  "_cmd": "de v 9, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de p 14 1`] = `
+{
+  "_cmd": "de v 9, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de p 15 1`] = `
+{
+  "_cmd": "de v 9, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de p v 1 1`] = `
+{
+  "_cmd": "de v 9, de p v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de v 9, de p v 2 1`] = `
+{
+  "_cmd": "de v 9, de p v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, de p v 3 1`] = `
+{
+  "_cmd": "de v 9, de p v 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, de p v 4 1`] = `
+{
+  "_cmd": "de v 9, de p v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de p v 5 1`] = `
+{
+  "_cmd": "de v 9, de p v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de p v 6 1`] = `
+{
+  "_cmd": "de v 9, de p v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de p v 7 1`] = `
+{
+  "_cmd": "de v 9, de p v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, de p v 8 1`] = `
+{
+  "_cmd": "de v 9, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de p v 9 1`] = `
+{
+  "_cmd": "de v 9, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de p v 10 1`] = `
+{
+  "_cmd": "de v 9, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de p v 11 1`] = `
+{
+  "_cmd": "de v 9, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de p v 12 1`] = `
+{
+  "_cmd": "de v 9, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de p v 13 1`] = `
+{
+  "_cmd": "de v 9, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de p v 14 1`] = `
+{
+  "_cmd": "de v 9, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de p v 15 1`] = `
+{
+  "_cmd": "de v 9, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de p v 16 1`] = `
+{
+  "_cmd": "de v 9, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de p v 17 1`] = `
+{
+  "_cmd": "de v 9, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 9, de p v 18 1`] = `
+{
+  "_cmd": "de v 9, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 9, de p v 19 1`] = `
+{
+  "_cmd": "de v 9, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 9, de p v 20 1`] = `
+{
+  "_cmd": "de v 9, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 9, de v 1 1`] = `
+{
+  "_cmd": "de v 9, de v 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, de v 2 1`] = `
+{
+  "_cmd": "de v 9, de v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, de v 3 1`] = `
+{
+  "_cmd": "de v 9, de v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de v 4 1`] = `
+{
+  "_cmd": "de v 9, de v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de v 5 1`] = `
+{
+  "_cmd": "de v 9, de v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de v 6 1`] = `
+{
+  "_cmd": "de v 9, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de v 7 1`] = `
+{
+  "_cmd": "de v 9, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de v 8 1`] = `
+{
+  "_cmd": "de v 9, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de v 9 1`] = `
+{
+  "_cmd": "de v 9, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de v 10 1`] = `
+{
+  "_cmd": "de v 9, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de v 11 1`] = `
+{
+  "_cmd": "de v 9, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de v 12 1`] = `
+{
+  "_cmd": "de v 9, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de v 13 1`] = `
+{
+  "_cmd": "de v 9, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de v 14 1`] = `
+{
+  "_cmd": "de v 9, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de v 15 1`] = `
+{
+  "_cmd": "de v 9, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de v 16 1`] = `
+{
+  "_cmd": "de v 9, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de v 17 1`] = `
+{
+  "_cmd": "de v 9, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 9, de v 18 1`] = `
+{
+  "_cmd": "de v 9, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 9, de v 19 1`] = `
+{
+  "_cmd": "de v 9, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 9, de v 20 1`] = `
+{
+  "_cmd": "de v 9, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 9, de w 1 1`] = `
+{
+  "_cmd": "de v 9, de w 1",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, de w 2 1`] = `
+{
+  "_cmd": "de v 9, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de w 3 1`] = `
+{
+  "_cmd": "de v 9, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de w 4 1`] = `
+{
+  "_cmd": "de v 9, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de w 5 1`] = `
+{
+  "_cmd": "de v 9, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, de w 6 1`] = `
+{
+  "_cmd": "de v 9, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, de w 7 1`] = `
+{
+  "_cmd": "de v 9, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de w 8 1`] = `
+{
+  "_cmd": "de v 9, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de w 9 1`] = `
+{
+  "_cmd": "de v 9, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de w 10 1`] = `
+{
+  "_cmd": "de v 9, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de w 11 1`] = `
+{
+  "_cmd": "de v 9, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de w 12 1`] = `
+{
+  "_cmd": "de v 9, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de w 13 1`] = `
+{
+  "_cmd": "de v 9, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de w 14 1`] = `
+{
+  "_cmd": "de v 9, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de w 15 1`] = `
+{
+  "_cmd": "de v 9, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de w v 1 1`] = `
+{
+  "_cmd": "de v 9, de w v 1",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, de w v 2 1`] = `
+{
+  "_cmd": "de v 9, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, de w v 3 1`] = `
+{
+  "_cmd": "de v 9, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, de w v 4 1`] = `
+{
+  "_cmd": "de v 9, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, de w v 5 1`] = `
+{
+  "_cmd": "de v 9, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, de w v 6 1`] = `
+{
+  "_cmd": "de v 9, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, de w v 7 1`] = `
+{
+  "_cmd": "de v 9, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, de w v 8 1`] = `
+{
+  "_cmd": "de v 9, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, de w v 9 1`] = `
+{
+  "_cmd": "de v 9, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, de w v 10 1`] = `
+{
+  "_cmd": "de v 9, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, de w v 11 1`] = `
+{
+  "_cmd": "de v 9, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, de w v 12 1`] = `
+{
+  "_cmd": "de v 9, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, de w v 13 1`] = `
+{
+  "_cmd": "de v 9, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, de w v 14 1`] = `
+{
+  "_cmd": "de v 9, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, de w v 15 1`] = `
+{
+  "_cmd": "de v 9, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, de w v 16 1`] = `
+{
+  "_cmd": "de v 9, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 9, de w v 17 1`] = `
+{
+  "_cmd": "de v 9, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 9, de w v 18 1`] = `
+{
+  "_cmd": "de v 9, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 9, de w v 19 1`] = `
+{
+  "_cmd": "de v 9, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 9, de w v 20 1`] = `
+{
+  "_cmd": "de v 9, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 10, de d 1 1`] = `
+{
+  "_cmd": "de v 10, de d 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de v 10, de d 2 1`] = `
+{
+  "_cmd": "de v 10, de d 2",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, de d 3 1`] = `
+{
+  "_cmd": "de v 10, de d 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de d 4 1`] = `
+{
+  "_cmd": "de v 10, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de d 5 1`] = `
+{
+  "_cmd": "de v 10, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de d 6 1`] = `
+{
+  "_cmd": "de v 10, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, de d 7 1`] = `
+{
+  "_cmd": "de v 10, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, de d 8 1`] = `
+{
+  "_cmd": "de v 10, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de d 9 1`] = `
+{
+  "_cmd": "de v 10, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de d 10 1`] = `
+{
+  "_cmd": "de v 10, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de d 11 1`] = `
+{
+  "_cmd": "de v 10, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de d 12 1`] = `
+{
+  "_cmd": "de v 10, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de d 13 1`] = `
+{
+  "_cmd": "de v 10, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de d 14 1`] = `
+{
+  "_cmd": "de v 10, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de d 15 1`] = `
+{
+  "_cmd": "de v 10, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de d v 1 1`] = `
+{
+  "_cmd": "de v 10, de d v 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de v 10, de d v 2 1`] = `
+{
+  "_cmd": "de v 10, de d v 2",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, de d v 3 1`] = `
+{
+  "_cmd": "de v 10, de d v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de d v 4 1`] = `
+{
+  "_cmd": "de v 10, de d v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de d v 5 1`] = `
+{
+  "_cmd": "de v 10, de d v 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de d v 6 1`] = `
+{
+  "_cmd": "de v 10, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, de d v 7 1`] = `
+{
+  "_cmd": "de v 10, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, de d v 8 1`] = `
+{
+  "_cmd": "de v 10, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de d v 9 1`] = `
+{
+  "_cmd": "de v 10, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de d v 10 1`] = `
+{
+  "_cmd": "de v 10, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de d v 11 1`] = `
+{
+  "_cmd": "de v 10, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de d v 12 1`] = `
+{
+  "_cmd": "de v 10, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de d v 13 1`] = `
+{
+  "_cmd": "de v 10, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de d v 14 1`] = `
+{
+  "_cmd": "de v 10, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de d v 15 1`] = `
+{
+  "_cmd": "de v 10, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de d v 16 1`] = `
+{
+  "_cmd": "de v 10, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de d v 17 1`] = `
+{
+  "_cmd": "de v 10, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 10, de d v 18 1`] = `
+{
+  "_cmd": "de v 10, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 10, de d v 19 1`] = `
+{
+  "_cmd": "de v 10, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 10, de d v 20 1`] = `
+{
+  "_cmd": "de v 10, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 10, de p 1 1`] = `
+{
+  "_cmd": "de v 10, de p 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de v 10, de p 2 1`] = `
+{
+  "_cmd": "de v 10, de p 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, de p 3 1`] = `
+{
+  "_cmd": "de v 10, de p 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de p 4 1`] = `
+{
+  "_cmd": "de v 10, de p 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de p 5 1`] = `
+{
+  "_cmd": "de v 10, de p 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de p 6 1`] = `
+{
+  "_cmd": "de v 10, de p 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de p 7 1`] = `
+{
+  "_cmd": "de v 10, de p 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, de p 8 1`] = `
+{
+  "_cmd": "de v 10, de p 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de p 9 1`] = `
+{
+  "_cmd": "de v 10, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de p 10 1`] = `
+{
+  "_cmd": "de v 10, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de p 11 1`] = `
+{
+  "_cmd": "de v 10, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de p 12 1`] = `
+{
+  "_cmd": "de v 10, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de p 13 1`] = `
+{
+  "_cmd": "de v 10, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de p 14 1`] = `
+{
+  "_cmd": "de v 10, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de p 15 1`] = `
+{
+  "_cmd": "de v 10, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de p v 1 1`] = `
+{
+  "_cmd": "de v 10, de p v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de v 10, de p v 2 1`] = `
+{
+  "_cmd": "de v 10, de p v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, de p v 3 1`] = `
+{
+  "_cmd": "de v 10, de p v 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, de p v 4 1`] = `
+{
+  "_cmd": "de v 10, de p v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de p v 5 1`] = `
+{
+  "_cmd": "de v 10, de p v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de p v 6 1`] = `
+{
+  "_cmd": "de v 10, de p v 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de p v 7 1`] = `
+{
+  "_cmd": "de v 10, de p v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, de p v 8 1`] = `
+{
+  "_cmd": "de v 10, de p v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, de p v 9 1`] = `
+{
+  "_cmd": "de v 10, de p v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de p v 10 1`] = `
+{
+  "_cmd": "de v 10, de p v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de p v 11 1`] = `
+{
+  "_cmd": "de v 10, de p v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de p v 12 1`] = `
+{
+  "_cmd": "de v 10, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de p v 13 1`] = `
+{
+  "_cmd": "de v 10, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de p v 14 1`] = `
+{
+  "_cmd": "de v 10, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de p v 15 1`] = `
+{
+  "_cmd": "de v 10, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de p v 16 1`] = `
+{
+  "_cmd": "de v 10, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de p v 17 1`] = `
+{
+  "_cmd": "de v 10, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 10, de p v 18 1`] = `
+{
+  "_cmd": "de v 10, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 10, de p v 19 1`] = `
+{
+  "_cmd": "de v 10, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 10, de p v 20 1`] = `
+{
+  "_cmd": "de v 10, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 10, de v 1 1`] = `
+{
+  "_cmd": "de v 10, de v 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de v 10, de v 2 1`] = `
+{
+  "_cmd": "de v 10, de v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, de v 3 1`] = `
+{
+  "_cmd": "de v 10, de v 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de v 4 1`] = `
+{
+  "_cmd": "de v 10, de v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de v 5 1`] = `
+{
+  "_cmd": "de v 10, de v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de v 6 1`] = `
+{
+  "_cmd": "de v 10, de v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de v 7 1`] = `
+{
+  "_cmd": "de v 10, de v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, de v 8 1`] = `
+{
+  "_cmd": "de v 10, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de v 9 1`] = `
+{
+  "_cmd": "de v 10, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de v 10 1`] = `
+{
+  "_cmd": "de v 10, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de v 11 1`] = `
+{
+  "_cmd": "de v 10, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de v 12 1`] = `
+{
+  "_cmd": "de v 10, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de v 13 1`] = `
+{
+  "_cmd": "de v 10, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de v 14 1`] = `
+{
+  "_cmd": "de v 10, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de v 15 1`] = `
+{
+  "_cmd": "de v 10, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de v 16 1`] = `
+{
+  "_cmd": "de v 10, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de v 17 1`] = `
+{
+  "_cmd": "de v 10, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 10, de v 18 1`] = `
+{
+  "_cmd": "de v 10, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 10, de v 19 1`] = `
+{
+  "_cmd": "de v 10, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 10, de v 20 1`] = `
+{
+  "_cmd": "de v 10, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 10, de w 1 1`] = `
+{
+  "_cmd": "de v 10, de w 1",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, de w 2 1`] = `
+{
+  "_cmd": "de v 10, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de w 3 1`] = `
+{
+  "_cmd": "de v 10, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de w 4 1`] = `
+{
+  "_cmd": "de v 10, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de w 5 1`] = `
+{
+  "_cmd": "de v 10, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de w 6 1`] = `
+{
+  "_cmd": "de v 10, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, de w 7 1`] = `
+{
+  "_cmd": "de v 10, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de w 8 1`] = `
+{
+  "_cmd": "de v 10, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de w 9 1`] = `
+{
+  "_cmd": "de v 10, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de w 10 1`] = `
+{
+  "_cmd": "de v 10, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de w 11 1`] = `
+{
+  "_cmd": "de v 10, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de w 12 1`] = `
+{
+  "_cmd": "de v 10, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de w 13 1`] = `
+{
+  "_cmd": "de v 10, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de w 14 1`] = `
+{
+  "_cmd": "de v 10, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de w 15 1`] = `
+{
+  "_cmd": "de v 10, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de w v 1 1`] = `
+{
+  "_cmd": "de v 10, de w v 1",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, de w v 2 1`] = `
+{
+  "_cmd": "de v 10, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, de w v 3 1`] = `
+{
+  "_cmd": "de v 10, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, de w v 4 1`] = `
+{
+  "_cmd": "de v 10, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, de w v 5 1`] = `
+{
+  "_cmd": "de v 10, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, de w v 6 1`] = `
+{
+  "_cmd": "de v 10, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, de w v 7 1`] = `
+{
+  "_cmd": "de v 10, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, de w v 8 1`] = `
+{
+  "_cmd": "de v 10, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, de w v 9 1`] = `
+{
+  "_cmd": "de v 10, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, de w v 10 1`] = `
+{
+  "_cmd": "de v 10, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, de w v 11 1`] = `
+{
+  "_cmd": "de v 10, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, de w v 12 1`] = `
+{
+  "_cmd": "de v 10, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, de w v 13 1`] = `
+{
+  "_cmd": "de v 10, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, de w v 14 1`] = `
+{
+  "_cmd": "de v 10, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, de w v 15 1`] = `
+{
+  "_cmd": "de v 10, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, de w v 16 1`] = `
+{
+  "_cmd": "de v 10, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 10, de w v 17 1`] = `
+{
+  "_cmd": "de v 10, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 10, de w v 18 1`] = `
+{
+  "_cmd": "de v 10, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 10, de w v 19 1`] = `
+{
+  "_cmd": "de v 10, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 10, de w v 20 1`] = `
+{
+  "_cmd": "de v 10, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 11, de d 1 1`] = `
+{
+  "_cmd": "de v 11, de d 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de v 11, de d 2 1`] = `
+{
+  "_cmd": "de v 11, de d 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, de d 3 1`] = `
+{
+  "_cmd": "de v 11, de d 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de d 4 1`] = `
+{
+  "_cmd": "de v 11, de d 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de d 5 1`] = `
+{
+  "_cmd": "de v 11, de d 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de d 6 1`] = `
+{
+  "_cmd": "de v 11, de d 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de d 7 1`] = `
+{
+  "_cmd": "de v 11, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, de d 8 1`] = `
+{
+  "_cmd": "de v 11, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de d 9 1`] = `
+{
+  "_cmd": "de v 11, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de d 10 1`] = `
+{
+  "_cmd": "de v 11, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de d 11 1`] = `
+{
+  "_cmd": "de v 11, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de d 12 1`] = `
+{
+  "_cmd": "de v 11, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de d 13 1`] = `
+{
+  "_cmd": "de v 11, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de d 14 1`] = `
+{
+  "_cmd": "de v 11, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de d 15 1`] = `
+{
+  "_cmd": "de v 11, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de d v 1 1`] = `
+{
+  "_cmd": "de v 11, de d v 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de v 11, de d v 2 1`] = `
+{
+  "_cmd": "de v 11, de d v 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, de d v 3 1`] = `
+{
+  "_cmd": "de v 11, de d v 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de d v 4 1`] = `
+{
+  "_cmd": "de v 11, de d v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, de d v 5 1`] = `
+{
+  "_cmd": "de v 11, de d v 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de d v 6 1`] = `
+{
+  "_cmd": "de v 11, de d v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de d v 7 1`] = `
+{
+  "_cmd": "de v 11, de d v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, de d v 8 1`] = `
+{
+  "_cmd": "de v 11, de d v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de d v 9 1`] = `
+{
+  "_cmd": "de v 11, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de d v 10 1`] = `
+{
+  "_cmd": "de v 11, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de d v 11 1`] = `
+{
+  "_cmd": "de v 11, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de d v 12 1`] = `
+{
+  "_cmd": "de v 11, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de d v 13 1`] = `
+{
+  "_cmd": "de v 11, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de d v 14 1`] = `
+{
+  "_cmd": "de v 11, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de d v 15 1`] = `
+{
+  "_cmd": "de v 11, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de d v 16 1`] = `
+{
+  "_cmd": "de v 11, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de d v 17 1`] = `
+{
+  "_cmd": "de v 11, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 11, de d v 18 1`] = `
+{
+  "_cmd": "de v 11, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 11, de d v 19 1`] = `
+{
+  "_cmd": "de v 11, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 11, de d v 20 1`] = `
+{
+  "_cmd": "de v 11, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 11, de p 1 1`] = `
+{
+  "_cmd": "de v 11, de p 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, de p 2 1`] = `
+{
+  "_cmd": "de v 11, de p 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, de p 3 1`] = `
+{
+  "_cmd": "de v 11, de p 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, de p 4 1`] = `
+{
+  "_cmd": "de v 11, de p 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, de p 5 1`] = `
+{
+  "_cmd": "de v 11, de p 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de p 6 1`] = `
+{
+  "_cmd": "de v 11, de p 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de p 7 1`] = `
+{
+  "_cmd": "de v 11, de p 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de p 8 1`] = `
+{
+  "_cmd": "de v 11, de p 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de p 9 1`] = `
+{
+  "_cmd": "de v 11, de p 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de p 10 1`] = `
+{
+  "_cmd": "de v 11, de p 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de p 11 1`] = `
+{
+  "_cmd": "de v 11, de p 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de p 12 1`] = `
+{
+  "_cmd": "de v 11, de p 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de p 13 1`] = `
+{
+  "_cmd": "de v 11, de p 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de p 14 1`] = `
+{
+  "_cmd": "de v 11, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de p 15 1`] = `
+{
+  "_cmd": "de v 11, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de p v 1 1`] = `
+{
+  "_cmd": "de v 11, de p v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, de p v 2 1`] = `
+{
+  "_cmd": "de v 11, de p v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, de p v 3 1`] = `
+{
+  "_cmd": "de v 11, de p v 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, de p v 4 1`] = `
+{
+  "_cmd": "de v 11, de p v 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de p v 5 1`] = `
+{
+  "_cmd": "de v 11, de p v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de p v 6 1`] = `
+{
+  "_cmd": "de v 11, de p v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de p v 7 1`] = `
+{
+  "_cmd": "de v 11, de p v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de p v 8 1`] = `
+{
+  "_cmd": "de v 11, de p v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, de p v 9 1`] = `
+{
+  "_cmd": "de v 11, de p v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de p v 10 1`] = `
+{
+  "_cmd": "de v 11, de p v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de p v 11 1`] = `
+{
+  "_cmd": "de v 11, de p v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de p v 12 1`] = `
+{
+  "_cmd": "de v 11, de p v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de p v 13 1`] = `
+{
+  "_cmd": "de v 11, de p v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de p v 14 1`] = `
+{
+  "_cmd": "de v 11, de p v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de p v 15 1`] = `
+{
+  "_cmd": "de v 11, de p v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de p v 16 1`] = `
+{
+  "_cmd": "de v 11, de p v 16",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de p v 17 1`] = `
+{
+  "_cmd": "de v 11, de p v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de v 11, de p v 18 1`] = `
+{
+  "_cmd": "de v 11, de p v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de v 11, de p v 19 1`] = `
+{
+  "_cmd": "de v 11, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 11, de p v 20 1`] = `
+{
+  "_cmd": "de v 11, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 11, de v 1 1`] = `
+{
+  "_cmd": "de v 11, de v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, de v 2 1`] = `
+{
+  "_cmd": "de v 11, de v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, de v 3 1`] = `
+{
+  "_cmd": "de v 11, de v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de v 4 1`] = `
+{
+  "_cmd": "de v 11, de v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, de v 5 1`] = `
+{
+  "_cmd": "de v 11, de v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de v 6 1`] = `
+{
+  "_cmd": "de v 11, de v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de v 7 1`] = `
+{
+  "_cmd": "de v 11, de v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de v 8 1`] = `
+{
+  "_cmd": "de v 11, de v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de v 9 1`] = `
+{
+  "_cmd": "de v 11, de v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de v 10 1`] = `
+{
+  "_cmd": "de v 11, de v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de v 11 1`] = `
+{
+  "_cmd": "de v 11, de v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de v 12 1`] = `
+{
+  "_cmd": "de v 11, de v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de v 13 1`] = `
+{
+  "_cmd": "de v 11, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de v 14 1`] = `
+{
+  "_cmd": "de v 11, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de v 15 1`] = `
+{
+  "_cmd": "de v 11, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de v 16 1`] = `
+{
+  "_cmd": "de v 11, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de v 17 1`] = `
+{
+  "_cmd": "de v 11, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 11, de v 18 1`] = `
+{
+  "_cmd": "de v 11, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 11, de v 19 1`] = `
+{
+  "_cmd": "de v 11, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 11, de v 20 1`] = `
+{
+  "_cmd": "de v 11, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 11, de w 1 1`] = `
+{
+  "_cmd": "de v 11, de w 1",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, de w 2 1`] = `
+{
+  "_cmd": "de v 11, de w 2",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de w 3 1`] = `
+{
+  "_cmd": "de v 11, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, de w 4 1`] = `
+{
+  "_cmd": "de v 11, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de w 5 1`] = `
+{
+  "_cmd": "de v 11, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de w 6 1`] = `
+{
+  "_cmd": "de v 11, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, de w 7 1`] = `
+{
+  "_cmd": "de v 11, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, de w 8 1`] = `
+{
+  "_cmd": "de v 11, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de w 9 1`] = `
+{
+  "_cmd": "de v 11, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de w 10 1`] = `
+{
+  "_cmd": "de v 11, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de w 11 1`] = `
+{
+  "_cmd": "de v 11, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de w 12 1`] = `
+{
+  "_cmd": "de v 11, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de w 13 1`] = `
+{
+  "_cmd": "de v 11, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de w 14 1`] = `
+{
+  "_cmd": "de v 11, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de w 15 1`] = `
+{
+  "_cmd": "de v 11, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de w v 1 1`] = `
+{
+  "_cmd": "de v 11, de w v 1",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, de w v 2 1`] = `
+{
+  "_cmd": "de v 11, de w v 2",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, de w v 3 1`] = `
+{
+  "_cmd": "de v 11, de w v 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, de w v 4 1`] = `
+{
+  "_cmd": "de v 11, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, de w v 5 1`] = `
+{
+  "_cmd": "de v 11, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, de w v 6 1`] = `
+{
+  "_cmd": "de v 11, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, de w v 7 1`] = `
+{
+  "_cmd": "de v 11, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, de w v 8 1`] = `
+{
+  "_cmd": "de v 11, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, de w v 9 1`] = `
+{
+  "_cmd": "de v 11, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, de w v 10 1`] = `
+{
+  "_cmd": "de v 11, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, de w v 11 1`] = `
+{
+  "_cmd": "de v 11, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, de w v 12 1`] = `
+{
+  "_cmd": "de v 11, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, de w v 13 1`] = `
+{
+  "_cmd": "de v 11, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, de w v 14 1`] = `
+{
+  "_cmd": "de v 11, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, de w v 15 1`] = `
+{
+  "_cmd": "de v 11, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, de w v 16 1`] = `
+{
+  "_cmd": "de v 11, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 11, de w v 17 1`] = `
+{
+  "_cmd": "de v 11, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 11, de w v 18 1`] = `
+{
+  "_cmd": "de v 11, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 11, de w v 19 1`] = `
+{
+  "_cmd": "de v 11, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 11, de w v 20 1`] = `
+{
+  "_cmd": "de v 11, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 12, de d 1 1`] = `
+{
+  "_cmd": "de v 12, de d 1",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de v 12, de d 2 1`] = `
+{
+  "_cmd": "de v 12, de d 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, de d 3 1`] = `
+{
+  "_cmd": "de v 12, de d 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, de d 4 1`] = `
+{
+  "_cmd": "de v 12, de d 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de d 5 1`] = `
+{
+  "_cmd": "de v 12, de d 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de d 6 1`] = `
+{
+  "_cmd": "de v 12, de d 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de d 7 1`] = `
+{
+  "_cmd": "de v 12, de d 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de d 8 1`] = `
+{
+  "_cmd": "de v 12, de d 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, de d 9 1`] = `
+{
+  "_cmd": "de v 12, de d 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de d 10 1`] = `
+{
+  "_cmd": "de v 12, de d 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de d 11 1`] = `
+{
+  "_cmd": "de v 12, de d 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de d 12 1`] = `
+{
+  "_cmd": "de v 12, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de d 13 1`] = `
+{
+  "_cmd": "de v 12, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de d 14 1`] = `
+{
+  "_cmd": "de v 12, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de d 15 1`] = `
+{
+  "_cmd": "de v 12, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de d v 1 1`] = `
+{
+  "_cmd": "de v 12, de d v 1",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de v 12, de d v 2 1`] = `
+{
+  "_cmd": "de v 12, de d v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de d v 3 1`] = `
+{
+  "_cmd": "de v 12, de d v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, de d v 4 1`] = `
+{
+  "_cmd": "de v 12, de d v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de d v 5 1`] = `
+{
+  "_cmd": "de v 12, de d v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de d v 6 1`] = `
+{
+  "_cmd": "de v 12, de d v 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de d v 7 1`] = `
+{
+  "_cmd": "de v 12, de d v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de d v 8 1`] = `
+{
+  "_cmd": "de v 12, de d v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, de d v 9 1`] = `
+{
+  "_cmd": "de v 12, de d v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de d v 10 1`] = `
+{
+  "_cmd": "de v 12, de d v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de d v 11 1`] = `
+{
+  "_cmd": "de v 12, de d v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de d v 12 1`] = `
+{
+  "_cmd": "de v 12, de d v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de d v 13 1`] = `
+{
+  "_cmd": "de v 12, de d v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de d v 14 1`] = `
+{
+  "_cmd": "de v 12, de d v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de d v 15 1`] = `
+{
+  "_cmd": "de v 12, de d v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de d v 16 1`] = `
+{
+  "_cmd": "de v 12, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, de d v 17 1`] = `
+{
+  "_cmd": "de v 12, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 12, de d v 18 1`] = `
+{
+  "_cmd": "de v 12, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 12, de d v 19 1`] = `
+{
+  "_cmd": "de v 12, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 12, de d v 20 1`] = `
+{
+  "_cmd": "de v 12, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 12, de p 1 1`] = `
+{
+  "_cmd": "de v 12, de p 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, de p 2 1`] = `
+{
+  "_cmd": "de v 12, de p 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de p 3 1`] = `
+{
+  "_cmd": "de v 12, de p 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, de p 4 1`] = `
+{
+  "_cmd": "de v 12, de p 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de p 5 1`] = `
+{
+  "_cmd": "de v 12, de p 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de p 6 1`] = `
+{
+  "_cmd": "de v 12, de p 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de p 7 1`] = `
+{
+  "_cmd": "de v 12, de p 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de p 8 1`] = `
+{
+  "_cmd": "de v 12, de p 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de p 9 1`] = `
+{
+  "_cmd": "de v 12, de p 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de p 10 1`] = `
+{
+  "_cmd": "de v 12, de p 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de p 11 1`] = `
+{
+  "_cmd": "de v 12, de p 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de p 12 1`] = `
+{
+  "_cmd": "de v 12, de p 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de p 13 1`] = `
+{
+  "_cmd": "de v 12, de p 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de p 14 1`] = `
+{
+  "_cmd": "de v 12, de p 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de p 15 1`] = `
+{
+  "_cmd": "de v 12, de p 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de p v 1 1`] = `
+{
+  "_cmd": "de v 12, de p v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, de p v 2 1`] = `
+{
+  "_cmd": "de v 12, de p v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de p v 3 1`] = `
+{
+  "_cmd": "de v 12, de p v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, de p v 4 1`] = `
+{
+  "_cmd": "de v 12, de p v 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, de p v 5 1`] = `
+{
+  "_cmd": "de v 12, de p v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de p v 6 1`] = `
+{
+  "_cmd": "de v 12, de p v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de p v 7 1`] = `
+{
+  "_cmd": "de v 12, de p v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de p v 8 1`] = `
+{
+  "_cmd": "de v 12, de p v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de p v 9 1`] = `
+{
+  "_cmd": "de v 12, de p v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, de p v 10 1`] = `
+{
+  "_cmd": "de v 12, de p v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de p v 11 1`] = `
+{
+  "_cmd": "de v 12, de p v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de p v 12 1`] = `
+{
+  "_cmd": "de v 12, de p v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de p v 13 1`] = `
+{
+  "_cmd": "de v 12, de p v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de p v 14 1`] = `
+{
+  "_cmd": "de v 12, de p v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de p v 15 1`] = `
+{
+  "_cmd": "de v 12, de p v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de p v 16 1`] = `
+{
+  "_cmd": "de v 12, de p v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, de p v 17 1`] = `
+{
+  "_cmd": "de v 12, de p v 17",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de v 12, de p v 18 1`] = `
+{
+  "_cmd": "de v 12, de p v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de v 12, de p v 19 1`] = `
+{
+  "_cmd": "de v 12, de p v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de v 12, de p v 20 1`] = `
+{
+  "_cmd": "de v 12, de p v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de v 12, de v 1 1`] = `
+{
+  "_cmd": "de v 12, de v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, de v 2 1`] = `
+{
+  "_cmd": "de v 12, de v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de v 3 1`] = `
+{
+  "_cmd": "de v 12, de v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, de v 4 1`] = `
+{
+  "_cmd": "de v 12, de v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de v 5 1`] = `
+{
+  "_cmd": "de v 12, de v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de v 6 1`] = `
+{
+  "_cmd": "de v 12, de v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de v 7 1`] = `
+{
+  "_cmd": "de v 12, de v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de v 8 1`] = `
+{
+  "_cmd": "de v 12, de v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de v 9 1`] = `
+{
+  "_cmd": "de v 12, de v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de v 10 1`] = `
+{
+  "_cmd": "de v 12, de v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de v 11 1`] = `
+{
+  "_cmd": "de v 12, de v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de v 12 1`] = `
+{
+  "_cmd": "de v 12, de v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de v 13 1`] = `
+{
+  "_cmd": "de v 12, de v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de v 14 1`] = `
+{
+  "_cmd": "de v 12, de v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de v 15 1`] = `
+{
+  "_cmd": "de v 12, de v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de v 16 1`] = `
+{
+  "_cmd": "de v 12, de v 16",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, de v 17 1`] = `
+{
+  "_cmd": "de v 12, de v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de v 12, de v 18 1`] = `
+{
+  "_cmd": "de v 12, de v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de v 12, de v 19 1`] = `
+{
+  "_cmd": "de v 12, de v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de v 12, de v 20 1`] = `
+{
+  "_cmd": "de v 12, de v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de v 12, de w 1 1`] = `
+{
+  "_cmd": "de v 12, de w 1",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de w 2 1`] = `
+{
+  "_cmd": "de v 12, de w 2",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, de w 3 1`] = `
+{
+  "_cmd": "de v 12, de w 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de w 4 1`] = `
+{
+  "_cmd": "de v 12, de w 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de w 5 1`] = `
+{
+  "_cmd": "de v 12, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de w 6 1`] = `
+{
+  "_cmd": "de v 12, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de w 7 1`] = `
+{
+  "_cmd": "de v 12, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, de w 8 1`] = `
+{
+  "_cmd": "de v 12, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, de w 9 1`] = `
+{
+  "_cmd": "de v 12, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de w 10 1`] = `
+{
+  "_cmd": "de v 12, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de w 11 1`] = `
+{
+  "_cmd": "de v 12, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de w 12 1`] = `
+{
+  "_cmd": "de v 12, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de w 13 1`] = `
+{
+  "_cmd": "de v 12, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de w 14 1`] = `
+{
+  "_cmd": "de v 12, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de w 15 1`] = `
+{
+  "_cmd": "de v 12, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, de w v 1 1`] = `
+{
+  "_cmd": "de v 12, de w v 1",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, de w v 2 1`] = `
+{
+  "_cmd": "de v 12, de w v 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, de w v 3 1`] = `
+{
+  "_cmd": "de v 12, de w v 3",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, de w v 4 1`] = `
+{
+  "_cmd": "de v 12, de w v 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, de w v 5 1`] = `
+{
+  "_cmd": "de v 12, de w v 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, de w v 6 1`] = `
+{
+  "_cmd": "de v 12, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, de w v 7 1`] = `
+{
+  "_cmd": "de v 12, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, de w v 8 1`] = `
+{
+  "_cmd": "de v 12, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, de w v 9 1`] = `
+{
+  "_cmd": "de v 12, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, de w v 10 1`] = `
+{
+  "_cmd": "de v 12, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, de w v 11 1`] = `
+{
+  "_cmd": "de v 12, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, de w v 12 1`] = `
+{
+  "_cmd": "de v 12, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, de w v 13 1`] = `
+{
+  "_cmd": "de v 12, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, de w v 14 1`] = `
+{
+  "_cmd": "de v 12, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, de w v 15 1`] = `
+{
+  "_cmd": "de v 12, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, de w v 16 1`] = `
+{
+  "_cmd": "de v 12, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 12, de w v 17 1`] = `
+{
+  "_cmd": "de v 12, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 12, de w v 18 1`] = `
+{
+  "_cmd": "de v 12, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 12, de w v 19 1`] = `
+{
+  "_cmd": "de v 12, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 12, de w v 20 1`] = `
+{
+  "_cmd": "de v 12, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 13, de d 1 1`] = `
+{
+  "_cmd": "de v 13, de d 1",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de v 13, de d 2 1`] = `
+{
+  "_cmd": "de v 13, de d 2",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, de d 3 1`] = `
+{
+  "_cmd": "de v 13, de d 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, de d 4 1`] = `
+{
+  "_cmd": "de v 13, de d 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de d 5 1`] = `
+{
+  "_cmd": "de v 13, de d 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de d 6 1`] = `
+{
+  "_cmd": "de v 13, de d 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de d 7 1`] = `
+{
+  "_cmd": "de v 13, de d 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de d 8 1`] = `
+{
+  "_cmd": "de v 13, de d 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de d 9 1`] = `
+{
+  "_cmd": "de v 13, de d 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, de d 10 1`] = `
+{
+  "_cmd": "de v 13, de d 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de d 11 1`] = `
+{
+  "_cmd": "de v 13, de d 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de d 12 1`] = `
+{
+  "_cmd": "de v 13, de d 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de d 13 1`] = `
+{
+  "_cmd": "de v 13, de d 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de d 14 1`] = `
+{
+  "_cmd": "de v 13, de d 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de d 15 1`] = `
+{
+  "_cmd": "de v 13, de d 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de d v 1 1`] = `
+{
+  "_cmd": "de v 13, de d v 1",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de v 13, de d v 2 1`] = `
+{
+  "_cmd": "de v 13, de d v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de d v 3 1`] = `
+{
+  "_cmd": "de v 13, de d v 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, de d v 4 1`] = `
+{
+  "_cmd": "de v 13, de d v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de d v 5 1`] = `
+{
+  "_cmd": "de v 13, de d v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de d v 6 1`] = `
+{
+  "_cmd": "de v 13, de d v 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de d v 7 1`] = `
+{
+  "_cmd": "de v 13, de d v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de d v 8 1`] = `
+{
+  "_cmd": "de v 13, de d v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de d v 9 1`] = `
+{
+  "_cmd": "de v 13, de d v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, de d v 10 1`] = `
+{
+  "_cmd": "de v 13, de d v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de d v 11 1`] = `
+{
+  "_cmd": "de v 13, de d v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de d v 12 1`] = `
+{
+  "_cmd": "de v 13, de d v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de d v 13 1`] = `
+{
+  "_cmd": "de v 13, de d v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de d v 14 1`] = `
+{
+  "_cmd": "de v 13, de d v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de d v 15 1`] = `
+{
+  "_cmd": "de v 13, de d v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de d v 16 1`] = `
+{
+  "_cmd": "de v 13, de d v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, de d v 17 1`] = `
+{
+  "_cmd": "de v 13, de d v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de v 13, de d v 18 1`] = `
+{
+  "_cmd": "de v 13, de d v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de v 13, de d v 19 1`] = `
+{
+  "_cmd": "de v 13, de d v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de v 13, de d v 20 1`] = `
+{
+  "_cmd": "de v 13, de d v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de v 13, de p 1 1`] = `
+{
+  "_cmd": "de v 13, de p 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, de p 2 1`] = `
+{
+  "_cmd": "de v 13, de p 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de p 3 1`] = `
+{
+  "_cmd": "de v 13, de p 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, de p 4 1`] = `
+{
+  "_cmd": "de v 13, de p 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de p 5 1`] = `
+{
+  "_cmd": "de v 13, de p 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de p 6 1`] = `
+{
+  "_cmd": "de v 13, de p 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de p 7 1`] = `
+{
+  "_cmd": "de v 13, de p 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de p 8 1`] = `
+{
+  "_cmd": "de v 13, de p 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de p 9 1`] = `
+{
+  "_cmd": "de v 13, de p 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de p 10 1`] = `
+{
+  "_cmd": "de v 13, de p 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de p 11 1`] = `
+{
+  "_cmd": "de v 13, de p 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de p 12 1`] = `
+{
+  "_cmd": "de v 13, de p 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de p 13 1`] = `
+{
+  "_cmd": "de v 13, de p 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de p 14 1`] = `
+{
+  "_cmd": "de v 13, de p 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de p 15 1`] = `
+{
+  "_cmd": "de v 13, de p 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de p v 1 1`] = `
+{
+  "_cmd": "de v 13, de p v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, de p v 2 1`] = `
+{
+  "_cmd": "de v 13, de p v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de p v 3 1`] = `
+{
+  "_cmd": "de v 13, de p v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, de p v 4 1`] = `
+{
+  "_cmd": "de v 13, de p v 4",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, de p v 5 1`] = `
+{
+  "_cmd": "de v 13, de p v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de p v 6 1`] = `
+{
+  "_cmd": "de v 13, de p v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de p v 7 1`] = `
+{
+  "_cmd": "de v 13, de p v 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de p v 8 1`] = `
+{
+  "_cmd": "de v 13, de p v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de p v 9 1`] = `
+{
+  "_cmd": "de v 13, de p v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de p v 10 1`] = `
+{
+  "_cmd": "de v 13, de p v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, de p v 11 1`] = `
+{
+  "_cmd": "de v 13, de p v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de p v 12 1`] = `
+{
+  "_cmd": "de v 13, de p v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de p v 13 1`] = `
+{
+  "_cmd": "de v 13, de p v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de p v 14 1`] = `
+{
+  "_cmd": "de v 13, de p v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de p v 15 1`] = `
+{
+  "_cmd": "de v 13, de p v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de p v 16 1`] = `
+{
+  "_cmd": "de v 13, de p v 16",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, de p v 17 1`] = `
+{
+  "_cmd": "de v 13, de p v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de v 13, de p v 18 1`] = `
+{
+  "_cmd": "de v 13, de p v 18",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de v 13, de p v 19 1`] = `
+{
+  "_cmd": "de v 13, de p v 19",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de v 13, de p v 20 1`] = `
+{
+  "_cmd": "de v 13, de p v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de v 13, de v 1 1`] = `
+{
+  "_cmd": "de v 13, de v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, de v 2 1`] = `
+{
+  "_cmd": "de v 13, de v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de v 3 1`] = `
+{
+  "_cmd": "de v 13, de v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, de v 4 1`] = `
+{
+  "_cmd": "de v 13, de v 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de v 5 1`] = `
+{
+  "_cmd": "de v 13, de v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de v 6 1`] = `
+{
+  "_cmd": "de v 13, de v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de v 7 1`] = `
+{
+  "_cmd": "de v 13, de v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de v 8 1`] = `
+{
+  "_cmd": "de v 13, de v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de v 9 1`] = `
+{
+  "_cmd": "de v 13, de v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, de v 10 1`] = `
+{
+  "_cmd": "de v 13, de v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de v 11 1`] = `
+{
+  "_cmd": "de v 13, de v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de v 12 1`] = `
+{
+  "_cmd": "de v 13, de v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de v 13 1`] = `
+{
+  "_cmd": "de v 13, de v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de v 14 1`] = `
+{
+  "_cmd": "de v 13, de v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de v 15 1`] = `
+{
+  "_cmd": "de v 13, de v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de v 16 1`] = `
+{
+  "_cmd": "de v 13, de v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, de v 17 1`] = `
+{
+  "_cmd": "de v 13, de v 17",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de v 13, de v 18 1`] = `
+{
+  "_cmd": "de v 13, de v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de v 13, de v 19 1`] = `
+{
+  "_cmd": "de v 13, de v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de v 13, de v 20 1`] = `
+{
+  "_cmd": "de v 13, de v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de v 13, de w 1 1`] = `
+{
+  "_cmd": "de v 13, de w 1",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de w 2 1`] = `
+{
+  "_cmd": "de v 13, de w 2",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, de w 3 1`] = `
+{
+  "_cmd": "de v 13, de w 3",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de w 4 1`] = `
+{
+  "_cmd": "de v 13, de w 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de w 5 1`] = `
+{
+  "_cmd": "de v 13, de w 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de w 6 1`] = `
+{
+  "_cmd": "de v 13, de w 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de w 7 1`] = `
+{
+  "_cmd": "de v 13, de w 7",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de w 8 1`] = `
+{
+  "_cmd": "de v 13, de w 8",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, de w 9 1`] = `
+{
+  "_cmd": "de v 13, de w 9",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de w 10 1`] = `
+{
+  "_cmd": "de v 13, de w 10",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de w 11 1`] = `
+{
+  "_cmd": "de v 13, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de w 12 1`] = `
+{
+  "_cmd": "de v 13, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de w 13 1`] = `
+{
+  "_cmd": "de v 13, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de w 14 1`] = `
+{
+  "_cmd": "de v 13, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de w 15 1`] = `
+{
+  "_cmd": "de v 13, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, de w v 1 1`] = `
+{
+  "_cmd": "de v 13, de w v 1",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, de w v 2 1`] = `
+{
+  "_cmd": "de v 13, de w v 2",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, de w v 3 1`] = `
+{
+  "_cmd": "de v 13, de w v 3",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, de w v 4 1`] = `
+{
+  "_cmd": "de v 13, de w v 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, de w v 5 1`] = `
+{
+  "_cmd": "de v 13, de w v 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, de w v 6 1`] = `
+{
+  "_cmd": "de v 13, de w v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, de w v 7 1`] = `
+{
+  "_cmd": "de v 13, de w v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, de w v 8 1`] = `
+{
+  "_cmd": "de v 13, de w v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, de w v 9 1`] = `
+{
+  "_cmd": "de v 13, de w v 9",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, de w v 10 1`] = `
+{
+  "_cmd": "de v 13, de w v 10",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, de w v 11 1`] = `
+{
+  "_cmd": "de v 13, de w v 11",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, de w v 12 1`] = `
+{
+  "_cmd": "de v 13, de w v 12",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, de w v 13 1`] = `
+{
+  "_cmd": "de v 13, de w v 13",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, de w v 14 1`] = `
+{
+  "_cmd": "de v 13, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, de w v 15 1`] = `
+{
+  "_cmd": "de v 13, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, de w v 16 1`] = `
+{
+  "_cmd": "de v 13, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`de v 13, de w v 17 1`] = `
+{
+  "_cmd": "de v 13, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`de v 13, de w v 18 1`] = `
+{
+  "_cmd": "de v 13, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`de v 13, de w v 19 1`] = `
+{
+  "_cmd": "de v 13, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`de v 13, de w v 20 1`] = `
+{
+  "_cmd": "de v 13, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`de v 14, de d 1 1`] = `
+{
+  "_cmd": "de v 14, de d 1",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de v 14, de d 2 1`] = `
+{
+  "_cmd": "de v 14, de d 2",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, de d 3 1`] = `
+{
+  "_cmd": "de v 14, de d 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, de d 4 1`] = `
+{
+  "_cmd": "de v 14, de d 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de d 5 1`] = `
+{
+  "_cmd": "de v 14, de d 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de d 6 1`] = `
+{
+  "_cmd": "de v 14, de d 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de d 7 1`] = `
+{
+  "_cmd": "de v 14, de d 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de d 8 1`] = `
+{
+  "_cmd": "de v 14, de d 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de d 9 1`] = `
+{
+  "_cmd": "de v 14, de d 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de d 10 1`] = `
+{
+  "_cmd": "de v 14, de d 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, de d 11 1`] = `
+{
+  "_cmd": "de v 14, de d 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de d 12 1`] = `
+{
+  "_cmd": "de v 14, de d 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de d 13 1`] = `
+{
+  "_cmd": "de v 14, de d 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de d 14 1`] = `
+{
+  "_cmd": "de v 14, de d 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de d 15 1`] = `
+{
+  "_cmd": "de v 14, de d 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de d v 1 1`] = `
+{
+  "_cmd": "de v 14, de d v 1",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de v 14, de d v 2 1`] = `
+{
+  "_cmd": "de v 14, de d v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de d v 3 1`] = `
+{
+  "_cmd": "de v 14, de d v 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, de d v 4 1`] = `
+{
+  "_cmd": "de v 14, de d v 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de d v 5 1`] = `
+{
+  "_cmd": "de v 14, de d v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, de d v 6 1`] = `
+{
+  "_cmd": "de v 14, de d v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de d v 7 1`] = `
+{
+  "_cmd": "de v 14, de d v 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de d v 8 1`] = `
+{
+  "_cmd": "de v 14, de d v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de d v 9 1`] = `
+{
+  "_cmd": "de v 14, de d v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de d v 10 1`] = `
+{
+  "_cmd": "de v 14, de d v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, de d v 11 1`] = `
+{
+  "_cmd": "de v 14, de d v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de d v 12 1`] = `
+{
+  "_cmd": "de v 14, de d v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de d v 13 1`] = `
+{
+  "_cmd": "de v 14, de d v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de d v 14 1`] = `
+{
+  "_cmd": "de v 14, de d v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de d v 15 1`] = `
+{
+  "_cmd": "de v 14, de d v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de d v 16 1`] = `
+{
+  "_cmd": "de v 14, de d v 16",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, de d v 17 1`] = `
+{
+  "_cmd": "de v 14, de d v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de v 14, de d v 18 1`] = `
+{
+  "_cmd": "de v 14, de d v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de v 14, de d v 19 1`] = `
+{
+  "_cmd": "de v 14, de d v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de v 14, de d v 20 1`] = `
+{
+  "_cmd": "de v 14, de d v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de v 14, de p 1 1`] = `
+{
+  "_cmd": "de v 14, de p 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, de p 2 1`] = `
+{
+  "_cmd": "de v 14, de p 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de p 3 1`] = `
+{
+  "_cmd": "de v 14, de p 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, de p 4 1`] = `
+{
+  "_cmd": "de v 14, de p 4",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, de p 5 1`] = `
+{
+  "_cmd": "de v 14, de p 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, de p 6 1`] = `
+{
+  "_cmd": "de v 14, de p 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de p 7 1`] = `
+{
+  "_cmd": "de v 14, de p 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de p 8 1`] = `
+{
+  "_cmd": "de v 14, de p 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de p 9 1`] = `
+{
+  "_cmd": "de v 14, de p 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de p 10 1`] = `
+{
+  "_cmd": "de v 14, de p 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de p 11 1`] = `
+{
+  "_cmd": "de v 14, de p 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de p 12 1`] = `
+{
+  "_cmd": "de v 14, de p 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de p 13 1`] = `
+{
+  "_cmd": "de v 14, de p 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de p 14 1`] = `
+{
+  "_cmd": "de v 14, de p 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de p 15 1`] = `
+{
+  "_cmd": "de v 14, de p 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de p v 1 1`] = `
+{
+  "_cmd": "de v 14, de p v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, de p v 2 1`] = `
+{
+  "_cmd": "de v 14, de p v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de p v 3 1`] = `
+{
+  "_cmd": "de v 14, de p v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, de p v 4 1`] = `
+{
+  "_cmd": "de v 14, de p v 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, de p v 5 1`] = `
+{
+  "_cmd": "de v 14, de p v 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de p v 6 1`] = `
+{
+  "_cmd": "de v 14, de p v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de p v 7 1`] = `
+{
+  "_cmd": "de v 14, de p v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de p v 8 1`] = `
+{
+  "_cmd": "de v 14, de p v 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de p v 9 1`] = `
+{
+  "_cmd": "de v 14, de p v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de p v 10 1`] = `
+{
+  "_cmd": "de v 14, de p v 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de p v 11 1`] = `
+{
+  "_cmd": "de v 14, de p v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, de p v 12 1`] = `
+{
+  "_cmd": "de v 14, de p v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de p v 13 1`] = `
+{
+  "_cmd": "de v 14, de p v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de p v 14 1`] = `
+{
+  "_cmd": "de v 14, de p v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de p v 15 1`] = `
+{
+  "_cmd": "de v 14, de p v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de p v 16 1`] = `
+{
+  "_cmd": "de v 14, de p v 16",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, de p v 17 1`] = `
+{
+  "_cmd": "de v 14, de p v 17",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de v 14, de p v 18 1`] = `
+{
+  "_cmd": "de v 14, de p v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de v 14, de p v 19 1`] = `
+{
+  "_cmd": "de v 14, de p v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de v 14, de p v 20 1`] = `
+{
+  "_cmd": "de v 14, de p v 20",
+  "attacker": 4,
+  "defender": 19,
+}
+`;
+
+exports[`de v 14, de v 1 1`] = `
+{
+  "_cmd": "de v 14, de v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, de v 2 1`] = `
+{
+  "_cmd": "de v 14, de v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de v 3 1`] = `
+{
+  "_cmd": "de v 14, de v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, de v 4 1`] = `
+{
+  "_cmd": "de v 14, de v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de v 5 1`] = `
+{
+  "_cmd": "de v 14, de v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, de v 6 1`] = `
+{
+  "_cmd": "de v 14, de v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de v 7 1`] = `
+{
+  "_cmd": "de v 14, de v 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de v 8 1`] = `
+{
+  "_cmd": "de v 14, de v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de v 9 1`] = `
+{
+  "_cmd": "de v 14, de v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de v 10 1`] = `
+{
+  "_cmd": "de v 14, de v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, de v 11 1`] = `
+{
+  "_cmd": "de v 14, de v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de v 12 1`] = `
+{
+  "_cmd": "de v 14, de v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de v 13 1`] = `
+{
+  "_cmd": "de v 14, de v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de v 14 1`] = `
+{
+  "_cmd": "de v 14, de v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de v 15 1`] = `
+{
+  "_cmd": "de v 14, de v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de v 16 1`] = `
+{
+  "_cmd": "de v 14, de v 16",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, de v 17 1`] = `
+{
+  "_cmd": "de v 14, de v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`de v 14, de v 18 1`] = `
+{
+  "_cmd": "de v 14, de v 18",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de v 14, de v 19 1`] = `
+{
+  "_cmd": "de v 14, de v 19",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de v 14, de v 20 1`] = `
+{
+  "_cmd": "de v 14, de v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de v 14, de w 1 1`] = `
+{
+  "_cmd": "de v 14, de w 1",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de w 2 1`] = `
+{
+  "_cmd": "de v 14, de w 2",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, de w 3 1`] = `
+{
+  "_cmd": "de v 14, de w 3",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de w 4 1`] = `
+{
+  "_cmd": "de v 14, de w 4",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, de w 5 1`] = `
+{
+  "_cmd": "de v 14, de w 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de w 6 1`] = `
+{
+  "_cmd": "de v 14, de w 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de w 7 1`] = `
+{
+  "_cmd": "de v 14, de w 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de w 8 1`] = `
+{
+  "_cmd": "de v 14, de w 8",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de w 9 1`] = `
+{
+  "_cmd": "de v 14, de w 9",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, de w 10 1`] = `
+{
+  "_cmd": "de v 14, de w 10",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de w 11 1`] = `
+{
+  "_cmd": "de v 14, de w 11",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de w 12 1`] = `
+{
+  "_cmd": "de v 14, de w 12",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de w 13 1`] = `
+{
+  "_cmd": "de v 14, de w 13",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de w 14 1`] = `
+{
+  "_cmd": "de v 14, de w 14",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de w 15 1`] = `
+{
+  "_cmd": "de v 14, de w 15",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, de w v 1 1`] = `
+{
+  "_cmd": "de v 14, de w v 1",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, de w v 2 1`] = `
+{
+  "_cmd": "de v 14, de w v 2",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, de w v 3 1`] = `
+{
+  "_cmd": "de v 14, de w v 3",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, de w v 4 1`] = `
+{
+  "_cmd": "de v 14, de w v 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, de w v 5 1`] = `
+{
+  "_cmd": "de v 14, de w v 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, de w v 6 1`] = `
+{
+  "_cmd": "de v 14, de w v 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, de w v 7 1`] = `
+{
+  "_cmd": "de v 14, de w v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, de w v 8 1`] = `
+{
+  "_cmd": "de v 14, de w v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, de w v 9 1`] = `
+{
+  "_cmd": "de v 14, de w v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, de w v 10 1`] = `
+{
+  "_cmd": "de v 14, de w v 10",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, de w v 11 1`] = `
+{
+  "_cmd": "de v 14, de w v 11",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, de w v 12 1`] = `
+{
+  "_cmd": "de v 14, de w v 12",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, de w v 13 1`] = `
+{
+  "_cmd": "de v 14, de w v 13",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, de w v 14 1`] = `
+{
+  "_cmd": "de v 14, de w v 14",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, de w v 15 1`] = `
+{
+  "_cmd": "de v 14, de w v 15",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, de w v 16 1`] = `
+{
+  "_cmd": "de v 14, de w v 16",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`de v 14, de w v 17 1`] = `
+{
+  "_cmd": "de v 14, de w v 17",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`de v 14, de w v 18 1`] = `
+{
+  "_cmd": "de v 14, de w v 18",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`de v 14, de w v 19 1`] = `
+{
+  "_cmd": "de v 14, de w v 19",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`de v 14, de w v 20 1`] = `
+{
+  "_cmd": "de v 14, de w v 20",
+  "attacker": 1,
+  "defender": 20,
+}
+`;
+
+exports[`de v 15, de d 1 1`] = `
+{
+  "_cmd": "de v 15, de d 1",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, de d 2 1`] = `
+{
+  "_cmd": "de v 15, de d 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, de d 3 1`] = `
+{
+  "_cmd": "de v 15, de d 3",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de d 4 1`] = `
+{
+  "_cmd": "de v 15, de d 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, de d 5 1`] = `
+{
+  "_cmd": "de v 15, de d 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de d 6 1`] = `
+{
+  "_cmd": "de v 15, de d 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de d 7 1`] = `
+{
+  "_cmd": "de v 15, de d 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de d 8 1`] = `
+{
+  "_cmd": "de v 15, de d 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de d 9 1`] = `
+{
+  "_cmd": "de v 15, de d 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de d 10 1`] = `
+{
+  "_cmd": "de v 15, de d 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, de d 11 1`] = `
+{
+  "_cmd": "de v 15, de d 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de d 12 1`] = `
+{
+  "_cmd": "de v 15, de d 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de d 13 1`] = `
+{
+  "_cmd": "de v 15, de d 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de d 14 1`] = `
+{
+  "_cmd": "de v 15, de d 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de d 15 1`] = `
+{
+  "_cmd": "de v 15, de d 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de d v 1 1`] = `
+{
+  "_cmd": "de v 15, de d v 1",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, de d v 2 1`] = `
+{
+  "_cmd": "de v 15, de d v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, de d v 3 1`] = `
+{
+  "_cmd": "de v 15, de d v 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de d v 4 1`] = `
+{
+  "_cmd": "de v 15, de d v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, de d v 5 1`] = `
+{
+  "_cmd": "de v 15, de d v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de d v 6 1`] = `
+{
+  "_cmd": "de v 15, de d v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de d v 7 1`] = `
+{
+  "_cmd": "de v 15, de d v 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de d v 8 1`] = `
+{
+  "_cmd": "de v 15, de d v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de d v 9 1`] = `
+{
+  "_cmd": "de v 15, de d v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de d v 10 1`] = `
+{
+  "_cmd": "de v 15, de d v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, de d v 11 1`] = `
+{
+  "_cmd": "de v 15, de d v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de d v 12 1`] = `
+{
+  "_cmd": "de v 15, de d v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de d v 13 1`] = `
+{
+  "_cmd": "de v 15, de d v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de d v 14 1`] = `
+{
+  "_cmd": "de v 15, de d v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de d v 15 1`] = `
+{
+  "_cmd": "de v 15, de d v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de d v 16 1`] = `
+{
+  "_cmd": "de v 15, de d v 16",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, de d v 17 1`] = `
+{
+  "_cmd": "de v 15, de d v 17",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de v 15, de d v 18 1`] = `
+{
+  "_cmd": "de v 15, de d v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de v 15, de d v 19 1`] = `
+{
+  "_cmd": "de v 15, de d v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de v 15, de d v 20 1`] = `
+{
+  "_cmd": "de v 15, de d v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de v 15, de p 1 1`] = `
+{
+  "_cmd": "de v 15, de p 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, de p 2 1`] = `
+{
+  "_cmd": "de v 15, de p 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, de p 3 1`] = `
+{
+  "_cmd": "de v 15, de p 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, de p 4 1`] = `
+{
+  "_cmd": "de v 15, de p 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de p 5 1`] = `
+{
+  "_cmd": "de v 15, de p 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de p 6 1`] = `
+{
+  "_cmd": "de v 15, de p 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de p 7 1`] = `
+{
+  "_cmd": "de v 15, de p 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de p 8 1`] = `
+{
+  "_cmd": "de v 15, de p 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de p 9 1`] = `
+{
+  "_cmd": "de v 15, de p 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de p 10 1`] = `
+{
+  "_cmd": "de v 15, de p 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de p 11 1`] = `
+{
+  "_cmd": "de v 15, de p 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de p 12 1`] = `
+{
+  "_cmd": "de v 15, de p 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de p 13 1`] = `
+{
+  "_cmd": "de v 15, de p 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de p 14 1`] = `
+{
+  "_cmd": "de v 15, de p 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de p 15 1`] = `
+{
+  "_cmd": "de v 15, de p 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de p v 1 1`] = `
+{
+  "_cmd": "de v 15, de p v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, de p v 2 1`] = `
+{
+  "_cmd": "de v 15, de p v 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, de p v 3 1`] = `
+{
+  "_cmd": "de v 15, de p v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, de p v 4 1`] = `
+{
+  "_cmd": "de v 15, de p v 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de p v 5 1`] = `
+{
+  "_cmd": "de v 15, de p v 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, de p v 6 1`] = `
+{
+  "_cmd": "de v 15, de p v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de p v 7 1`] = `
+{
+  "_cmd": "de v 15, de p v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de p v 8 1`] = `
+{
+  "_cmd": "de v 15, de p v 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de p v 9 1`] = `
+{
+  "_cmd": "de v 15, de p v 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de p v 10 1`] = `
+{
+  "_cmd": "de v 15, de p v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de p v 11 1`] = `
+{
+  "_cmd": "de v 15, de p v 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, de p v 12 1`] = `
+{
+  "_cmd": "de v 15, de p v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de p v 13 1`] = `
+{
+  "_cmd": "de v 15, de p v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de p v 14 1`] = `
+{
+  "_cmd": "de v 15, de p v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de p v 15 1`] = `
+{
+  "_cmd": "de v 15, de p v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de p v 16 1`] = `
+{
+  "_cmd": "de v 15, de p v 16",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, de p v 17 1`] = `
+{
+  "_cmd": "de v 15, de p v 17",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de v 15, de p v 18 1`] = `
+{
+  "_cmd": "de v 15, de p v 18",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de v 15, de p v 19 1`] = `
+{
+  "_cmd": "de v 15, de p v 19",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de v 15, de p v 20 1`] = `
+{
+  "_cmd": "de v 15, de p v 20",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de v 15, de v 1 1`] = `
+{
+  "_cmd": "de v 15, de v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, de v 2 1`] = `
+{
+  "_cmd": "de v 15, de v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, de v 3 1`] = `
+{
+  "_cmd": "de v 15, de v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, de v 4 1`] = `
+{
+  "_cmd": "de v 15, de v 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de v 5 1`] = `
+{
+  "_cmd": "de v 15, de v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de v 6 1`] = `
+{
+  "_cmd": "de v 15, de v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de v 7 1`] = `
+{
+  "_cmd": "de v 15, de v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de v 8 1`] = `
+{
+  "_cmd": "de v 15, de v 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de v 9 1`] = `
+{
+  "_cmd": "de v 15, de v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de v 10 1`] = `
+{
+  "_cmd": "de v 15, de v 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de v 11 1`] = `
+{
+  "_cmd": "de v 15, de v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de v 12 1`] = `
+{
+  "_cmd": "de v 15, de v 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de v 13 1`] = `
+{
+  "_cmd": "de v 15, de v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de v 14 1`] = `
+{
+  "_cmd": "de v 15, de v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de v 15 1`] = `
+{
+  "_cmd": "de v 15, de v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de v 16 1`] = `
+{
+  "_cmd": "de v 15, de v 16",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, de v 17 1`] = `
+{
+  "_cmd": "de v 15, de v 17",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de v 15, de v 18 1`] = `
+{
+  "_cmd": "de v 15, de v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`de v 15, de v 19 1`] = `
+{
+  "_cmd": "de v 15, de v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de v 15, de v 20 1`] = `
+{
+  "_cmd": "de v 15, de v 20",
+  "attacker": 4,
+  "defender": 19,
+}
+`;
+
+exports[`de v 15, de w 1 1`] = `
+{
+  "_cmd": "de v 15, de w 1",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, de w 2 1`] = `
+{
+  "_cmd": "de v 15, de w 2",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, de w 3 1`] = `
+{
+  "_cmd": "de v 15, de w 3",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, de w 4 1`] = `
+{
+  "_cmd": "de v 15, de w 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de w 5 1`] = `
+{
+  "_cmd": "de v 15, de w 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de w 6 1`] = `
+{
+  "_cmd": "de v 15, de w 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de w 7 1`] = `
+{
+  "_cmd": "de v 15, de w 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de w 8 1`] = `
+{
+  "_cmd": "de v 15, de w 8",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de w 9 1`] = `
+{
+  "_cmd": "de v 15, de w 9",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, de w 10 1`] = `
+{
+  "_cmd": "de v 15, de w 10",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, de w 11 1`] = `
+{
+  "_cmd": "de v 15, de w 11",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de w 12 1`] = `
+{
+  "_cmd": "de v 15, de w 12",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de w 13 1`] = `
+{
+  "_cmd": "de v 15, de w 13",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de w 14 1`] = `
+{
+  "_cmd": "de v 15, de w 14",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de w 15 1`] = `
+{
+  "_cmd": "de v 15, de w 15",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, de w v 1 1`] = `
+{
+  "_cmd": "de v 15, de w v 1",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, de w v 2 1`] = `
+{
+  "_cmd": "de v 15, de w v 2",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, de w v 3 1`] = `
+{
+  "_cmd": "de v 15, de w v 3",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, de w v 4 1`] = `
+{
+  "_cmd": "de v 15, de w v 4",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, de w v 5 1`] = `
+{
+  "_cmd": "de v 15, de w v 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, de w v 6 1`] = `
+{
+  "_cmd": "de v 15, de w v 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, de w v 7 1`] = `
+{
+  "_cmd": "de v 15, de w v 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, de w v 8 1`] = `
+{
+  "_cmd": "de v 15, de w v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, de w v 9 1`] = `
+{
+  "_cmd": "de v 15, de w v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, de w v 10 1`] = `
+{
+  "_cmd": "de v 15, de w v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, de w v 11 1`] = `
+{
+  "_cmd": "de v 15, de w v 11",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, de w v 12 1`] = `
+{
+  "_cmd": "de v 15, de w v 12",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, de w v 13 1`] = `
+{
+  "_cmd": "de v 15, de w v 13",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, de w v 14 1`] = `
+{
+  "_cmd": "de v 15, de w v 14",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, de w v 15 1`] = `
+{
+  "_cmd": "de v 15, de w v 15",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, de w v 16 1`] = `
+{
+  "_cmd": "de v 15, de w v 16",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`de v 15, de w v 17 1`] = `
+{
+  "_cmd": "de v 15, de w v 17",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`de v 15, de w v 18 1`] = `
+{
+  "_cmd": "de v 15, de w v 18",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`de v 15, de w v 19 1`] = `
+{
+  "_cmd": "de v 15, de w v 19",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`de v 15, de w v 20 1`] = `
+{
+  "_cmd": "de v 15, de w v 20",
+  "attacker": 2,
+  "defender": 20,
+}
+`;
+
+exports[`de v 16, de d 1 1`] = `
+{
+  "_cmd": "de v 16, de d 1",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, de d 2 1`] = `
+{
+  "_cmd": "de v 16, de d 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, de d 3 1`] = `
+{
+  "_cmd": "de v 16, de d 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, de d 4 1`] = `
+{
+  "_cmd": "de v 16, de d 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, de d 5 1`] = `
+{
+  "_cmd": "de v 16, de d 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de d 6 1`] = `
+{
+  "_cmd": "de v 16, de d 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de d 7 1`] = `
+{
+  "_cmd": "de v 16, de d 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de d 8 1`] = `
+{
+  "_cmd": "de v 16, de d 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de d 9 1`] = `
+{
+  "_cmd": "de v 16, de d 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de d 10 1`] = `
+{
+  "_cmd": "de v 16, de d 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de d 11 1`] = `
+{
+  "_cmd": "de v 16, de d 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, de d 12 1`] = `
+{
+  "_cmd": "de v 16, de d 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de d 13 1`] = `
+{
+  "_cmd": "de v 16, de d 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de d 14 1`] = `
+{
+  "_cmd": "de v 16, de d 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de d 15 1`] = `
+{
+  "_cmd": "de v 16, de d 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de d v 1 1`] = `
+{
+  "_cmd": "de v 16, de d v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, de d v 2 1`] = `
+{
+  "_cmd": "de v 16, de d v 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, de d v 3 1`] = `
+{
+  "_cmd": "de v 16, de d v 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, de d v 4 1`] = `
+{
+  "_cmd": "de v 16, de d v 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, de d v 5 1`] = `
+{
+  "_cmd": "de v 16, de d v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de d v 6 1`] = `
+{
+  "_cmd": "de v 16, de d v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, de d v 7 1`] = `
+{
+  "_cmd": "de v 16, de d v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de d v 8 1`] = `
+{
+  "_cmd": "de v 16, de d v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de d v 9 1`] = `
+{
+  "_cmd": "de v 16, de d v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de d v 10 1`] = `
+{
+  "_cmd": "de v 16, de d v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de d v 11 1`] = `
+{
+  "_cmd": "de v 16, de d v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, de d v 12 1`] = `
+{
+  "_cmd": "de v 16, de d v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de d v 13 1`] = `
+{
+  "_cmd": "de v 16, de d v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de d v 14 1`] = `
+{
+  "_cmd": "de v 16, de d v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de d v 15 1`] = `
+{
+  "_cmd": "de v 16, de d v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de d v 16 1`] = `
+{
+  "_cmd": "de v 16, de d v 16",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, de d v 17 1`] = `
+{
+  "_cmd": "de v 16, de d v 17",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de v 16, de d v 18 1`] = `
+{
+  "_cmd": "de v 16, de d v 18",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de v 16, de d v 19 1`] = `
+{
+  "_cmd": "de v 16, de d v 19",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de v 16, de d v 20 1`] = `
+{
+  "_cmd": "de v 16, de d v 20",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de v 16, de p 1 1`] = `
+{
+  "_cmd": "de v 16, de p 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, de p 2 1`] = `
+{
+  "_cmd": "de v 16, de p 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, de p 3 1`] = `
+{
+  "_cmd": "de v 16, de p 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, de p 4 1`] = `
+{
+  "_cmd": "de v 16, de p 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, de p 5 1`] = `
+{
+  "_cmd": "de v 16, de p 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de p 6 1`] = `
+{
+  "_cmd": "de v 16, de p 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, de p 7 1`] = `
+{
+  "_cmd": "de v 16, de p 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de p 8 1`] = `
+{
+  "_cmd": "de v 16, de p 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de p 9 1`] = `
+{
+  "_cmd": "de v 16, de p 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de p 10 1`] = `
+{
+  "_cmd": "de v 16, de p 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de p 11 1`] = `
+{
+  "_cmd": "de v 16, de p 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de p 12 1`] = `
+{
+  "_cmd": "de v 16, de p 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de p 13 1`] = `
+{
+  "_cmd": "de v 16, de p 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de p 14 1`] = `
+{
+  "_cmd": "de v 16, de p 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de p 15 1`] = `
+{
+  "_cmd": "de v 16, de p 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de p v 1 1`] = `
+{
+  "_cmd": "de v 16, de p v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, de p v 2 1`] = `
+{
+  "_cmd": "de v 16, de p v 2",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, de p v 3 1`] = `
+{
+  "_cmd": "de v 16, de p v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, de p v 4 1`] = `
+{
+  "_cmd": "de v 16, de p v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, de p v 5 1`] = `
+{
+  "_cmd": "de v 16, de p v 5",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, de p v 6 1`] = `
+{
+  "_cmd": "de v 16, de p v 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de p v 7 1`] = `
+{
+  "_cmd": "de v 16, de p v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de p v 8 1`] = `
+{
+  "_cmd": "de v 16, de p v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de p v 9 1`] = `
+{
+  "_cmd": "de v 16, de p v 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de p v 10 1`] = `
+{
+  "_cmd": "de v 16, de p v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de p v 11 1`] = `
+{
+  "_cmd": "de v 16, de p v 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de p v 12 1`] = `
+{
+  "_cmd": "de v 16, de p v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, de p v 13 1`] = `
+{
+  "_cmd": "de v 16, de p v 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de p v 14 1`] = `
+{
+  "_cmd": "de v 16, de p v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de p v 15 1`] = `
+{
+  "_cmd": "de v 16, de p v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de p v 16 1`] = `
+{
+  "_cmd": "de v 16, de p v 16",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, de p v 17 1`] = `
+{
+  "_cmd": "de v 16, de p v 17",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de v 16, de p v 18 1`] = `
+{
+  "_cmd": "de v 16, de p v 18",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de v 16, de p v 19 1`] = `
+{
+  "_cmd": "de v 16, de p v 19",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de v 16, de p v 20 1`] = `
+{
+  "_cmd": "de v 16, de p v 20",
+  "attacker": 6,
+  "defender": 19,
+}
+`;
+
+exports[`de v 16, de v 1 1`] = `
+{
+  "_cmd": "de v 16, de v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, de v 2 1`] = `
+{
+  "_cmd": "de v 16, de v 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, de v 3 1`] = `
+{
+  "_cmd": "de v 16, de v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, de v 4 1`] = `
+{
+  "_cmd": "de v 16, de v 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, de v 5 1`] = `
+{
+  "_cmd": "de v 16, de v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de v 6 1`] = `
+{
+  "_cmd": "de v 16, de v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, de v 7 1`] = `
+{
+  "_cmd": "de v 16, de v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de v 8 1`] = `
+{
+  "_cmd": "de v 16, de v 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de v 9 1`] = `
+{
+  "_cmd": "de v 16, de v 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de v 10 1`] = `
+{
+  "_cmd": "de v 16, de v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de v 11 1`] = `
+{
+  "_cmd": "de v 16, de v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, de v 12 1`] = `
+{
+  "_cmd": "de v 16, de v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de v 13 1`] = `
+{
+  "_cmd": "de v 16, de v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de v 14 1`] = `
+{
+  "_cmd": "de v 16, de v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de v 15 1`] = `
+{
+  "_cmd": "de v 16, de v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de v 16 1`] = `
+{
+  "_cmd": "de v 16, de v 16",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, de v 17 1`] = `
+{
+  "_cmd": "de v 16, de v 17",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de v 16, de v 18 1`] = `
+{
+  "_cmd": "de v 16, de v 18",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de v 16, de v 19 1`] = `
+{
+  "_cmd": "de v 16, de v 19",
+  "attacker": 5,
+  "defender": 18,
+}
+`;
+
+exports[`de v 16, de v 20 1`] = `
+{
+  "_cmd": "de v 16, de v 20",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de v 16, de w 1 1`] = `
+{
+  "_cmd": "de v 16, de w 1",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, de w 2 1`] = `
+{
+  "_cmd": "de v 16, de w 2",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, de w 3 1`] = `
+{
+  "_cmd": "de v 16, de w 3",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, de w 4 1`] = `
+{
+  "_cmd": "de v 16, de w 4",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de w 5 1`] = `
+{
+  "_cmd": "de v 16, de w 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, de w 6 1`] = `
+{
+  "_cmd": "de v 16, de w 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de w 7 1`] = `
+{
+  "_cmd": "de v 16, de w 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de w 8 1`] = `
+{
+  "_cmd": "de v 16, de w 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de w 9 1`] = `
+{
+  "_cmd": "de v 16, de w 9",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de w 10 1`] = `
+{
+  "_cmd": "de v 16, de w 10",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, de w 11 1`] = `
+{
+  "_cmd": "de v 16, de w 11",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de w 12 1`] = `
+{
+  "_cmd": "de v 16, de w 12",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de w 13 1`] = `
+{
+  "_cmd": "de v 16, de w 13",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de w 14 1`] = `
+{
+  "_cmd": "de v 16, de w 14",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de w 15 1`] = `
+{
+  "_cmd": "de v 16, de w 15",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, de w v 1 1`] = `
+{
+  "_cmd": "de v 16, de w v 1",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, de w v 2 1`] = `
+{
+  "_cmd": "de v 16, de w v 2",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, de w v 3 1`] = `
+{
+  "_cmd": "de v 16, de w v 3",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, de w v 4 1`] = `
+{
+  "_cmd": "de v 16, de w v 4",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, de w v 5 1`] = `
+{
+  "_cmd": "de v 16, de w v 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, de w v 6 1`] = `
+{
+  "_cmd": "de v 16, de w v 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, de w v 7 1`] = `
+{
+  "_cmd": "de v 16, de w v 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, de w v 8 1`] = `
+{
+  "_cmd": "de v 16, de w v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, de w v 9 1`] = `
+{
+  "_cmd": "de v 16, de w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, de w v 10 1`] = `
+{
+  "_cmd": "de v 16, de w v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, de w v 11 1`] = `
+{
+  "_cmd": "de v 16, de w v 11",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, de w v 12 1`] = `
+{
+  "_cmd": "de v 16, de w v 12",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, de w v 13 1`] = `
+{
+  "_cmd": "de v 16, de w v 13",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, de w v 14 1`] = `
+{
+  "_cmd": "de v 16, de w v 14",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, de w v 15 1`] = `
+{
+  "_cmd": "de v 16, de w v 15",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, de w v 16 1`] = `
+{
+  "_cmd": "de v 16, de w v 16",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`de v 16, de w v 17 1`] = `
+{
+  "_cmd": "de v 16, de w v 17",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`de v 16, de w v 18 1`] = `
+{
+  "_cmd": "de v 16, de w v 18",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`de v 16, de w v 19 1`] = `
+{
+  "_cmd": "de v 16, de w v 19",
+  "attacker": 3,
+  "defender": 19,
+}
+`;
+
+exports[`de v 16, de w v 20 1`] = `
+{
+  "_cmd": "de v 16, de w v 20",
+  "attacker": 3,
+  "defender": 20,
+}
+`;
+
+exports[`de v 17, de d 1 1`] = `
+{
+  "_cmd": "de v 17, de d 1",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, de d 2 1`] = `
+{
+  "_cmd": "de v 17, de d 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, de d 3 1`] = `
+{
+  "_cmd": "de v 17, de d 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, de d 4 1`] = `
+{
+  "_cmd": "de v 17, de d 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, de d 5 1`] = `
+{
+  "_cmd": "de v 17, de d 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de d 6 1`] = `
+{
+  "_cmd": "de v 17, de d 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de d 7 1`] = `
+{
+  "_cmd": "de v 17, de d 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de d 8 1`] = `
+{
+  "_cmd": "de v 17, de d 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de d 9 1`] = `
+{
+  "_cmd": "de v 17, de d 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de d 10 1`] = `
+{
+  "_cmd": "de v 17, de d 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de d 11 1`] = `
+{
+  "_cmd": "de v 17, de d 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de d 12 1`] = `
+{
+  "_cmd": "de v 17, de d 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, de d 13 1`] = `
+{
+  "_cmd": "de v 17, de d 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de d 14 1`] = `
+{
+  "_cmd": "de v 17, de d 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de d 15 1`] = `
+{
+  "_cmd": "de v 17, de d 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de d v 1 1`] = `
+{
+  "_cmd": "de v 17, de d v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, de d v 2 1`] = `
+{
+  "_cmd": "de v 17, de d v 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, de d v 3 1`] = `
+{
+  "_cmd": "de v 17, de d v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de d v 4 1`] = `
+{
+  "_cmd": "de v 17, de d v 4",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, de d v 5 1`] = `
+{
+  "_cmd": "de v 17, de d v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de d v 6 1`] = `
+{
+  "_cmd": "de v 17, de d v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, de d v 7 1`] = `
+{
+  "_cmd": "de v 17, de d v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de d v 8 1`] = `
+{
+  "_cmd": "de v 17, de d v 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de d v 9 1`] = `
+{
+  "_cmd": "de v 17, de d v 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de d v 10 1`] = `
+{
+  "_cmd": "de v 17, de d v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de d v 11 1`] = `
+{
+  "_cmd": "de v 17, de d v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de d v 12 1`] = `
+{
+  "_cmd": "de v 17, de d v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, de d v 13 1`] = `
+{
+  "_cmd": "de v 17, de d v 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de d v 14 1`] = `
+{
+  "_cmd": "de v 17, de d v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de d v 15 1`] = `
+{
+  "_cmd": "de v 17, de d v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de d v 16 1`] = `
+{
+  "_cmd": "de v 17, de d v 16",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 17, de d v 17 1`] = `
+{
+  "_cmd": "de v 17, de d v 17",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de v 17, de d v 18 1`] = `
+{
+  "_cmd": "de v 17, de d v 18",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de v 17, de d v 19 1`] = `
+{
+  "_cmd": "de v 17, de d v 19",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de v 17, de d v 20 1`] = `
+{
+  "_cmd": "de v 17, de d v 20",
+  "attacker": 6,
+  "defender": 19,
+}
+`;
+
+exports[`de v 17, de p 1 1`] = `
+{
+  "_cmd": "de v 17, de p 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, de p 2 1`] = `
+{
+  "_cmd": "de v 17, de p 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, de p 3 1`] = `
+{
+  "_cmd": "de v 17, de p 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de p 4 1`] = `
+{
+  "_cmd": "de v 17, de p 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, de p 5 1`] = `
+{
+  "_cmd": "de v 17, de p 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de p 6 1`] = `
+{
+  "_cmd": "de v 17, de p 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, de p 7 1`] = `
+{
+  "_cmd": "de v 17, de p 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de p 8 1`] = `
+{
+  "_cmd": "de v 17, de p 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de p 9 1`] = `
+{
+  "_cmd": "de v 17, de p 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de p 10 1`] = `
+{
+  "_cmd": "de v 17, de p 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de p 11 1`] = `
+{
+  "_cmd": "de v 17, de p 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de p 12 1`] = `
+{
+  "_cmd": "de v 17, de p 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de p 13 1`] = `
+{
+  "_cmd": "de v 17, de p 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de p 14 1`] = `
+{
+  "_cmd": "de v 17, de p 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de p 15 1`] = `
+{
+  "_cmd": "de v 17, de p 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de p v 1 1`] = `
+{
+  "_cmd": "de v 17, de p v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, de p v 2 1`] = `
+{
+  "_cmd": "de v 17, de p v 2",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, de p v 3 1`] = `
+{
+  "_cmd": "de v 17, de p v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de p v 4 1`] = `
+{
+  "_cmd": "de v 17, de p v 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, de p v 5 1`] = `
+{
+  "_cmd": "de v 17, de p v 5",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, de p v 6 1`] = `
+{
+  "_cmd": "de v 17, de p v 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de p v 7 1`] = `
+{
+  "_cmd": "de v 17, de p v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de p v 8 1`] = `
+{
+  "_cmd": "de v 17, de p v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de p v 9 1`] = `
+{
+  "_cmd": "de v 17, de p v 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de p v 10 1`] = `
+{
+  "_cmd": "de v 17, de p v 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de p v 11 1`] = `
+{
+  "_cmd": "de v 17, de p v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de p v 12 1`] = `
+{
+  "_cmd": "de v 17, de p v 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de p v 13 1`] = `
+{
+  "_cmd": "de v 17, de p v 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, de p v 14 1`] = `
+{
+  "_cmd": "de v 17, de p v 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de p v 15 1`] = `
+{
+  "_cmd": "de v 17, de p v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de p v 16 1`] = `
+{
+  "_cmd": "de v 17, de p v 16",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de p v 17 1`] = `
+{
+  "_cmd": "de v 17, de p v 17",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de v 17, de p v 18 1`] = `
+{
+  "_cmd": "de v 17, de p v 18",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de v 17, de p v 19 1`] = `
+{
+  "_cmd": "de v 17, de p v 19",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de v 17, de p v 20 1`] = `
+{
+  "_cmd": "de v 17, de p v 20",
+  "attacker": 7,
+  "defender": 19,
+}
+`;
+
+exports[`de v 17, de v 1 1`] = `
+{
+  "_cmd": "de v 17, de v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, de v 2 1`] = `
+{
+  "_cmd": "de v 17, de v 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, de v 3 1`] = `
+{
+  "_cmd": "de v 17, de v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de v 4 1`] = `
+{
+  "_cmd": "de v 17, de v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, de v 5 1`] = `
+{
+  "_cmd": "de v 17, de v 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de v 6 1`] = `
+{
+  "_cmd": "de v 17, de v 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, de v 7 1`] = `
+{
+  "_cmd": "de v 17, de v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de v 8 1`] = `
+{
+  "_cmd": "de v 17, de v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de v 9 1`] = `
+{
+  "_cmd": "de v 17, de v 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de v 10 1`] = `
+{
+  "_cmd": "de v 17, de v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de v 11 1`] = `
+{
+  "_cmd": "de v 17, de v 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de v 12 1`] = `
+{
+  "_cmd": "de v 17, de v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, de v 13 1`] = `
+{
+  "_cmd": "de v 17, de v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de v 14 1`] = `
+{
+  "_cmd": "de v 17, de v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de v 15 1`] = `
+{
+  "_cmd": "de v 17, de v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de v 16 1`] = `
+{
+  "_cmd": "de v 17, de v 16",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de v 17, de v 17 1`] = `
+{
+  "_cmd": "de v 17, de v 17",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de v 17, de v 18 1`] = `
+{
+  "_cmd": "de v 17, de v 18",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de v 17, de v 19 1`] = `
+{
+  "_cmd": "de v 17, de v 19",
+  "attacker": 7,
+  "defender": 18,
+}
+`;
+
+exports[`de v 17, de v 20 1`] = `
+{
+  "_cmd": "de v 17, de v 20",
+  "attacker": 6,
+  "defender": 19,
+}
+`;
+
+exports[`de v 17, de w 1 1`] = `
+{
+  "_cmd": "de v 17, de w 1",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, de w 2 1`] = `
+{
+  "_cmd": "de v 17, de w 2",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de w 3 1`] = `
+{
+  "_cmd": "de v 17, de w 3",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, de w 4 1`] = `
+{
+  "_cmd": "de v 17, de w 4",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de w 5 1`] = `
+{
+  "_cmd": "de v 17, de w 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, de w 6 1`] = `
+{
+  "_cmd": "de v 17, de w 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de w 7 1`] = `
+{
+  "_cmd": "de v 17, de w 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de w 8 1`] = `
+{
+  "_cmd": "de v 17, de w 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de w 9 1`] = `
+{
+  "_cmd": "de v 17, de w 9",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de w 10 1`] = `
+{
+  "_cmd": "de v 17, de w 10",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de w 11 1`] = `
+{
+  "_cmd": "de v 17, de w 11",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, de w 12 1`] = `
+{
+  "_cmd": "de v 17, de w 12",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de w 13 1`] = `
+{
+  "_cmd": "de v 17, de w 13",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de w 14 1`] = `
+{
+  "_cmd": "de v 17, de w 14",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de w 15 1`] = `
+{
+  "_cmd": "de v 17, de w 15",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 17, de w v 1 1`] = `
+{
+  "_cmd": "de v 17, de w v 1",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, de w v 2 1`] = `
+{
+  "_cmd": "de v 17, de w v 2",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, de w v 3 1`] = `
+{
+  "_cmd": "de v 17, de w v 3",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, de w v 4 1`] = `
+{
+  "_cmd": "de v 17, de w v 4",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, de w v 5 1`] = `
+{
+  "_cmd": "de v 17, de w v 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, de w v 6 1`] = `
+{
+  "_cmd": "de v 17, de w v 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, de w v 7 1`] = `
+{
+  "_cmd": "de v 17, de w v 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, de w v 8 1`] = `
+{
+  "_cmd": "de v 17, de w v 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, de w v 9 1`] = `
+{
+  "_cmd": "de v 17, de w v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, de w v 10 1`] = `
+{
+  "_cmd": "de v 17, de w v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, de w v 11 1`] = `
+{
+  "_cmd": "de v 17, de w v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, de w v 12 1`] = `
+{
+  "_cmd": "de v 17, de w v 12",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, de w v 13 1`] = `
+{
+  "_cmd": "de v 17, de w v 13",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, de w v 14 1`] = `
+{
+  "_cmd": "de v 17, de w v 14",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, de w v 15 1`] = `
+{
+  "_cmd": "de v 17, de w v 15",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de v 17, de w v 16 1`] = `
+{
+  "_cmd": "de v 17, de w v 16",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`de v 17, de w v 17 1`] = `
+{
+  "_cmd": "de v 17, de w v 17",
+  "attacker": 5,
+  "defender": 17,
+}
+`;
+
+exports[`de v 17, de w v 18 1`] = `
+{
+  "_cmd": "de v 17, de w v 18",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`de v 17, de w v 19 1`] = `
+{
+  "_cmd": "de v 17, de w v 19",
+  "attacker": 4,
+  "defender": 19,
+}
+`;
+
+exports[`de v 17, de w v 20 1`] = `
+{
+  "_cmd": "de v 17, de w v 20",
+  "attacker": 4,
+  "defender": 20,
+}
+`;
+
+exports[`de v 18, de d 1 1`] = `
+{
+  "_cmd": "de v 18, de d 1",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, de d 2 1`] = `
+{
+  "_cmd": "de v 18, de d 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, de d 3 1`] = `
+{
+  "_cmd": "de v 18, de d 3",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, de d 4 1`] = `
+{
+  "_cmd": "de v 18, de d 4",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, de d 5 1`] = `
+{
+  "_cmd": "de v 18, de d 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de d 6 1`] = `
+{
+  "_cmd": "de v 18, de d 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de d 7 1`] = `
+{
+  "_cmd": "de v 18, de d 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de d 8 1`] = `
+{
+  "_cmd": "de v 18, de d 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de d 9 1`] = `
+{
+  "_cmd": "de v 18, de d 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de d 10 1`] = `
+{
+  "_cmd": "de v 18, de d 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de d 11 1`] = `
+{
+  "_cmd": "de v 18, de d 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de d 12 1`] = `
+{
+  "_cmd": "de v 18, de d 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, de d 13 1`] = `
+{
+  "_cmd": "de v 18, de d 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de d 14 1`] = `
+{
+  "_cmd": "de v 18, de d 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de d 15 1`] = `
+{
+  "_cmd": "de v 18, de d 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de d v 1 1`] = `
+{
+  "_cmd": "de v 18, de d v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, de d v 2 1`] = `
+{
+  "_cmd": "de v 18, de d v 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, de d v 3 1`] = `
+{
+  "_cmd": "de v 18, de d v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de d v 4 1`] = `
+{
+  "_cmd": "de v 18, de d v 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, de d v 5 1`] = `
+{
+  "_cmd": "de v 18, de d v 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de d v 6 1`] = `
+{
+  "_cmd": "de v 18, de d v 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de d v 7 1`] = `
+{
+  "_cmd": "de v 18, de d v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de d v 8 1`] = `
+{
+  "_cmd": "de v 18, de d v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de d v 9 1`] = `
+{
+  "_cmd": "de v 18, de d v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de d v 10 1`] = `
+{
+  "_cmd": "de v 18, de d v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de d v 11 1`] = `
+{
+  "_cmd": "de v 18, de d v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de d v 12 1`] = `
+{
+  "_cmd": "de v 18, de d v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, de d v 13 1`] = `
+{
+  "_cmd": "de v 18, de d v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de d v 14 1`] = `
+{
+  "_cmd": "de v 18, de d v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de d v 15 1`] = `
+{
+  "_cmd": "de v 18, de d v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de d v 16 1`] = `
+{
+  "_cmd": "de v 18, de d v 16",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, de d v 17 1`] = `
+{
+  "_cmd": "de v 18, de d v 17",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de v 18, de d v 18 1`] = `
+{
+  "_cmd": "de v 18, de d v 18",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de v 18, de d v 19 1`] = `
+{
+  "_cmd": "de v 18, de d v 19",
+  "attacker": 7,
+  "defender": 18,
+}
+`;
+
+exports[`de v 18, de d v 20 1`] = `
+{
+  "_cmd": "de v 18, de d v 20",
+  "attacker": 7,
+  "defender": 19,
+}
+`;
+
+exports[`de v 18, de p 1 1`] = `
+{
+  "_cmd": "de v 18, de p 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, de p 2 1`] = `
+{
+  "_cmd": "de v 18, de p 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, de p 3 1`] = `
+{
+  "_cmd": "de v 18, de p 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de p 4 1`] = `
+{
+  "_cmd": "de v 18, de p 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, de p 5 1`] = `
+{
+  "_cmd": "de v 18, de p 5",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, de p 6 1`] = `
+{
+  "_cmd": "de v 18, de p 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de p 7 1`] = `
+{
+  "_cmd": "de v 18, de p 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de p 8 1`] = `
+{
+  "_cmd": "de v 18, de p 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de p 9 1`] = `
+{
+  "_cmd": "de v 18, de p 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de p 10 1`] = `
+{
+  "_cmd": "de v 18, de p 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de p 11 1`] = `
+{
+  "_cmd": "de v 18, de p 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de p 12 1`] = `
+{
+  "_cmd": "de v 18, de p 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de p 13 1`] = `
+{
+  "_cmd": "de v 18, de p 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de p 14 1`] = `
+{
+  "_cmd": "de v 18, de p 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de p 15 1`] = `
+{
+  "_cmd": "de v 18, de p 15",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de p v 1 1`] = `
+{
+  "_cmd": "de v 18, de p v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, de p v 2 1`] = `
+{
+  "_cmd": "de v 18, de p v 2",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, de p v 3 1`] = `
+{
+  "_cmd": "de v 18, de p v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de p v 4 1`] = `
+{
+  "_cmd": "de v 18, de p v 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, de p v 5 1`] = `
+{
+  "_cmd": "de v 18, de p v 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, de p v 6 1`] = `
+{
+  "_cmd": "de v 18, de p v 6",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de p v 7 1`] = `
+{
+  "_cmd": "de v 18, de p v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de p v 8 1`] = `
+{
+  "_cmd": "de v 18, de p v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de p v 9 1`] = `
+{
+  "_cmd": "de v 18, de p v 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de p v 10 1`] = `
+{
+  "_cmd": "de v 18, de p v 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de p v 11 1`] = `
+{
+  "_cmd": "de v 18, de p v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de p v 12 1`] = `
+{
+  "_cmd": "de v 18, de p v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de p v 13 1`] = `
+{
+  "_cmd": "de v 18, de p v 13",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, de p v 14 1`] = `
+{
+  "_cmd": "de v 18, de p v 14",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de p v 15 1`] = `
+{
+  "_cmd": "de v 18, de p v 15",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de p v 16 1`] = `
+{
+  "_cmd": "de v 18, de p v 16",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de p v 17 1`] = `
+{
+  "_cmd": "de v 18, de p v 17",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, de p v 18 1`] = `
+{
+  "_cmd": "de v 18, de p v 18",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de v 18, de p v 19 1`] = `
+{
+  "_cmd": "de v 18, de p v 19",
+  "attacker": 9,
+  "defender": 18,
+}
+`;
+
+exports[`de v 18, de p v 20 1`] = `
+{
+  "_cmd": "de v 18, de p v 20",
+  "attacker": 9,
+  "defender": 19,
+}
+`;
+
+exports[`de v 18, de v 1 1`] = `
+{
+  "_cmd": "de v 18, de v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, de v 2 1`] = `
+{
+  "_cmd": "de v 18, de v 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, de v 3 1`] = `
+{
+  "_cmd": "de v 18, de v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de v 4 1`] = `
+{
+  "_cmd": "de v 18, de v 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, de v 5 1`] = `
+{
+  "_cmd": "de v 18, de v 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de v 6 1`] = `
+{
+  "_cmd": "de v 18, de v 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de v 7 1`] = `
+{
+  "_cmd": "de v 18, de v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de v 8 1`] = `
+{
+  "_cmd": "de v 18, de v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de v 9 1`] = `
+{
+  "_cmd": "de v 18, de v 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de v 10 1`] = `
+{
+  "_cmd": "de v 18, de v 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de v 11 1`] = `
+{
+  "_cmd": "de v 18, de v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de v 12 1`] = `
+{
+  "_cmd": "de v 18, de v 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de v 13 1`] = `
+{
+  "_cmd": "de v 18, de v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de v 14 1`] = `
+{
+  "_cmd": "de v 18, de v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de v 15 1`] = `
+{
+  "_cmd": "de v 18, de v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de v 16 1`] = `
+{
+  "_cmd": "de v 18, de v 16",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, de v 17 1`] = `
+{
+  "_cmd": "de v 18, de v 17",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de v 18, de v 18 1`] = `
+{
+  "_cmd": "de v 18, de v 18",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de v 18, de v 19 1`] = `
+{
+  "_cmd": "de v 18, de v 19",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de v 18, de v 20 1`] = `
+{
+  "_cmd": "de v 18, de v 20",
+  "attacker": 8,
+  "defender": 19,
+}
+`;
+
+exports[`de v 18, de w 1 1`] = `
+{
+  "_cmd": "de v 18, de w 1",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, de w 2 1`] = `
+{
+  "_cmd": "de v 18, de w 2",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de w 3 1`] = `
+{
+  "_cmd": "de v 18, de w 3",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, de w 4 1`] = `
+{
+  "_cmd": "de v 18, de w 4",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de w 5 1`] = `
+{
+  "_cmd": "de v 18, de w 5",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de w 6 1`] = `
+{
+  "_cmd": "de v 18, de w 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de w 7 1`] = `
+{
+  "_cmd": "de v 18, de w 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de w 8 1`] = `
+{
+  "_cmd": "de v 18, de w 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de w 9 1`] = `
+{
+  "_cmd": "de v 18, de w 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de w 10 1`] = `
+{
+  "_cmd": "de v 18, de w 10",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de w 11 1`] = `
+{
+  "_cmd": "de v 18, de w 11",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, de w 12 1`] = `
+{
+  "_cmd": "de v 18, de w 12",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, de w 13 1`] = `
+{
+  "_cmd": "de v 18, de w 13",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de w 14 1`] = `
+{
+  "_cmd": "de v 18, de w 14",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de w 15 1`] = `
+{
+  "_cmd": "de v 18, de w 15",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, de w v 1 1`] = `
+{
+  "_cmd": "de v 18, de w v 1",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, de w v 2 1`] = `
+{
+  "_cmd": "de v 18, de w v 2",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, de w v 3 1`] = `
+{
+  "_cmd": "de v 18, de w v 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, de w v 4 1`] = `
+{
+  "_cmd": "de v 18, de w v 4",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, de w v 5 1`] = `
+{
+  "_cmd": "de v 18, de w v 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, de w v 6 1`] = `
+{
+  "_cmd": "de v 18, de w v 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, de w v 7 1`] = `
+{
+  "_cmd": "de v 18, de w v 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, de w v 8 1`] = `
+{
+  "_cmd": "de v 18, de w v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, de w v 9 1`] = `
+{
+  "_cmd": "de v 18, de w v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, de w v 10 1`] = `
+{
+  "_cmd": "de v 18, de w v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, de w v 11 1`] = `
+{
+  "_cmd": "de v 18, de w v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, de w v 12 1`] = `
+{
+  "_cmd": "de v 18, de w v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, de w v 13 1`] = `
+{
+  "_cmd": "de v 18, de w v 13",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, de w v 14 1`] = `
+{
+  "_cmd": "de v 18, de w v 14",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, de w v 15 1`] = `
+{
+  "_cmd": "de v 18, de w v 15",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, de w v 16 1`] = `
+{
+  "_cmd": "de v 18, de w v 16",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`de v 18, de w v 17 1`] = `
+{
+  "_cmd": "de v 18, de w v 17",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`de v 18, de w v 18 1`] = `
+{
+  "_cmd": "de v 18, de w v 18",
+  "attacker": 6,
+  "defender": 18,
+}
+`;
+
+exports[`de v 18, de w v 19 1`] = `
+{
+  "_cmd": "de v 18, de w v 19",
+  "attacker": 5,
+  "defender": 19,
+}
+`;
+
+exports[`de v 18, de w v 20 1`] = `
+{
+  "_cmd": "de v 18, de w v 20",
+  "attacker": 5,
+  "defender": 20,
+}
+`;
+
+exports[`de v 19, de d 1 1`] = `
+{
+  "_cmd": "de v 19, de d 1",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, de d 2 1`] = `
+{
+  "_cmd": "de v 19, de d 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, de d 3 1`] = `
+{
+  "_cmd": "de v 19, de d 3",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, de d 4 1`] = `
+{
+  "_cmd": "de v 19, de d 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de d 5 1`] = `
+{
+  "_cmd": "de v 19, de d 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, de d 6 1`] = `
+{
+  "_cmd": "de v 19, de d 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de d 7 1`] = `
+{
+  "_cmd": "de v 19, de d 7",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de d 8 1`] = `
+{
+  "_cmd": "de v 19, de d 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de d 9 1`] = `
+{
+  "_cmd": "de v 19, de d 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de d 10 1`] = `
+{
+  "_cmd": "de v 19, de d 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de d 11 1`] = `
+{
+  "_cmd": "de v 19, de d 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de d 12 1`] = `
+{
+  "_cmd": "de v 19, de d 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de d 13 1`] = `
+{
+  "_cmd": "de v 19, de d 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, de d 14 1`] = `
+{
+  "_cmd": "de v 19, de d 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de d 15 1`] = `
+{
+  "_cmd": "de v 19, de d 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de d v 1 1`] = `
+{
+  "_cmd": "de v 19, de d v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, de d v 2 1`] = `
+{
+  "_cmd": "de v 19, de d v 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, de d v 3 1`] = `
+{
+  "_cmd": "de v 19, de d v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de d v 4 1`] = `
+{
+  "_cmd": "de v 19, de d v 4",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de d v 5 1`] = `
+{
+  "_cmd": "de v 19, de d v 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, de d v 6 1`] = `
+{
+  "_cmd": "de v 19, de d v 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de d v 7 1`] = `
+{
+  "_cmd": "de v 19, de d v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, de d v 8 1`] = `
+{
+  "_cmd": "de v 19, de d v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de d v 9 1`] = `
+{
+  "_cmd": "de v 19, de d v 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de d v 10 1`] = `
+{
+  "_cmd": "de v 19, de d v 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de d v 11 1`] = `
+{
+  "_cmd": "de v 19, de d v 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de d v 12 1`] = `
+{
+  "_cmd": "de v 19, de d v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de d v 13 1`] = `
+{
+  "_cmd": "de v 19, de d v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, de d v 14 1`] = `
+{
+  "_cmd": "de v 19, de d v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de d v 15 1`] = `
+{
+  "_cmd": "de v 19, de d v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de d v 16 1`] = `
+{
+  "_cmd": "de v 19, de d v 16",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, de d v 17 1`] = `
+{
+  "_cmd": "de v 19, de d v 17",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de v 19, de d v 18 1`] = `
+{
+  "_cmd": "de v 19, de d v 18",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de v 19, de d v 19 1`] = `
+{
+  "_cmd": "de v 19, de d v 19",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de v 19, de d v 20 1`] = `
+{
+  "_cmd": "de v 19, de d v 20",
+  "attacker": 8,
+  "defender": 19,
+}
+`;
+
+exports[`de v 19, de p 1 1`] = `
+{
+  "_cmd": "de v 19, de p 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, de p 2 1`] = `
+{
+  "_cmd": "de v 19, de p 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, de p 3 1`] = `
+{
+  "_cmd": "de v 19, de p 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de p 4 1`] = `
+{
+  "_cmd": "de v 19, de p 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, de p 5 1`] = `
+{
+  "_cmd": "de v 19, de p 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de p 6 1`] = `
+{
+  "_cmd": "de v 19, de p 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de p 7 1`] = `
+{
+  "_cmd": "de v 19, de p 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, de p 8 1`] = `
+{
+  "_cmd": "de v 19, de p 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de p 9 1`] = `
+{
+  "_cmd": "de v 19, de p 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de p 10 1`] = `
+{
+  "_cmd": "de v 19, de p 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de p 11 1`] = `
+{
+  "_cmd": "de v 19, de p 11",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de p 12 1`] = `
+{
+  "_cmd": "de v 19, de p 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de p 13 1`] = `
+{
+  "_cmd": "de v 19, de p 13",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de p 14 1`] = `
+{
+  "_cmd": "de v 19, de p 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de p 15 1`] = `
+{
+  "_cmd": "de v 19, de p 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de p v 1 1`] = `
+{
+  "_cmd": "de v 19, de p v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, de p v 2 1`] = `
+{
+  "_cmd": "de v 19, de p v 2",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, de p v 3 1`] = `
+{
+  "_cmd": "de v 19, de p v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de p v 4 1`] = `
+{
+  "_cmd": "de v 19, de p v 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, de p v 5 1`] = `
+{
+  "_cmd": "de v 19, de p v 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de p v 6 1`] = `
+{
+  "_cmd": "de v 19, de p v 6",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, de p v 7 1`] = `
+{
+  "_cmd": "de v 19, de p v 7",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de p v 8 1`] = `
+{
+  "_cmd": "de v 19, de p v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de p v 9 1`] = `
+{
+  "_cmd": "de v 19, de p v 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de p v 10 1`] = `
+{
+  "_cmd": "de v 19, de p v 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de p v 11 1`] = `
+{
+  "_cmd": "de v 19, de p v 11",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de p v 12 1`] = `
+{
+  "_cmd": "de v 19, de p v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de p v 13 1`] = `
+{
+  "_cmd": "de v 19, de p v 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de p v 14 1`] = `
+{
+  "_cmd": "de v 19, de p v 14",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, de p v 15 1`] = `
+{
+  "_cmd": "de v 19, de p v 15",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de p v 16 1`] = `
+{
+  "_cmd": "de v 19, de p v 16",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de p v 17 1`] = `
+{
+  "_cmd": "de v 19, de p v 17",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, de p v 18 1`] = `
+{
+  "_cmd": "de v 19, de p v 18",
+  "attacker": 10,
+  "defender": 16,
+}
+`;
+
+exports[`de v 19, de p v 19 1`] = `
+{
+  "_cmd": "de v 19, de p v 19",
+  "attacker": 10,
+  "defender": 18,
+}
+`;
+
+exports[`de v 19, de p v 20 1`] = `
+{
+  "_cmd": "de v 19, de p v 20",
+  "attacker": 10,
+  "defender": 19,
+}
+`;
+
+exports[`de v 19, de v 1 1`] = `
+{
+  "_cmd": "de v 19, de v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, de v 2 1`] = `
+{
+  "_cmd": "de v 19, de v 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, de v 3 1`] = `
+{
+  "_cmd": "de v 19, de v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de v 4 1`] = `
+{
+  "_cmd": "de v 19, de v 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, de v 5 1`] = `
+{
+  "_cmd": "de v 19, de v 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de v 6 1`] = `
+{
+  "_cmd": "de v 19, de v 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de v 7 1`] = `
+{
+  "_cmd": "de v 19, de v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, de v 8 1`] = `
+{
+  "_cmd": "de v 19, de v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de v 9 1`] = `
+{
+  "_cmd": "de v 19, de v 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de v 10 1`] = `
+{
+  "_cmd": "de v 19, de v 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de v 11 1`] = `
+{
+  "_cmd": "de v 19, de v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de v 12 1`] = `
+{
+  "_cmd": "de v 19, de v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de v 13 1`] = `
+{
+  "_cmd": "de v 19, de v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, de v 14 1`] = `
+{
+  "_cmd": "de v 19, de v 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de v 15 1`] = `
+{
+  "_cmd": "de v 19, de v 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de v 16 1`] = `
+{
+  "_cmd": "de v 19, de v 16",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, de v 17 1`] = `
+{
+  "_cmd": "de v 19, de v 17",
+  "attacker": 9,
+  "defender": 16,
+}
+`;
+
+exports[`de v 19, de v 18 1`] = `
+{
+  "_cmd": "de v 19, de v 18",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de v 19, de v 19 1`] = `
+{
+  "_cmd": "de v 19, de v 19",
+  "attacker": 9,
+  "defender": 18,
+}
+`;
+
+exports[`de v 19, de v 20 1`] = `
+{
+  "_cmd": "de v 19, de v 20",
+  "attacker": 9,
+  "defender": 19,
+}
+`;
+
+exports[`de v 19, de w 1 1`] = `
+{
+  "_cmd": "de v 19, de w 1",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, de w 2 1`] = `
+{
+  "_cmd": "de v 19, de w 2",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de w 3 1`] = `
+{
+  "_cmd": "de v 19, de w 3",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, de w 4 1`] = `
+{
+  "_cmd": "de v 19, de w 4",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, de w 5 1`] = `
+{
+  "_cmd": "de v 19, de w 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de w 6 1`] = `
+{
+  "_cmd": "de v 19, de w 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, de w 7 1`] = `
+{
+  "_cmd": "de v 19, de w 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de w 8 1`] = `
+{
+  "_cmd": "de v 19, de w 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de w 9 1`] = `
+{
+  "_cmd": "de v 19, de w 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de w 10 1`] = `
+{
+  "_cmd": "de v 19, de w 10",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de w 11 1`] = `
+{
+  "_cmd": "de v 19, de w 11",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de w 12 1`] = `
+{
+  "_cmd": "de v 19, de w 12",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, de w 13 1`] = `
+{
+  "_cmd": "de v 19, de w 13",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de w 14 1`] = `
+{
+  "_cmd": "de v 19, de w 14",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de w 15 1`] = `
+{
+  "_cmd": "de v 19, de w 15",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, de w v 1 1`] = `
+{
+  "_cmd": "de v 19, de w v 1",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, de w v 2 1`] = `
+{
+  "_cmd": "de v 19, de w v 2",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, de w v 3 1`] = `
+{
+  "_cmd": "de v 19, de w v 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, de w v 4 1`] = `
+{
+  "_cmd": "de v 19, de w v 4",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, de w v 5 1`] = `
+{
+  "_cmd": "de v 19, de w v 5",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, de w v 6 1`] = `
+{
+  "_cmd": "de v 19, de w v 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, de w v 7 1`] = `
+{
+  "_cmd": "de v 19, de w v 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, de w v 8 1`] = `
+{
+  "_cmd": "de v 19, de w v 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, de w v 9 1`] = `
+{
+  "_cmd": "de v 19, de w v 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, de w v 10 1`] = `
+{
+  "_cmd": "de v 19, de w v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, de w v 11 1`] = `
+{
+  "_cmd": "de v 19, de w v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, de w v 12 1`] = `
+{
+  "_cmd": "de v 19, de w v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, de w v 13 1`] = `
+{
+  "_cmd": "de v 19, de w v 13",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, de w v 14 1`] = `
+{
+  "_cmd": "de v 19, de w v 14",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, de w v 15 1`] = `
+{
+  "_cmd": "de v 19, de w v 15",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, de w v 16 1`] = `
+{
+  "_cmd": "de v 19, de w v 16",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`de v 19, de w v 17 1`] = `
+{
+  "_cmd": "de v 19, de w v 17",
+  "attacker": 7,
+  "defender": 17,
+}
+`;
+
+exports[`de v 19, de w v 18 1`] = `
+{
+  "_cmd": "de v 19, de w v 18",
+  "attacker": 7,
+  "defender": 18,
+}
+`;
+
+exports[`de v 19, de w v 19 1`] = `
+{
+  "_cmd": "de v 19, de w v 19",
+  "attacker": 7,
+  "defender": 19,
+}
+`;
+
+exports[`de v 19, de w v 20 1`] = `
+{
+  "_cmd": "de v 19, de w v 20",
+  "attacker": 6,
+  "defender": 20,
+}
+`;
+
+exports[`de v 20, de d 1 1`] = `
+{
+  "_cmd": "de v 20, de d 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, de d 2 1`] = `
+{
+  "_cmd": "de v 20, de d 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, de d 3 1`] = `
+{
+  "_cmd": "de v 20, de d 3",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, de d 4 1`] = `
+{
+  "_cmd": "de v 20, de d 4",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de d 5 1`] = `
+{
+  "_cmd": "de v 20, de d 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, de d 6 1`] = `
+{
+  "_cmd": "de v 20, de d 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de d 7 1`] = `
+{
+  "_cmd": "de v 20, de d 7",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de d 8 1`] = `
+{
+  "_cmd": "de v 20, de d 8",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de d 9 1`] = `
+{
+  "_cmd": "de v 20, de d 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de d 10 1`] = `
+{
+  "_cmd": "de v 20, de d 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de d 11 1`] = `
+{
+  "_cmd": "de v 20, de d 11",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de d 12 1`] = `
+{
+  "_cmd": "de v 20, de d 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de d 13 1`] = `
+{
+  "_cmd": "de v 20, de d 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de d 14 1`] = `
+{
+  "_cmd": "de v 20, de d 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, de d 15 1`] = `
+{
+  "_cmd": "de v 20, de d 15",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de d v 1 1`] = `
+{
+  "_cmd": "de v 20, de d v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, de d v 2 1`] = `
+{
+  "_cmd": "de v 20, de d v 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, de d v 3 1`] = `
+{
+  "_cmd": "de v 20, de d v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de d v 4 1`] = `
+{
+  "_cmd": "de v 20, de d v 4",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de d v 5 1`] = `
+{
+  "_cmd": "de v 20, de d v 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, de d v 6 1`] = `
+{
+  "_cmd": "de v 20, de d v 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de d v 7 1`] = `
+{
+  "_cmd": "de v 20, de d v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, de d v 8 1`] = `
+{
+  "_cmd": "de v 20, de d v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de d v 9 1`] = `
+{
+  "_cmd": "de v 20, de d v 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de d v 10 1`] = `
+{
+  "_cmd": "de v 20, de d v 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de d v 11 1`] = `
+{
+  "_cmd": "de v 20, de d v 11",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de d v 12 1`] = `
+{
+  "_cmd": "de v 20, de d v 12",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de d v 13 1`] = `
+{
+  "_cmd": "de v 20, de d v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de d v 14 1`] = `
+{
+  "_cmd": "de v 20, de d v 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, de d v 15 1`] = `
+{
+  "_cmd": "de v 20, de d v 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de d v 16 1`] = `
+{
+  "_cmd": "de v 20, de d v 16",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, de d v 17 1`] = `
+{
+  "_cmd": "de v 20, de d v 17",
+  "attacker": 9,
+  "defender": 16,
+}
+`;
+
+exports[`de v 20, de d v 18 1`] = `
+{
+  "_cmd": "de v 20, de d v 18",
+  "attacker": 9,
+  "defender": 17,
+}
+`;
+
+exports[`de v 20, de d v 19 1`] = `
+{
+  "_cmd": "de v 20, de d v 19",
+  "attacker": 9,
+  "defender": 18,
+}
+`;
+
+exports[`de v 20, de d v 20 1`] = `
+{
+  "_cmd": "de v 20, de d v 20",
+  "attacker": 9,
+  "defender": 19,
+}
+`;
+
+exports[`de v 20, de p 1 1`] = `
+{
+  "_cmd": "de v 20, de p 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, de p 2 1`] = `
+{
+  "_cmd": "de v 20, de p 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, de p 3 1`] = `
+{
+  "_cmd": "de v 20, de p 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de p 4 1`] = `
+{
+  "_cmd": "de v 20, de p 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, de p 5 1`] = `
+{
+  "_cmd": "de v 20, de p 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de p 6 1`] = `
+{
+  "_cmd": "de v 20, de p 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de p 7 1`] = `
+{
+  "_cmd": "de v 20, de p 7",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, de p 8 1`] = `
+{
+  "_cmd": "de v 20, de p 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de p 9 1`] = `
+{
+  "_cmd": "de v 20, de p 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de p 10 1`] = `
+{
+  "_cmd": "de v 20, de p 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de p 11 1`] = `
+{
+  "_cmd": "de v 20, de p 11",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de p 12 1`] = `
+{
+  "_cmd": "de v 20, de p 12",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de p 13 1`] = `
+{
+  "_cmd": "de v 20, de p 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de p 14 1`] = `
+{
+  "_cmd": "de v 20, de p 14",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de p 15 1`] = `
+{
+  "_cmd": "de v 20, de p 15",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de p v 1 1`] = `
+{
+  "_cmd": "de v 20, de p v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, de p v 2 1`] = `
+{
+  "_cmd": "de v 20, de p v 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, de p v 3 1`] = `
+{
+  "_cmd": "de v 20, de p v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de p v 4 1`] = `
+{
+  "_cmd": "de v 20, de p v 4",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, de p v 5 1`] = `
+{
+  "_cmd": "de v 20, de p v 5",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de p v 6 1`] = `
+{
+  "_cmd": "de v 20, de p v 6",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, de p v 7 1`] = `
+{
+  "_cmd": "de v 20, de p v 7",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de p v 8 1`] = `
+{
+  "_cmd": "de v 20, de p v 8",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de p v 9 1`] = `
+{
+  "_cmd": "de v 20, de p v 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de p v 10 1`] = `
+{
+  "_cmd": "de v 20, de p v 10",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de p v 11 1`] = `
+{
+  "_cmd": "de v 20, de p v 11",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de p v 12 1`] = `
+{
+  "_cmd": "de v 20, de p v 12",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de p v 13 1`] = `
+{
+  "_cmd": "de v 20, de p v 13",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de p v 14 1`] = `
+{
+  "_cmd": "de v 20, de p v 14",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de p v 15 1`] = `
+{
+  "_cmd": "de v 20, de p v 15",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, de p v 16 1`] = `
+{
+  "_cmd": "de v 20, de p v 16",
+  "attacker": 12,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de p v 17 1`] = `
+{
+  "_cmd": "de v 20, de p v 17",
+  "attacker": 11,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, de p v 18 1`] = `
+{
+  "_cmd": "de v 20, de p v 18",
+  "attacker": 11,
+  "defender": 16,
+}
+`;
+
+exports[`de v 20, de p v 19 1`] = `
+{
+  "_cmd": "de v 20, de p v 19",
+  "attacker": 11,
+  "defender": 17,
+}
+`;
+
+exports[`de v 20, de p v 20 1`] = `
+{
+  "_cmd": "de v 20, de p v 20",
+  "attacker": 11,
+  "defender": 19,
+}
+`;
+
+exports[`de v 20, de v 1 1`] = `
+{
+  "_cmd": "de v 20, de v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, de v 2 1`] = `
+{
+  "_cmd": "de v 20, de v 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, de v 3 1`] = `
+{
+  "_cmd": "de v 20, de v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de v 4 1`] = `
+{
+  "_cmd": "de v 20, de v 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, de v 5 1`] = `
+{
+  "_cmd": "de v 20, de v 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de v 6 1`] = `
+{
+  "_cmd": "de v 20, de v 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de v 7 1`] = `
+{
+  "_cmd": "de v 20, de v 7",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, de v 8 1`] = `
+{
+  "_cmd": "de v 20, de v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de v 9 1`] = `
+{
+  "_cmd": "de v 20, de v 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de v 10 1`] = `
+{
+  "_cmd": "de v 20, de v 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de v 11 1`] = `
+{
+  "_cmd": "de v 20, de v 11",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de v 12 1`] = `
+{
+  "_cmd": "de v 20, de v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de v 13 1`] = `
+{
+  "_cmd": "de v 20, de v 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de v 14 1`] = `
+{
+  "_cmd": "de v 20, de v 14",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, de v 15 1`] = `
+{
+  "_cmd": "de v 20, de v 15",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de v 16 1`] = `
+{
+  "_cmd": "de v 20, de v 16",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, de v 17 1`] = `
+{
+  "_cmd": "de v 20, de v 17",
+  "attacker": 10,
+  "defender": 16,
+}
+`;
+
+exports[`de v 20, de v 18 1`] = `
+{
+  "_cmd": "de v 20, de v 18",
+  "attacker": 10,
+  "defender": 17,
+}
+`;
+
+exports[`de v 20, de v 19 1`] = `
+{
+  "_cmd": "de v 20, de v 19",
+  "attacker": 10,
+  "defender": 18,
+}
+`;
+
+exports[`de v 20, de v 20 1`] = `
+{
+  "_cmd": "de v 20, de v 20",
+  "attacker": 10,
+  "defender": 19,
+}
+`;
+
+exports[`de v 20, de w 1 1`] = `
+{
+  "_cmd": "de v 20, de w 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, de w 2 1`] = `
+{
+  "_cmd": "de v 20, de w 2",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de w 3 1`] = `
+{
+  "_cmd": "de v 20, de w 3",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, de w 4 1`] = `
+{
+  "_cmd": "de v 20, de w 4",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, de w 5 1`] = `
+{
+  "_cmd": "de v 20, de w 5",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de w 6 1`] = `
+{
+  "_cmd": "de v 20, de w 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, de w 7 1`] = `
+{
+  "_cmd": "de v 20, de w 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de w 8 1`] = `
+{
+  "_cmd": "de v 20, de w 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de w 9 1`] = `
+{
+  "_cmd": "de v 20, de w 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de w 10 1`] = `
+{
+  "_cmd": "de v 20, de w 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de w 11 1`] = `
+{
+  "_cmd": "de v 20, de w 11",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de w 12 1`] = `
+{
+  "_cmd": "de v 20, de w 12",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de w 13 1`] = `
+{
+  "_cmd": "de v 20, de w 13",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, de w 14 1`] = `
+{
+  "_cmd": "de v 20, de w 14",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de w 15 1`] = `
+{
+  "_cmd": "de v 20, de w 15",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, de w v 1 1`] = `
+{
+  "_cmd": "de v 20, de w v 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, de w v 2 1`] = `
+{
+  "_cmd": "de v 20, de w v 2",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, de w v 3 1`] = `
+{
+  "_cmd": "de v 20, de w v 3",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, de w v 4 1`] = `
+{
+  "_cmd": "de v 20, de w v 4",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, de w v 5 1`] = `
+{
+  "_cmd": "de v 20, de w v 5",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, de w v 6 1`] = `
+{
+  "_cmd": "de v 20, de w v 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, de w v 7 1`] = `
+{
+  "_cmd": "de v 20, de w v 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, de w v 8 1`] = `
+{
+  "_cmd": "de v 20, de w v 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, de w v 9 1`] = `
+{
+  "_cmd": "de v 20, de w v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, de w v 10 1`] = `
+{
+  "_cmd": "de v 20, de w v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, de w v 11 1`] = `
+{
+  "_cmd": "de v 20, de w v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, de w v 12 1`] = `
+{
+  "_cmd": "de v 20, de w v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, de w v 13 1`] = `
+{
+  "_cmd": "de v 20, de w v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, de w v 14 1`] = `
+{
+  "_cmd": "de v 20, de w v 14",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, de w v 15 1`] = `
+{
+  "_cmd": "de v 20, de w v 15",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, de w v 16 1`] = `
+{
+  "_cmd": "de v 20, de w v 16",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`de v 20, de w v 17 1`] = `
+{
+  "_cmd": "de v 20, de w v 17",
+  "attacker": 8,
+  "defender": 17,
+}
+`;
+
+exports[`de v 20, de w v 18 1`] = `
+{
+  "_cmd": "de v 20, de w v 18",
+  "attacker": 8,
+  "defender": 18,
+}
+`;
+
+exports[`de v 20, de w v 19 1`] = `
+{
+  "_cmd": "de v 20, de w v 19",
+  "attacker": 8,
+  "defender": 19,
+}
+`;
+
+exports[`de v 20, de w v 20 1`] = `
+{
+  "_cmd": "de v 20, de w v 20",
+  "attacker": 8,
+  "defender": 20,
+}
+`;

--- a/bot/tests/simpleCalc/__snapshots__/de-vs-wa.test.js.snap
+++ b/bot/tests/simpleCalc/__snapshots__/de-vs-wa.test.js.snap
@@ -1,0 +1,39601 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`de b 1, wa d 1 1`] = `
+{
+  "_cmd": "de b 1, wa d 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b 1, wa d 2 1`] = `
+{
+  "_cmd": "de b 1, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, wa d 3 1`] = `
+{
+  "_cmd": "de b 1, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, wa d 4 1`] = `
+{
+  "_cmd": "de b 1, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa d 5 1`] = `
+{
+  "_cmd": "de b 1, wa d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa d 6 1`] = `
+{
+  "_cmd": "de b 1, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa d 7 1`] = `
+{
+  "_cmd": "de b 1, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa d 8 1`] = `
+{
+  "_cmd": "de b 1, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa d 9 1`] = `
+{
+  "_cmd": "de b 1, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa d 10 1`] = `
+{
+  "_cmd": "de b 1, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa d v 1 1`] = `
+{
+  "_cmd": "de b 1, wa d v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b 1, wa d v 2 1`] = `
+{
+  "_cmd": "de b 1, wa d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, wa d v 3 1`] = `
+{
+  "_cmd": "de b 1, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, wa d v 4 1`] = `
+{
+  "_cmd": "de b 1, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa d v 5 1`] = `
+{
+  "_cmd": "de b 1, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa d v 6 1`] = `
+{
+  "_cmd": "de b 1, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa d v 7 1`] = `
+{
+  "_cmd": "de b 1, wa d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa d v 8 1`] = `
+{
+  "_cmd": "de b 1, wa d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa d v 9 1`] = `
+{
+  "_cmd": "de b 1, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa d v 10 1`] = `
+{
+  "_cmd": "de b 1, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa d v 11 1`] = `
+{
+  "_cmd": "de b 1, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, wa d v 12 1`] = `
+{
+  "_cmd": "de b 1, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, wa d v 13 1`] = `
+{
+  "_cmd": "de b 1, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, wa d v 14 1`] = `
+{
+  "_cmd": "de b 1, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, wa d v 15 1`] = `
+{
+  "_cmd": "de b 1, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, wa p 1 1`] = `
+{
+  "_cmd": "de b 1, wa p 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, wa p 2 1`] = `
+{
+  "_cmd": "de b 1, wa p 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, wa p 3 1`] = `
+{
+  "_cmd": "de b 1, wa p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, wa p 4 1`] = `
+{
+  "_cmd": "de b 1, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa p 5 1`] = `
+{
+  "_cmd": "de b 1, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa p 6 1`] = `
+{
+  "_cmd": "de b 1, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa p 7 1`] = `
+{
+  "_cmd": "de b 1, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa p 8 1`] = `
+{
+  "_cmd": "de b 1, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa p 9 1`] = `
+{
+  "_cmd": "de b 1, wa p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa p 10 1`] = `
+{
+  "_cmd": "de b 1, wa p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa p v 1 1`] = `
+{
+  "_cmd": "de b 1, wa p v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, wa p v 2 1`] = `
+{
+  "_cmd": "de b 1, wa p v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, wa p v 3 1`] = `
+{
+  "_cmd": "de b 1, wa p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, wa p v 4 1`] = `
+{
+  "_cmd": "de b 1, wa p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa p v 5 1`] = `
+{
+  "_cmd": "de b 1, wa p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa p v 6 1`] = `
+{
+  "_cmd": "de b 1, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa p v 7 1`] = `
+{
+  "_cmd": "de b 1, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa p v 8 1`] = `
+{
+  "_cmd": "de b 1, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa p v 9 1`] = `
+{
+  "_cmd": "de b 1, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa p v 10 1`] = `
+{
+  "_cmd": "de b 1, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa p v 11 1`] = `
+{
+  "_cmd": "de b 1, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa p v 12 1`] = `
+{
+  "_cmd": "de b 1, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, wa p v 13 1`] = `
+{
+  "_cmd": "de b 1, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, wa p v 14 1`] = `
+{
+  "_cmd": "de b 1, wa p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, wa p v 15 1`] = `
+{
+  "_cmd": "de b 1, wa p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, wa v 1 1`] = `
+{
+  "_cmd": "de b 1, wa v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b 1, wa v 2 1`] = `
+{
+  "_cmd": "de b 1, wa v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, wa v 3 1`] = `
+{
+  "_cmd": "de b 1, wa v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, wa v 4 1`] = `
+{
+  "_cmd": "de b 1, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa v 5 1`] = `
+{
+  "_cmd": "de b 1, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa v 6 1`] = `
+{
+  "_cmd": "de b 1, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa v 7 1`] = `
+{
+  "_cmd": "de b 1, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa v 8 1`] = `
+{
+  "_cmd": "de b 1, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa v 9 1`] = `
+{
+  "_cmd": "de b 1, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa v 10 1`] = `
+{
+  "_cmd": "de b 1, wa v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa v 11 1`] = `
+{
+  "_cmd": "de b 1, wa v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, wa v 12 1`] = `
+{
+  "_cmd": "de b 1, wa v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, wa v 13 1`] = `
+{
+  "_cmd": "de b 1, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, wa v 14 1`] = `
+{
+  "_cmd": "de b 1, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, wa v 15 1`] = `
+{
+  "_cmd": "de b 1, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 1, wa w 1 1`] = `
+{
+  "_cmd": "de b 1, wa w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, wa w 2 1`] = `
+{
+  "_cmd": "de b 1, wa w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 1, wa w 3 1`] = `
+{
+  "_cmd": "de b 1, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa w 4 1`] = `
+{
+  "_cmd": "de b 1, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa w 5 1`] = `
+{
+  "_cmd": "de b 1, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa w 6 1`] = `
+{
+  "_cmd": "de b 1, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa w 7 1`] = `
+{
+  "_cmd": "de b 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa w 8 1`] = `
+{
+  "_cmd": "de b 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa w 9 1`] = `
+{
+  "_cmd": "de b 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa w 10 1`] = `
+{
+  "_cmd": "de b 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa w v 1 1`] = `
+{
+  "_cmd": "de b 1, wa w v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b 1, wa w v 2 1`] = `
+{
+  "_cmd": "de b 1, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 1, wa w v 3 1`] = `
+{
+  "_cmd": "de b 1, wa w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 1, wa w v 4 1`] = `
+{
+  "_cmd": "de b 1, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 1, wa w v 5 1`] = `
+{
+  "_cmd": "de b 1, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 1, wa w v 6 1`] = `
+{
+  "_cmd": "de b 1, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 1, wa w v 7 1`] = `
+{
+  "_cmd": "de b 1, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 1, wa w v 8 1`] = `
+{
+  "_cmd": "de b 1, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 1, wa w v 9 1`] = `
+{
+  "_cmd": "de b 1, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 1, wa w v 10 1`] = `
+{
+  "_cmd": "de b 1, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 1, wa w v 11 1`] = `
+{
+  "_cmd": "de b 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 1, wa w v 12 1`] = `
+{
+  "_cmd": "de b 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 1, wa w v 13 1`] = `
+{
+  "_cmd": "de b 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 1, wa w v 14 1`] = `
+{
+  "_cmd": "de b 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 1, wa w v 15 1`] = `
+{
+  "_cmd": "de b 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, wa d 1 1`] = `
+{
+  "_cmd": "de b 2, wa d 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b 2, wa d 2 1`] = `
+{
+  "_cmd": "de b 2, wa d 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, wa d 3 1`] = `
+{
+  "_cmd": "de b 2, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa d 4 1`] = `
+{
+  "_cmd": "de b 2, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa d 5 1`] = `
+{
+  "_cmd": "de b 2, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, wa d 6 1`] = `
+{
+  "_cmd": "de b 2, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa d 7 1`] = `
+{
+  "_cmd": "de b 2, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa d 8 1`] = `
+{
+  "_cmd": "de b 2, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa d 9 1`] = `
+{
+  "_cmd": "de b 2, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa d 10 1`] = `
+{
+  "_cmd": "de b 2, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa d v 1 1`] = `
+{
+  "_cmd": "de b 2, wa d v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b 2, wa d v 2 1`] = `
+{
+  "_cmd": "de b 2, wa d v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, wa d v 3 1`] = `
+{
+  "_cmd": "de b 2, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, wa d v 4 1`] = `
+{
+  "_cmd": "de b 2, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa d v 5 1`] = `
+{
+  "_cmd": "de b 2, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, wa d v 6 1`] = `
+{
+  "_cmd": "de b 2, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa d v 7 1`] = `
+{
+  "_cmd": "de b 2, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa d v 8 1`] = `
+{
+  "_cmd": "de b 2, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa d v 9 1`] = `
+{
+  "_cmd": "de b 2, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa d v 10 1`] = `
+{
+  "_cmd": "de b 2, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa d v 11 1`] = `
+{
+  "_cmd": "de b 2, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa d v 12 1`] = `
+{
+  "_cmd": "de b 2, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, wa d v 13 1`] = `
+{
+  "_cmd": "de b 2, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, wa d v 14 1`] = `
+{
+  "_cmd": "de b 2, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, wa d v 15 1`] = `
+{
+  "_cmd": "de b 2, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 2, wa p 1 1`] = `
+{
+  "_cmd": "de b 2, wa p 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b 2, wa p 2 1`] = `
+{
+  "_cmd": "de b 2, wa p 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, wa p 3 1`] = `
+{
+  "_cmd": "de b 2, wa p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, wa p 4 1`] = `
+{
+  "_cmd": "de b 2, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa p 5 1`] = `
+{
+  "_cmd": "de b 2, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa p 6 1`] = `
+{
+  "_cmd": "de b 2, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa p 7 1`] = `
+{
+  "_cmd": "de b 2, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa p 8 1`] = `
+{
+  "_cmd": "de b 2, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa p 9 1`] = `
+{
+  "_cmd": "de b 2, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa p 10 1`] = `
+{
+  "_cmd": "de b 2, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa p v 1 1`] = `
+{
+  "_cmd": "de b 2, wa p v 1",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`de b 2, wa p v 2 1`] = `
+{
+  "_cmd": "de b 2, wa p v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, wa p v 3 1`] = `
+{
+  "_cmd": "de b 2, wa p v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, wa p v 4 1`] = `
+{
+  "_cmd": "de b 2, wa p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa p v 5 1`] = `
+{
+  "_cmd": "de b 2, wa p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa p v 6 1`] = `
+{
+  "_cmd": "de b 2, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, wa p v 7 1`] = `
+{
+  "_cmd": "de b 2, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa p v 8 1`] = `
+{
+  "_cmd": "de b 2, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa p v 9 1`] = `
+{
+  "_cmd": "de b 2, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa p v 10 1`] = `
+{
+  "_cmd": "de b 2, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa p v 11 1`] = `
+{
+  "_cmd": "de b 2, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa p v 12 1`] = `
+{
+  "_cmd": "de b 2, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, wa p v 13 1`] = `
+{
+  "_cmd": "de b 2, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, wa p v 14 1`] = `
+{
+  "_cmd": "de b 2, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, wa p v 15 1`] = `
+{
+  "_cmd": "de b 2, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, wa v 1 1`] = `
+{
+  "_cmd": "de b 2, wa v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b 2, wa v 2 1`] = `
+{
+  "_cmd": "de b 2, wa v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, wa v 3 1`] = `
+{
+  "_cmd": "de b 2, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, wa v 4 1`] = `
+{
+  "_cmd": "de b 2, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa v 5 1`] = `
+{
+  "_cmd": "de b 2, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa v 6 1`] = `
+{
+  "_cmd": "de b 2, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa v 7 1`] = `
+{
+  "_cmd": "de b 2, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa v 8 1`] = `
+{
+  "_cmd": "de b 2, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa v 9 1`] = `
+{
+  "_cmd": "de b 2, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa v 10 1`] = `
+{
+  "_cmd": "de b 2, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa v 11 1`] = `
+{
+  "_cmd": "de b 2, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa v 12 1`] = `
+{
+  "_cmd": "de b 2, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, wa v 13 1`] = `
+{
+  "_cmd": "de b 2, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, wa v 14 1`] = `
+{
+  "_cmd": "de b 2, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, wa v 15 1`] = `
+{
+  "_cmd": "de b 2, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, wa w 1 1`] = `
+{
+  "_cmd": "de b 2, wa w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b 2, wa w 2 1`] = `
+{
+  "_cmd": "de b 2, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, wa w 3 1`] = `
+{
+  "_cmd": "de b 2, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa w 4 1`] = `
+{
+  "_cmd": "de b 2, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 2, wa w 5 1`] = `
+{
+  "_cmd": "de b 2, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa w 6 1`] = `
+{
+  "_cmd": "de b 2, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa w 7 1`] = `
+{
+  "_cmd": "de b 2, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa w 8 1`] = `
+{
+  "_cmd": "de b 2, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa w 9 1`] = `
+{
+  "_cmd": "de b 2, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa w 10 1`] = `
+{
+  "_cmd": "de b 2, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa w v 1 1`] = `
+{
+  "_cmd": "de b 2, wa w v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b 2, wa w v 2 1`] = `
+{
+  "_cmd": "de b 2, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 2, wa w v 3 1`] = `
+{
+  "_cmd": "de b 2, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 2, wa w v 4 1`] = `
+{
+  "_cmd": "de b 2, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 2, wa w v 5 1`] = `
+{
+  "_cmd": "de b 2, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 2, wa w v 6 1`] = `
+{
+  "_cmd": "de b 2, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 2, wa w v 7 1`] = `
+{
+  "_cmd": "de b 2, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 2, wa w v 8 1`] = `
+{
+  "_cmd": "de b 2, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 2, wa w v 9 1`] = `
+{
+  "_cmd": "de b 2, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 2, wa w v 10 1`] = `
+{
+  "_cmd": "de b 2, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 2, wa w v 11 1`] = `
+{
+  "_cmd": "de b 2, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 2, wa w v 12 1`] = `
+{
+  "_cmd": "de b 2, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 2, wa w v 13 1`] = `
+{
+  "_cmd": "de b 2, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 2, wa w v 14 1`] = `
+{
+  "_cmd": "de b 2, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 2, wa w v 15 1`] = `
+{
+  "_cmd": "de b 2, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 3, wa d 1 1`] = `
+{
+  "_cmd": "de b 3, wa d 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b 3, wa d 2 1`] = `
+{
+  "_cmd": "de b 3, wa d 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, wa d 3 1`] = `
+{
+  "_cmd": "de b 3, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, wa d 4 1`] = `
+{
+  "_cmd": "de b 3, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa d 5 1`] = `
+{
+  "_cmd": "de b 3, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, wa d 6 1`] = `
+{
+  "_cmd": "de b 3, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa d 7 1`] = `
+{
+  "_cmd": "de b 3, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, wa d 8 1`] = `
+{
+  "_cmd": "de b 3, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa d 9 1`] = `
+{
+  "_cmd": "de b 3, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa d 10 1`] = `
+{
+  "_cmd": "de b 3, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa d v 1 1`] = `
+{
+  "_cmd": "de b 3, wa d v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b 3, wa d v 2 1`] = `
+{
+  "_cmd": "de b 3, wa d v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, wa d v 3 1`] = `
+{
+  "_cmd": "de b 3, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, wa d v 4 1`] = `
+{
+  "_cmd": "de b 3, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa d v 5 1`] = `
+{
+  "_cmd": "de b 3, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa d v 6 1`] = `
+{
+  "_cmd": "de b 3, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa d v 7 1`] = `
+{
+  "_cmd": "de b 3, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, wa d v 8 1`] = `
+{
+  "_cmd": "de b 3, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa d v 9 1`] = `
+{
+  "_cmd": "de b 3, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa d v 10 1`] = `
+{
+  "_cmd": "de b 3, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa d v 11 1`] = `
+{
+  "_cmd": "de b 3, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, wa d v 12 1`] = `
+{
+  "_cmd": "de b 3, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, wa d v 13 1`] = `
+{
+  "_cmd": "de b 3, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, wa d v 14 1`] = `
+{
+  "_cmd": "de b 3, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, wa d v 15 1`] = `
+{
+  "_cmd": "de b 3, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, wa p 1 1`] = `
+{
+  "_cmd": "de b 3, wa p 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, wa p 2 1`] = `
+{
+  "_cmd": "de b 3, wa p 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, wa p 3 1`] = `
+{
+  "_cmd": "de b 3, wa p 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, wa p 4 1`] = `
+{
+  "_cmd": "de b 3, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa p 5 1`] = `
+{
+  "_cmd": "de b 3, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa p 6 1`] = `
+{
+  "_cmd": "de b 3, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, wa p 7 1`] = `
+{
+  "_cmd": "de b 3, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa p 8 1`] = `
+{
+  "_cmd": "de b 3, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa p 9 1`] = `
+{
+  "_cmd": "de b 3, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa p 10 1`] = `
+{
+  "_cmd": "de b 3, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa p v 1 1`] = `
+{
+  "_cmd": "de b 3, wa p v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, wa p v 2 1`] = `
+{
+  "_cmd": "de b 3, wa p v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b 3, wa p v 3 1`] = `
+{
+  "_cmd": "de b 3, wa p v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, wa p v 4 1`] = `
+{
+  "_cmd": "de b 3, wa p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, wa p v 5 1`] = `
+{
+  "_cmd": "de b 3, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa p v 6 1`] = `
+{
+  "_cmd": "de b 3, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, wa p v 7 1`] = `
+{
+  "_cmd": "de b 3, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa p v 8 1`] = `
+{
+  "_cmd": "de b 3, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, wa p v 9 1`] = `
+{
+  "_cmd": "de b 3, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa p v 10 1`] = `
+{
+  "_cmd": "de b 3, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa p v 11 1`] = `
+{
+  "_cmd": "de b 3, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa p v 12 1`] = `
+{
+  "_cmd": "de b 3, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, wa p v 13 1`] = `
+{
+  "_cmd": "de b 3, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, wa p v 14 1`] = `
+{
+  "_cmd": "de b 3, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, wa p v 15 1`] = `
+{
+  "_cmd": "de b 3, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, wa v 1 1`] = `
+{
+  "_cmd": "de b 3, wa v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b 3, wa v 2 1`] = `
+{
+  "_cmd": "de b 3, wa v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b 3, wa v 3 1`] = `
+{
+  "_cmd": "de b 3, wa v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b 3, wa v 4 1`] = `
+{
+  "_cmd": "de b 3, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa v 5 1`] = `
+{
+  "_cmd": "de b 3, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa v 6 1`] = `
+{
+  "_cmd": "de b 3, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, wa v 7 1`] = `
+{
+  "_cmd": "de b 3, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa v 8 1`] = `
+{
+  "_cmd": "de b 3, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa v 9 1`] = `
+{
+  "_cmd": "de b 3, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa v 10 1`] = `
+{
+  "_cmd": "de b 3, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa v 11 1`] = `
+{
+  "_cmd": "de b 3, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, wa v 12 1`] = `
+{
+  "_cmd": "de b 3, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, wa v 13 1`] = `
+{
+  "_cmd": "de b 3, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, wa v 14 1`] = `
+{
+  "_cmd": "de b 3, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, wa v 15 1`] = `
+{
+  "_cmd": "de b 3, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, wa w 1 1`] = `
+{
+  "_cmd": "de b 3, wa w 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, wa w 2 1`] = `
+{
+  "_cmd": "de b 3, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, wa w 3 1`] = `
+{
+  "_cmd": "de b 3, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa w 4 1`] = `
+{
+  "_cmd": "de b 3, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa w 5 1`] = `
+{
+  "_cmd": "de b 3, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa w 6 1`] = `
+{
+  "_cmd": "de b 3, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, wa w 7 1`] = `
+{
+  "_cmd": "de b 3, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 3, wa w 8 1`] = `
+{
+  "_cmd": "de b 3, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa w 9 1`] = `
+{
+  "_cmd": "de b 3, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa w 10 1`] = `
+{
+  "_cmd": "de b 3, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, wa w v 1 1`] = `
+{
+  "_cmd": "de b 3, wa w v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b 3, wa w v 2 1`] = `
+{
+  "_cmd": "de b 3, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 3, wa w v 3 1`] = `
+{
+  "_cmd": "de b 3, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 3, wa w v 4 1`] = `
+{
+  "_cmd": "de b 3, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 3, wa w v 5 1`] = `
+{
+  "_cmd": "de b 3, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 3, wa w v 6 1`] = `
+{
+  "_cmd": "de b 3, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 3, wa w v 7 1`] = `
+{
+  "_cmd": "de b 3, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 3, wa w v 8 1`] = `
+{
+  "_cmd": "de b 3, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 3, wa w v 9 1`] = `
+{
+  "_cmd": "de b 3, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 3, wa w v 10 1`] = `
+{
+  "_cmd": "de b 3, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 3, wa w v 11 1`] = `
+{
+  "_cmd": "de b 3, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 3, wa w v 12 1`] = `
+{
+  "_cmd": "de b 3, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 3, wa w v 13 1`] = `
+{
+  "_cmd": "de b 3, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 3, wa w v 14 1`] = `
+{
+  "_cmd": "de b 3, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 3, wa w v 15 1`] = `
+{
+  "_cmd": "de b 3, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 4, wa d 1 1`] = `
+{
+  "_cmd": "de b 4, wa d 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b 4, wa d 2 1`] = `
+{
+  "_cmd": "de b 4, wa d 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, wa d 3 1`] = `
+{
+  "_cmd": "de b 4, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, wa d 4 1`] = `
+{
+  "_cmd": "de b 4, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa d 5 1`] = `
+{
+  "_cmd": "de b 4, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa d 6 1`] = `
+{
+  "_cmd": "de b 4, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa d 7 1`] = `
+{
+  "_cmd": "de b 4, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, wa d 8 1`] = `
+{
+  "_cmd": "de b 4, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa d 9 1`] = `
+{
+  "_cmd": "de b 4, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa d 10 1`] = `
+{
+  "_cmd": "de b 4, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, wa d v 1 1`] = `
+{
+  "_cmd": "de b 4, wa d v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, wa d v 2 1`] = `
+{
+  "_cmd": "de b 4, wa d v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, wa d v 3 1`] = `
+{
+  "_cmd": "de b 4, wa d v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, wa d v 4 1`] = `
+{
+  "_cmd": "de b 4, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa d v 5 1`] = `
+{
+  "_cmd": "de b 4, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, wa d v 6 1`] = `
+{
+  "_cmd": "de b 4, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa d v 7 1`] = `
+{
+  "_cmd": "de b 4, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa d v 8 1`] = `
+{
+  "_cmd": "de b 4, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa d v 9 1`] = `
+{
+  "_cmd": "de b 4, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa d v 10 1`] = `
+{
+  "_cmd": "de b 4, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, wa d v 11 1`] = `
+{
+  "_cmd": "de b 4, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, wa d v 12 1`] = `
+{
+  "_cmd": "de b 4, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, wa d v 13 1`] = `
+{
+  "_cmd": "de b 4, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, wa d v 14 1`] = `
+{
+  "_cmd": "de b 4, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, wa d v 15 1`] = `
+{
+  "_cmd": "de b 4, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, wa p 1 1`] = `
+{
+  "_cmd": "de b 4, wa p 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, wa p 2 1`] = `
+{
+  "_cmd": "de b 4, wa p 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, wa p 3 1`] = `
+{
+  "_cmd": "de b 4, wa p 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, wa p 4 1`] = `
+{
+  "_cmd": "de b 4, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, wa p 5 1`] = `
+{
+  "_cmd": "de b 4, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, wa p 6 1`] = `
+{
+  "_cmd": "de b 4, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa p 7 1`] = `
+{
+  "_cmd": "de b 4, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa p 8 1`] = `
+{
+  "_cmd": "de b 4, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, wa p 9 1`] = `
+{
+  "_cmd": "de b 4, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa p 10 1`] = `
+{
+  "_cmd": "de b 4, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa p v 1 1`] = `
+{
+  "_cmd": "de b 4, wa p v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, wa p v 2 1`] = `
+{
+  "_cmd": "de b 4, wa p v 2",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b 4, wa p v 3 1`] = `
+{
+  "_cmd": "de b 4, wa p v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, wa p v 4 1`] = `
+{
+  "_cmd": "de b 4, wa p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, wa p v 5 1`] = `
+{
+  "_cmd": "de b 4, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa p v 6 1`] = `
+{
+  "_cmd": "de b 4, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, wa p v 7 1`] = `
+{
+  "_cmd": "de b 4, wa p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa p v 8 1`] = `
+{
+  "_cmd": "de b 4, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, wa p v 9 1`] = `
+{
+  "_cmd": "de b 4, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa p v 10 1`] = `
+{
+  "_cmd": "de b 4, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa p v 11 1`] = `
+{
+  "_cmd": "de b 4, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, wa p v 12 1`] = `
+{
+  "_cmd": "de b 4, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, wa p v 13 1`] = `
+{
+  "_cmd": "de b 4, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, wa p v 14 1`] = `
+{
+  "_cmd": "de b 4, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, wa p v 15 1`] = `
+{
+  "_cmd": "de b 4, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, wa v 1 1`] = `
+{
+  "_cmd": "de b 4, wa v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b 4, wa v 2 1`] = `
+{
+  "_cmd": "de b 4, wa v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, wa v 3 1`] = `
+{
+  "_cmd": "de b 4, wa v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, wa v 4 1`] = `
+{
+  "_cmd": "de b 4, wa v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, wa v 5 1`] = `
+{
+  "_cmd": "de b 4, wa v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa v 6 1`] = `
+{
+  "_cmd": "de b 4, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa v 7 1`] = `
+{
+  "_cmd": "de b 4, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa v 8 1`] = `
+{
+  "_cmd": "de b 4, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, wa v 9 1`] = `
+{
+  "_cmd": "de b 4, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa v 10 1`] = `
+{
+  "_cmd": "de b 4, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa v 11 1`] = `
+{
+  "_cmd": "de b 4, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, wa v 12 1`] = `
+{
+  "_cmd": "de b 4, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, wa v 13 1`] = `
+{
+  "_cmd": "de b 4, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, wa v 14 1`] = `
+{
+  "_cmd": "de b 4, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, wa v 15 1`] = `
+{
+  "_cmd": "de b 4, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, wa w 1 1`] = `
+{
+  "_cmd": "de b 4, wa w 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b 4, wa w 2 1`] = `
+{
+  "_cmd": "de b 4, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 4, wa w 3 1`] = `
+{
+  "_cmd": "de b 4, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa w 4 1`] = `
+{
+  "_cmd": "de b 4, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, wa w 5 1`] = `
+{
+  "_cmd": "de b 4, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa w 6 1`] = `
+{
+  "_cmd": "de b 4, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa w 7 1`] = `
+{
+  "_cmd": "de b 4, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa w 8 1`] = `
+{
+  "_cmd": "de b 4, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa w 9 1`] = `
+{
+  "_cmd": "de b 4, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 4, wa w 10 1`] = `
+{
+  "_cmd": "de b 4, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, wa w v 1 1`] = `
+{
+  "_cmd": "de b 4, wa w v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b 4, wa w v 2 1`] = `
+{
+  "_cmd": "de b 4, wa w v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b 4, wa w v 3 1`] = `
+{
+  "_cmd": "de b 4, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 4, wa w v 4 1`] = `
+{
+  "_cmd": "de b 4, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 4, wa w v 5 1`] = `
+{
+  "_cmd": "de b 4, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 4, wa w v 6 1`] = `
+{
+  "_cmd": "de b 4, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 4, wa w v 7 1`] = `
+{
+  "_cmd": "de b 4, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 4, wa w v 8 1`] = `
+{
+  "_cmd": "de b 4, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 4, wa w v 9 1`] = `
+{
+  "_cmd": "de b 4, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 4, wa w v 10 1`] = `
+{
+  "_cmd": "de b 4, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 4, wa w v 11 1`] = `
+{
+  "_cmd": "de b 4, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 4, wa w v 12 1`] = `
+{
+  "_cmd": "de b 4, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 4, wa w v 13 1`] = `
+{
+  "_cmd": "de b 4, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 4, wa w v 14 1`] = `
+{
+  "_cmd": "de b 4, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 4, wa w v 15 1`] = `
+{
+  "_cmd": "de b 4, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 5, wa d 1 1`] = `
+{
+  "_cmd": "de b 5, wa d 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b 5, wa d 2 1`] = `
+{
+  "_cmd": "de b 5, wa d 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, wa d 3 1`] = `
+{
+  "_cmd": "de b 5, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, wa d 4 1`] = `
+{
+  "_cmd": "de b 5, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, wa d 5 1`] = `
+{
+  "_cmd": "de b 5, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa d 6 1`] = `
+{
+  "_cmd": "de b 5, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa d 7 1`] = `
+{
+  "_cmd": "de b 5, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa d 8 1`] = `
+{
+  "_cmd": "de b 5, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, wa d 9 1`] = `
+{
+  "_cmd": "de b 5, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa d 10 1`] = `
+{
+  "_cmd": "de b 5, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa d v 1 1`] = `
+{
+  "_cmd": "de b 5, wa d v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, wa d v 2 1`] = `
+{
+  "_cmd": "de b 5, wa d v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, wa d v 3 1`] = `
+{
+  "_cmd": "de b 5, wa d v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, wa d v 4 1`] = `
+{
+  "_cmd": "de b 5, wa d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, wa d v 5 1`] = `
+{
+  "_cmd": "de b 5, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa d v 6 1`] = `
+{
+  "_cmd": "de b 5, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, wa d v 7 1`] = `
+{
+  "_cmd": "de b 5, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa d v 8 1`] = `
+{
+  "_cmd": "de b 5, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa d v 9 1`] = `
+{
+  "_cmd": "de b 5, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa d v 10 1`] = `
+{
+  "_cmd": "de b 5, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa d v 11 1`] = `
+{
+  "_cmd": "de b 5, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, wa d v 12 1`] = `
+{
+  "_cmd": "de b 5, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, wa d v 13 1`] = `
+{
+  "_cmd": "de b 5, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, wa d v 14 1`] = `
+{
+  "_cmd": "de b 5, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, wa d v 15 1`] = `
+{
+  "_cmd": "de b 5, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, wa p 1 1`] = `
+{
+  "_cmd": "de b 5, wa p 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, wa p 2 1`] = `
+{
+  "_cmd": "de b 5, wa p 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, wa p 3 1`] = `
+{
+  "_cmd": "de b 5, wa p 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, wa p 4 1`] = `
+{
+  "_cmd": "de b 5, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, wa p 5 1`] = `
+{
+  "_cmd": "de b 5, wa p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, wa p 6 1`] = `
+{
+  "_cmd": "de b 5, wa p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa p 7 1`] = `
+{
+  "_cmd": "de b 5, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa p 8 1`] = `
+{
+  "_cmd": "de b 5, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa p 9 1`] = `
+{
+  "_cmd": "de b 5, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, wa p 10 1`] = `
+{
+  "_cmd": "de b 5, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa p v 1 1`] = `
+{
+  "_cmd": "de b 5, wa p v 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`de b 5, wa p v 2 1`] = `
+{
+  "_cmd": "de b 5, wa p v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b 5, wa p v 3 1`] = `
+{
+  "_cmd": "de b 5, wa p v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, wa p v 4 1`] = `
+{
+  "_cmd": "de b 5, wa p v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, wa p v 5 1`] = `
+{
+  "_cmd": "de b 5, wa p v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, wa p v 6 1`] = `
+{
+  "_cmd": "de b 5, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa p v 7 1`] = `
+{
+  "_cmd": "de b 5, wa p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, wa p v 8 1`] = `
+{
+  "_cmd": "de b 5, wa p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa p v 9 1`] = `
+{
+  "_cmd": "de b 5, wa p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa p v 10 1`] = `
+{
+  "_cmd": "de b 5, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa p v 11 1`] = `
+{
+  "_cmd": "de b 5, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa p v 12 1`] = `
+{
+  "_cmd": "de b 5, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, wa p v 13 1`] = `
+{
+  "_cmd": "de b 5, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, wa p v 14 1`] = `
+{
+  "_cmd": "de b 5, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, wa p v 15 1`] = `
+{
+  "_cmd": "de b 5, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, wa v 1 1`] = `
+{
+  "_cmd": "de b 5, wa v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b 5, wa v 2 1`] = `
+{
+  "_cmd": "de b 5, wa v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, wa v 3 1`] = `
+{
+  "_cmd": "de b 5, wa v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b 5, wa v 4 1`] = `
+{
+  "_cmd": "de b 5, wa v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, wa v 5 1`] = `
+{
+  "_cmd": "de b 5, wa v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, wa v 6 1`] = `
+{
+  "_cmd": "de b 5, wa v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa v 7 1`] = `
+{
+  "_cmd": "de b 5, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa v 8 1`] = `
+{
+  "_cmd": "de b 5, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa v 9 1`] = `
+{
+  "_cmd": "de b 5, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, wa v 10 1`] = `
+{
+  "_cmd": "de b 5, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa v 11 1`] = `
+{
+  "_cmd": "de b 5, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa v 12 1`] = `
+{
+  "_cmd": "de b 5, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, wa v 13 1`] = `
+{
+  "_cmd": "de b 5, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 5, wa v 14 1`] = `
+{
+  "_cmd": "de b 5, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, wa v 15 1`] = `
+{
+  "_cmd": "de b 5, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, wa w 1 1`] = `
+{
+  "_cmd": "de b 5, wa w 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, wa w 2 1`] = `
+{
+  "_cmd": "de b 5, wa w 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, wa w 3 1`] = `
+{
+  "_cmd": "de b 5, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 5, wa w 4 1`] = `
+{
+  "_cmd": "de b 5, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa w 5 1`] = `
+{
+  "_cmd": "de b 5, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, wa w 6 1`] = `
+{
+  "_cmd": "de b 5, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa w 7 1`] = `
+{
+  "_cmd": "de b 5, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa w 8 1`] = `
+{
+  "_cmd": "de b 5, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa w 9 1`] = `
+{
+  "_cmd": "de b 5, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa w 10 1`] = `
+{
+  "_cmd": "de b 5, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, wa w v 1 1`] = `
+{
+  "_cmd": "de b 5, wa w v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b 5, wa w v 2 1`] = `
+{
+  "_cmd": "de b 5, wa w v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b 5, wa w v 3 1`] = `
+{
+  "_cmd": "de b 5, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 5, wa w v 4 1`] = `
+{
+  "_cmd": "de b 5, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 5, wa w v 5 1`] = `
+{
+  "_cmd": "de b 5, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 5, wa w v 6 1`] = `
+{
+  "_cmd": "de b 5, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 5, wa w v 7 1`] = `
+{
+  "_cmd": "de b 5, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 5, wa w v 8 1`] = `
+{
+  "_cmd": "de b 5, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 5, wa w v 9 1`] = `
+{
+  "_cmd": "de b 5, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 5, wa w v 10 1`] = `
+{
+  "_cmd": "de b 5, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 5, wa w v 11 1`] = `
+{
+  "_cmd": "de b 5, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 5, wa w v 12 1`] = `
+{
+  "_cmd": "de b 5, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 5, wa w v 13 1`] = `
+{
+  "_cmd": "de b 5, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 5, wa w v 14 1`] = `
+{
+  "_cmd": "de b 5, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 5, wa w v 15 1`] = `
+{
+  "_cmd": "de b 5, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 6, wa d 1 1`] = `
+{
+  "_cmd": "de b 6, wa d 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, wa d 2 1`] = `
+{
+  "_cmd": "de b 6, wa d 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, wa d 3 1`] = `
+{
+  "_cmd": "de b 6, wa d 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa d 4 1`] = `
+{
+  "_cmd": "de b 6, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, wa d 5 1`] = `
+{
+  "_cmd": "de b 6, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa d 6 1`] = `
+{
+  "_cmd": "de b 6, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa d 7 1`] = `
+{
+  "_cmd": "de b 6, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, wa d 8 1`] = `
+{
+  "_cmd": "de b 6, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa d 9 1`] = `
+{
+  "_cmd": "de b 6, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa d 10 1`] = `
+{
+  "_cmd": "de b 6, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, wa d v 1 1`] = `
+{
+  "_cmd": "de b 6, wa d v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, wa d v 2 1`] = `
+{
+  "_cmd": "de b 6, wa d v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, wa d v 3 1`] = `
+{
+  "_cmd": "de b 6, wa d v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa d v 4 1`] = `
+{
+  "_cmd": "de b 6, wa d v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, wa d v 5 1`] = `
+{
+  "_cmd": "de b 6, wa d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, wa d v 6 1`] = `
+{
+  "_cmd": "de b 6, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa d v 7 1`] = `
+{
+  "_cmd": "de b 6, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, wa d v 8 1`] = `
+{
+  "_cmd": "de b 6, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa d v 9 1`] = `
+{
+  "_cmd": "de b 6, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa d v 10 1`] = `
+{
+  "_cmd": "de b 6, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa d v 11 1`] = `
+{
+  "_cmd": "de b 6, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, wa d v 12 1`] = `
+{
+  "_cmd": "de b 6, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, wa d v 13 1`] = `
+{
+  "_cmd": "de b 6, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, wa d v 14 1`] = `
+{
+  "_cmd": "de b 6, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, wa d v 15 1`] = `
+{
+  "_cmd": "de b 6, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 6, wa p 1 1`] = `
+{
+  "_cmd": "de b 6, wa p 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b 6, wa p 2 1`] = `
+{
+  "_cmd": "de b 6, wa p 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, wa p 3 1`] = `
+{
+  "_cmd": "de b 6, wa p 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, wa p 4 1`] = `
+{
+  "_cmd": "de b 6, wa p 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, wa p 5 1`] = `
+{
+  "_cmd": "de b 6, wa p 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, wa p 6 1`] = `
+{
+  "_cmd": "de b 6, wa p 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa p 7 1`] = `
+{
+  "_cmd": "de b 6, wa p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa p 8 1`] = `
+{
+  "_cmd": "de b 6, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa p 9 1`] = `
+{
+  "_cmd": "de b 6, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa p 10 1`] = `
+{
+  "_cmd": "de b 6, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa p v 1 1`] = `
+{
+  "_cmd": "de b 6, wa p v 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`de b 6, wa p v 2 1`] = `
+{
+  "_cmd": "de b 6, wa p v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, wa p v 3 1`] = `
+{
+  "_cmd": "de b 6, wa p v 3",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, wa p v 4 1`] = `
+{
+  "_cmd": "de b 6, wa p v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa p v 5 1`] = `
+{
+  "_cmd": "de b 6, wa p v 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, wa p v 6 1`] = `
+{
+  "_cmd": "de b 6, wa p v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa p v 7 1`] = `
+{
+  "_cmd": "de b 6, wa p v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa p v 8 1`] = `
+{
+  "_cmd": "de b 6, wa p v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, wa p v 9 1`] = `
+{
+  "_cmd": "de b 6, wa p v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa p v 10 1`] = `
+{
+  "_cmd": "de b 6, wa p v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa p v 11 1`] = `
+{
+  "_cmd": "de b 6, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, wa p v 12 1`] = `
+{
+  "_cmd": "de b 6, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, wa p v 13 1`] = `
+{
+  "_cmd": "de b 6, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, wa p v 14 1`] = `
+{
+  "_cmd": "de b 6, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, wa p v 15 1`] = `
+{
+  "_cmd": "de b 6, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, wa v 1 1`] = `
+{
+  "_cmd": "de b 6, wa v 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`de b 6, wa v 2 1`] = `
+{
+  "_cmd": "de b 6, wa v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, wa v 3 1`] = `
+{
+  "_cmd": "de b 6, wa v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b 6, wa v 4 1`] = `
+{
+  "_cmd": "de b 6, wa v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa v 5 1`] = `
+{
+  "_cmd": "de b 6, wa v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, wa v 6 1`] = `
+{
+  "_cmd": "de b 6, wa v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa v 7 1`] = `
+{
+  "_cmd": "de b 6, wa v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa v 8 1`] = `
+{
+  "_cmd": "de b 6, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa v 9 1`] = `
+{
+  "_cmd": "de b 6, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa v 10 1`] = `
+{
+  "_cmd": "de b 6, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa v 11 1`] = `
+{
+  "_cmd": "de b 6, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, wa v 12 1`] = `
+{
+  "_cmd": "de b 6, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, wa v 13 1`] = `
+{
+  "_cmd": "de b 6, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, wa v 14 1`] = `
+{
+  "_cmd": "de b 6, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, wa v 15 1`] = `
+{
+  "_cmd": "de b 6, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, wa w 1 1`] = `
+{
+  "_cmd": "de b 6, wa w 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b 6, wa w 2 1`] = `
+{
+  "_cmd": "de b 6, wa w 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa w 3 1`] = `
+{
+  "_cmd": "de b 6, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 6, wa w 4 1`] = `
+{
+  "_cmd": "de b 6, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa w 5 1`] = `
+{
+  "_cmd": "de b 6, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa w 6 1`] = `
+{
+  "_cmd": "de b 6, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, wa w 7 1`] = `
+{
+  "_cmd": "de b 6, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa w 8 1`] = `
+{
+  "_cmd": "de b 6, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa w 9 1`] = `
+{
+  "_cmd": "de b 6, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa w 10 1`] = `
+{
+  "_cmd": "de b 6, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, wa w v 1 1`] = `
+{
+  "_cmd": "de b 6, wa w v 1",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b 6, wa w v 2 1`] = `
+{
+  "_cmd": "de b 6, wa w v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b 6, wa w v 3 1`] = `
+{
+  "_cmd": "de b 6, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 6, wa w v 4 1`] = `
+{
+  "_cmd": "de b 6, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 6, wa w v 5 1`] = `
+{
+  "_cmd": "de b 6, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 6, wa w v 6 1`] = `
+{
+  "_cmd": "de b 6, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 6, wa w v 7 1`] = `
+{
+  "_cmd": "de b 6, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 6, wa w v 8 1`] = `
+{
+  "_cmd": "de b 6, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 6, wa w v 9 1`] = `
+{
+  "_cmd": "de b 6, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 6, wa w v 10 1`] = `
+{
+  "_cmd": "de b 6, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 6, wa w v 11 1`] = `
+{
+  "_cmd": "de b 6, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 6, wa w v 12 1`] = `
+{
+  "_cmd": "de b 6, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 6, wa w v 13 1`] = `
+{
+  "_cmd": "de b 6, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 6, wa w v 14 1`] = `
+{
+  "_cmd": "de b 6, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 6, wa w v 15 1`] = `
+{
+  "_cmd": "de b 6, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b 7, wa d 1 1`] = `
+{
+  "_cmd": "de b 7, wa d 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b 7, wa d 2 1`] = `
+{
+  "_cmd": "de b 7, wa d 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, wa d 3 1`] = `
+{
+  "_cmd": "de b 7, wa d 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, wa d 4 1`] = `
+{
+  "_cmd": "de b 7, wa d 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa d 5 1`] = `
+{
+  "_cmd": "de b 7, wa d 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, wa d 6 1`] = `
+{
+  "_cmd": "de b 7, wa d 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa d 7 1`] = `
+{
+  "_cmd": "de b 7, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa d 8 1`] = `
+{
+  "_cmd": "de b 7, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, wa d 9 1`] = `
+{
+  "_cmd": "de b 7, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa d 10 1`] = `
+{
+  "_cmd": "de b 7, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa d v 1 1`] = `
+{
+  "_cmd": "de b 7, wa d v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b 7, wa d v 2 1`] = `
+{
+  "_cmd": "de b 7, wa d v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, wa d v 3 1`] = `
+{
+  "_cmd": "de b 7, wa d v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, wa d v 4 1`] = `
+{
+  "_cmd": "de b 7, wa d v 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, wa d v 5 1`] = `
+{
+  "_cmd": "de b 7, wa d v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa d v 6 1`] = `
+{
+  "_cmd": "de b 7, wa d v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa d v 7 1`] = `
+{
+  "_cmd": "de b 7, wa d v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa d v 8 1`] = `
+{
+  "_cmd": "de b 7, wa d v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, wa d v 9 1`] = `
+{
+  "_cmd": "de b 7, wa d v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa d v 10 1`] = `
+{
+  "_cmd": "de b 7, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa d v 11 1`] = `
+{
+  "_cmd": "de b 7, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa d v 12 1`] = `
+{
+  "_cmd": "de b 7, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, wa d v 13 1`] = `
+{
+  "_cmd": "de b 7, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, wa d v 14 1`] = `
+{
+  "_cmd": "de b 7, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, wa d v 15 1`] = `
+{
+  "_cmd": "de b 7, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 7, wa p 1 1`] = `
+{
+  "_cmd": "de b 7, wa p 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, wa p 2 1`] = `
+{
+  "_cmd": "de b 7, wa p 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, wa p 3 1`] = `
+{
+  "_cmd": "de b 7, wa p 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, wa p 4 1`] = `
+{
+  "_cmd": "de b 7, wa p 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, wa p 5 1`] = `
+{
+  "_cmd": "de b 7, wa p 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa p 6 1`] = `
+{
+  "_cmd": "de b 7, wa p 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, wa p 7 1`] = `
+{
+  "_cmd": "de b 7, wa p 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa p 8 1`] = `
+{
+  "_cmd": "de b 7, wa p 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa p 9 1`] = `
+{
+  "_cmd": "de b 7, wa p 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa p 10 1`] = `
+{
+  "_cmd": "de b 7, wa p 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa p v 1 1`] = `
+{
+  "_cmd": "de b 7, wa p v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, wa p v 2 1`] = `
+{
+  "_cmd": "de b 7, wa p v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, wa p v 3 1`] = `
+{
+  "_cmd": "de b 7, wa p v 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, wa p v 4 1`] = `
+{
+  "_cmd": "de b 7, wa p v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, wa p v 5 1`] = `
+{
+  "_cmd": "de b 7, wa p v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, wa p v 6 1`] = `
+{
+  "_cmd": "de b 7, wa p v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa p v 7 1`] = `
+{
+  "_cmd": "de b 7, wa p v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa p v 8 1`] = `
+{
+  "_cmd": "de b 7, wa p v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa p v 9 1`] = `
+{
+  "_cmd": "de b 7, wa p v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, wa p v 10 1`] = `
+{
+  "_cmd": "de b 7, wa p v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa p v 11 1`] = `
+{
+  "_cmd": "de b 7, wa p v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa p v 12 1`] = `
+{
+  "_cmd": "de b 7, wa p v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa p v 13 1`] = `
+{
+  "_cmd": "de b 7, wa p v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, wa p v 14 1`] = `
+{
+  "_cmd": "de b 7, wa p v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, wa p v 15 1`] = `
+{
+  "_cmd": "de b 7, wa p v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, wa v 1 1`] = `
+{
+  "_cmd": "de b 7, wa v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b 7, wa v 2 1`] = `
+{
+  "_cmd": "de b 7, wa v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, wa v 3 1`] = `
+{
+  "_cmd": "de b 7, wa v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, wa v 4 1`] = `
+{
+  "_cmd": "de b 7, wa v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, wa v 5 1`] = `
+{
+  "_cmd": "de b 7, wa v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa v 6 1`] = `
+{
+  "_cmd": "de b 7, wa v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, wa v 7 1`] = `
+{
+  "_cmd": "de b 7, wa v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa v 8 1`] = `
+{
+  "_cmd": "de b 7, wa v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa v 9 1`] = `
+{
+  "_cmd": "de b 7, wa v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa v 10 1`] = `
+{
+  "_cmd": "de b 7, wa v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa v 11 1`] = `
+{
+  "_cmd": "de b 7, wa v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa v 12 1`] = `
+{
+  "_cmd": "de b 7, wa v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, wa v 13 1`] = `
+{
+  "_cmd": "de b 7, wa v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, wa v 14 1`] = `
+{
+  "_cmd": "de b 7, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, wa v 15 1`] = `
+{
+  "_cmd": "de b 7, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, wa w 1 1`] = `
+{
+  "_cmd": "de b 7, wa w 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b 7, wa w 2 1`] = `
+{
+  "_cmd": "de b 7, wa w 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b 7, wa w 3 1`] = `
+{
+  "_cmd": "de b 7, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, wa w 4 1`] = `
+{
+  "_cmd": "de b 7, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b 7, wa w 5 1`] = `
+{
+  "_cmd": "de b 7, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa w 6 1`] = `
+{
+  "_cmd": "de b 7, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa w 7 1`] = `
+{
+  "_cmd": "de b 7, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, wa w 8 1`] = `
+{
+  "_cmd": "de b 7, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa w 9 1`] = `
+{
+  "_cmd": "de b 7, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa w 10 1`] = `
+{
+  "_cmd": "de b 7, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa w v 1 1`] = `
+{
+  "_cmd": "de b 7, wa w v 1",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b 7, wa w v 2 1`] = `
+{
+  "_cmd": "de b 7, wa w v 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b 7, wa w v 3 1`] = `
+{
+  "_cmd": "de b 7, wa w v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 7, wa w v 4 1`] = `
+{
+  "_cmd": "de b 7, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b 7, wa w v 5 1`] = `
+{
+  "_cmd": "de b 7, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 7, wa w v 6 1`] = `
+{
+  "_cmd": "de b 7, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 7, wa w v 7 1`] = `
+{
+  "_cmd": "de b 7, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 7, wa w v 8 1`] = `
+{
+  "_cmd": "de b 7, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 7, wa w v 9 1`] = `
+{
+  "_cmd": "de b 7, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 7, wa w v 10 1`] = `
+{
+  "_cmd": "de b 7, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 7, wa w v 11 1`] = `
+{
+  "_cmd": "de b 7, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 7, wa w v 12 1`] = `
+{
+  "_cmd": "de b 7, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 7, wa w v 13 1`] = `
+{
+  "_cmd": "de b 7, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 7, wa w v 14 1`] = `
+{
+  "_cmd": "de b 7, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 7, wa w v 15 1`] = `
+{
+  "_cmd": "de b 7, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, wa d 1 1`] = `
+{
+  "_cmd": "de b 8, wa d 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b 8, wa d 2 1`] = `
+{
+  "_cmd": "de b 8, wa d 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, wa d 3 1`] = `
+{
+  "_cmd": "de b 8, wa d 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, wa d 4 1`] = `
+{
+  "_cmd": "de b 8, wa d 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa d 5 1`] = `
+{
+  "_cmd": "de b 8, wa d 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa d 6 1`] = `
+{
+  "_cmd": "de b 8, wa d 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, wa d 7 1`] = `
+{
+  "_cmd": "de b 8, wa d 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa d 8 1`] = `
+{
+  "_cmd": "de b 8, wa d 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa d 9 1`] = `
+{
+  "_cmd": "de b 8, wa d 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa d 10 1`] = `
+{
+  "_cmd": "de b 8, wa d 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa d v 1 1`] = `
+{
+  "_cmd": "de b 8, wa d v 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b 8, wa d v 2 1`] = `
+{
+  "_cmd": "de b 8, wa d v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, wa d v 3 1`] = `
+{
+  "_cmd": "de b 8, wa d v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, wa d v 4 1`] = `
+{
+  "_cmd": "de b 8, wa d v 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa d v 5 1`] = `
+{
+  "_cmd": "de b 8, wa d v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, wa d v 6 1`] = `
+{
+  "_cmd": "de b 8, wa d v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa d v 7 1`] = `
+{
+  "_cmd": "de b 8, wa d v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa d v 8 1`] = `
+{
+  "_cmd": "de b 8, wa d v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa d v 9 1`] = `
+{
+  "_cmd": "de b 8, wa d v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa d v 10 1`] = `
+{
+  "_cmd": "de b 8, wa d v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, wa d v 11 1`] = `
+{
+  "_cmd": "de b 8, wa d v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa d v 12 1`] = `
+{
+  "_cmd": "de b 8, wa d v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, wa d v 13 1`] = `
+{
+  "_cmd": "de b 8, wa d v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, wa d v 14 1`] = `
+{
+  "_cmd": "de b 8, wa d v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, wa d v 15 1`] = `
+{
+  "_cmd": "de b 8, wa d v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 8, wa p 1 1`] = `
+{
+  "_cmd": "de b 8, wa p 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, wa p 2 1`] = `
+{
+  "_cmd": "de b 8, wa p 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, wa p 3 1`] = `
+{
+  "_cmd": "de b 8, wa p 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, wa p 4 1`] = `
+{
+  "_cmd": "de b 8, wa p 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, wa p 5 1`] = `
+{
+  "_cmd": "de b 8, wa p 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa p 6 1`] = `
+{
+  "_cmd": "de b 8, wa p 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa p 7 1`] = `
+{
+  "_cmd": "de b 8, wa p 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, wa p 8 1`] = `
+{
+  "_cmd": "de b 8, wa p 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa p 9 1`] = `
+{
+  "_cmd": "de b 8, wa p 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa p 10 1`] = `
+{
+  "_cmd": "de b 8, wa p 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, wa p v 1 1`] = `
+{
+  "_cmd": "de b 8, wa p v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, wa p v 2 1`] = `
+{
+  "_cmd": "de b 8, wa p v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, wa p v 3 1`] = `
+{
+  "_cmd": "de b 8, wa p v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, wa p v 4 1`] = `
+{
+  "_cmd": "de b 8, wa p v 4",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, wa p v 5 1`] = `
+{
+  "_cmd": "de b 8, wa p v 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa p v 6 1`] = `
+{
+  "_cmd": "de b 8, wa p v 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, wa p v 7 1`] = `
+{
+  "_cmd": "de b 8, wa p v 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa p v 8 1`] = `
+{
+  "_cmd": "de b 8, wa p v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa p v 9 1`] = `
+{
+  "_cmd": "de b 8, wa p v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa p v 10 1`] = `
+{
+  "_cmd": "de b 8, wa p v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa p v 11 1`] = `
+{
+  "_cmd": "de b 8, wa p v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, wa p v 12 1`] = `
+{
+  "_cmd": "de b 8, wa p v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa p v 13 1`] = `
+{
+  "_cmd": "de b 8, wa p v 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, wa p v 14 1`] = `
+{
+  "_cmd": "de b 8, wa p v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, wa p v 15 1`] = `
+{
+  "_cmd": "de b 8, wa p v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, wa v 1 1`] = `
+{
+  "_cmd": "de b 8, wa v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b 8, wa v 2 1`] = `
+{
+  "_cmd": "de b 8, wa v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, wa v 3 1`] = `
+{
+  "_cmd": "de b 8, wa v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, wa v 4 1`] = `
+{
+  "_cmd": "de b 8, wa v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, wa v 5 1`] = `
+{
+  "_cmd": "de b 8, wa v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa v 6 1`] = `
+{
+  "_cmd": "de b 8, wa v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa v 7 1`] = `
+{
+  "_cmd": "de b 8, wa v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, wa v 8 1`] = `
+{
+  "_cmd": "de b 8, wa v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa v 9 1`] = `
+{
+  "_cmd": "de b 8, wa v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa v 10 1`] = `
+{
+  "_cmd": "de b 8, wa v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa v 11 1`] = `
+{
+  "_cmd": "de b 8, wa v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa v 12 1`] = `
+{
+  "_cmd": "de b 8, wa v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, wa v 13 1`] = `
+{
+  "_cmd": "de b 8, wa v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, wa v 14 1`] = `
+{
+  "_cmd": "de b 8, wa v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, wa v 15 1`] = `
+{
+  "_cmd": "de b 8, wa v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, wa w 1 1`] = `
+{
+  "_cmd": "de b 8, wa w 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b 8, wa w 2 1`] = `
+{
+  "_cmd": "de b 8, wa w 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b 8, wa w 3 1`] = `
+{
+  "_cmd": "de b 8, wa w 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa w 4 1`] = `
+{
+  "_cmd": "de b 8, wa w 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa w 5 1`] = `
+{
+  "_cmd": "de b 8, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b 8, wa w 6 1`] = `
+{
+  "_cmd": "de b 8, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa w 7 1`] = `
+{
+  "_cmd": "de b 8, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa w 8 1`] = `
+{
+  "_cmd": "de b 8, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa w 9 1`] = `
+{
+  "_cmd": "de b 8, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, wa w 10 1`] = `
+{
+  "_cmd": "de b 8, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa w v 1 1`] = `
+{
+  "_cmd": "de b 8, wa w v 1",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b 8, wa w v 2 1`] = `
+{
+  "_cmd": "de b 8, wa w v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b 8, wa w v 3 1`] = `
+{
+  "_cmd": "de b 8, wa w v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 8, wa w v 4 1`] = `
+{
+  "_cmd": "de b 8, wa w v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b 8, wa w v 5 1`] = `
+{
+  "_cmd": "de b 8, wa w v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b 8, wa w v 6 1`] = `
+{
+  "_cmd": "de b 8, wa w v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 8, wa w v 7 1`] = `
+{
+  "_cmd": "de b 8, wa w v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 8, wa w v 8 1`] = `
+{
+  "_cmd": "de b 8, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b 8, wa w v 9 1`] = `
+{
+  "_cmd": "de b 8, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b 8, wa w v 10 1`] = `
+{
+  "_cmd": "de b 8, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b 8, wa w v 11 1`] = `
+{
+  "_cmd": "de b 8, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b 8, wa w v 12 1`] = `
+{
+  "_cmd": "de b 8, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b 8, wa w v 13 1`] = `
+{
+  "_cmd": "de b 8, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b 8, wa w v 14 1`] = `
+{
+  "_cmd": "de b 8, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b 8, wa w v 15 1`] = `
+{
+  "_cmd": "de b 8, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b 9, wa d 1 1`] = `
+{
+  "_cmd": "de b 9, wa d 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b 9, wa d 2 1`] = `
+{
+  "_cmd": "de b 9, wa d 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, wa d 3 1`] = `
+{
+  "_cmd": "de b 9, wa d 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, wa d 4 1`] = `
+{
+  "_cmd": "de b 9, wa d 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa d 5 1`] = `
+{
+  "_cmd": "de b 9, wa d 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, wa d 6 1`] = `
+{
+  "_cmd": "de b 9, wa d 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa d 7 1`] = `
+{
+  "_cmd": "de b 9, wa d 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, wa d 8 1`] = `
+{
+  "_cmd": "de b 9, wa d 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa d 9 1`] = `
+{
+  "_cmd": "de b 9, wa d 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa d 10 1`] = `
+{
+  "_cmd": "de b 9, wa d 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa d v 1 1`] = `
+{
+  "_cmd": "de b 9, wa d v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, wa d v 2 1`] = `
+{
+  "_cmd": "de b 9, wa d v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, wa d v 3 1`] = `
+{
+  "_cmd": "de b 9, wa d v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, wa d v 4 1`] = `
+{
+  "_cmd": "de b 9, wa d v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, wa d v 5 1`] = `
+{
+  "_cmd": "de b 9, wa d v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, wa d v 6 1`] = `
+{
+  "_cmd": "de b 9, wa d v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, wa d v 7 1`] = `
+{
+  "_cmd": "de b 9, wa d v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa d v 8 1`] = `
+{
+  "_cmd": "de b 9, wa d v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa d v 9 1`] = `
+{
+  "_cmd": "de b 9, wa d v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa d v 10 1`] = `
+{
+  "_cmd": "de b 9, wa d v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa d v 11 1`] = `
+{
+  "_cmd": "de b 9, wa d v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, wa d v 12 1`] = `
+{
+  "_cmd": "de b 9, wa d v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, wa d v 13 1`] = `
+{
+  "_cmd": "de b 9, wa d v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, wa d v 14 1`] = `
+{
+  "_cmd": "de b 9, wa d v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, wa d v 15 1`] = `
+{
+  "_cmd": "de b 9, wa d v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, wa p 1 1`] = `
+{
+  "_cmd": "de b 9, wa p 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, wa p 2 1`] = `
+{
+  "_cmd": "de b 9, wa p 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, wa p 3 1`] = `
+{
+  "_cmd": "de b 9, wa p 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, wa p 4 1`] = `
+{
+  "_cmd": "de b 9, wa p 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, wa p 5 1`] = `
+{
+  "_cmd": "de b 9, wa p 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa p 6 1`] = `
+{
+  "_cmd": "de b 9, wa p 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, wa p 7 1`] = `
+{
+  "_cmd": "de b 9, wa p 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa p 8 1`] = `
+{
+  "_cmd": "de b 9, wa p 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, wa p 9 1`] = `
+{
+  "_cmd": "de b 9, wa p 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa p 10 1`] = `
+{
+  "_cmd": "de b 9, wa p 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa p v 1 1`] = `
+{
+  "_cmd": "de b 9, wa p v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, wa p v 2 1`] = `
+{
+  "_cmd": "de b 9, wa p v 2",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b 9, wa p v 3 1`] = `
+{
+  "_cmd": "de b 9, wa p v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, wa p v 4 1`] = `
+{
+  "_cmd": "de b 9, wa p v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, wa p v 5 1`] = `
+{
+  "_cmd": "de b 9, wa p v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa p v 6 1`] = `
+{
+  "_cmd": "de b 9, wa p v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, wa p v 7 1`] = `
+{
+  "_cmd": "de b 9, wa p v 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, wa p v 8 1`] = `
+{
+  "_cmd": "de b 9, wa p v 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa p v 9 1`] = `
+{
+  "_cmd": "de b 9, wa p v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa p v 10 1`] = `
+{
+  "_cmd": "de b 9, wa p v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa p v 11 1`] = `
+{
+  "_cmd": "de b 9, wa p v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa p v 12 1`] = `
+{
+  "_cmd": "de b 9, wa p v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, wa p v 13 1`] = `
+{
+  "_cmd": "de b 9, wa p v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, wa p v 14 1`] = `
+{
+  "_cmd": "de b 9, wa p v 14",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, wa p v 15 1`] = `
+{
+  "_cmd": "de b 9, wa p v 15",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, wa v 1 1`] = `
+{
+  "_cmd": "de b 9, wa v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b 9, wa v 2 1`] = `
+{
+  "_cmd": "de b 9, wa v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, wa v 3 1`] = `
+{
+  "_cmd": "de b 9, wa v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b 9, wa v 4 1`] = `
+{
+  "_cmd": "de b 9, wa v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, wa v 5 1`] = `
+{
+  "_cmd": "de b 9, wa v 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa v 6 1`] = `
+{
+  "_cmd": "de b 9, wa v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, wa v 7 1`] = `
+{
+  "_cmd": "de b 9, wa v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa v 8 1`] = `
+{
+  "_cmd": "de b 9, wa v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, wa v 9 1`] = `
+{
+  "_cmd": "de b 9, wa v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa v 10 1`] = `
+{
+  "_cmd": "de b 9, wa v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa v 11 1`] = `
+{
+  "_cmd": "de b 9, wa v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa v 12 1`] = `
+{
+  "_cmd": "de b 9, wa v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, wa v 13 1`] = `
+{
+  "_cmd": "de b 9, wa v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, wa v 14 1`] = `
+{
+  "_cmd": "de b 9, wa v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, wa v 15 1`] = `
+{
+  "_cmd": "de b 9, wa v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, wa w 1 1`] = `
+{
+  "_cmd": "de b 9, wa w 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, wa w 2 1`] = `
+{
+  "_cmd": "de b 9, wa w 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b 9, wa w 3 1`] = `
+{
+  "_cmd": "de b 9, wa w 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa w 4 1`] = `
+{
+  "_cmd": "de b 9, wa w 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, wa w 5 1`] = `
+{
+  "_cmd": "de b 9, wa w 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b 9, wa w 6 1`] = `
+{
+  "_cmd": "de b 9, wa w 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, wa w 7 1`] = `
+{
+  "_cmd": "de b 9, wa w 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa w 8 1`] = `
+{
+  "_cmd": "de b 9, wa w 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa w 9 1`] = `
+{
+  "_cmd": "de b 9, wa w 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa w 10 1`] = `
+{
+  "_cmd": "de b 9, wa w 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, wa w v 1 1`] = `
+{
+  "_cmd": "de b 9, wa w v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b 9, wa w v 2 1`] = `
+{
+  "_cmd": "de b 9, wa w v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b 9, wa w v 3 1`] = `
+{
+  "_cmd": "de b 9, wa w v 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b 9, wa w v 4 1`] = `
+{
+  "_cmd": "de b 9, wa w v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 9, wa w v 5 1`] = `
+{
+  "_cmd": "de b 9, wa w v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b 9, wa w v 6 1`] = `
+{
+  "_cmd": "de b 9, wa w v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b 9, wa w v 7 1`] = `
+{
+  "_cmd": "de b 9, wa w v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 9, wa w v 8 1`] = `
+{
+  "_cmd": "de b 9, wa w v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 9, wa w v 9 1`] = `
+{
+  "_cmd": "de b 9, wa w v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b 9, wa w v 10 1`] = `
+{
+  "_cmd": "de b 9, wa w v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b 9, wa w v 11 1`] = `
+{
+  "_cmd": "de b 9, wa w v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b 9, wa w v 12 1`] = `
+{
+  "_cmd": "de b 9, wa w v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b 9, wa w v 13 1`] = `
+{
+  "_cmd": "de b 9, wa w v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b 9, wa w v 14 1`] = `
+{
+  "_cmd": "de b 9, wa w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b 9, wa w v 15 1`] = `
+{
+  "_cmd": "de b 9, wa w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b 10, wa d 1 1`] = `
+{
+  "_cmd": "de b 10, wa d 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b 10, wa d 2 1`] = `
+{
+  "_cmd": "de b 10, wa d 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, wa d 3 1`] = `
+{
+  "_cmd": "de b 10, wa d 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, wa d 4 1`] = `
+{
+  "_cmd": "de b 10, wa d 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, wa d 5 1`] = `
+{
+  "_cmd": "de b 10, wa d 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa d 6 1`] = `
+{
+  "_cmd": "de b 10, wa d 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa d 7 1`] = `
+{
+  "_cmd": "de b 10, wa d 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa d 8 1`] = `
+{
+  "_cmd": "de b 10, wa d 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, wa d 9 1`] = `
+{
+  "_cmd": "de b 10, wa d 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa d 10 1`] = `
+{
+  "_cmd": "de b 10, wa d 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa d v 1 1`] = `
+{
+  "_cmd": "de b 10, wa d v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, wa d v 2 1`] = `
+{
+  "_cmd": "de b 10, wa d v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, wa d v 3 1`] = `
+{
+  "_cmd": "de b 10, wa d v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, wa d v 4 1`] = `
+{
+  "_cmd": "de b 10, wa d v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, wa d v 5 1`] = `
+{
+  "_cmd": "de b 10, wa d v 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa d v 6 1`] = `
+{
+  "_cmd": "de b 10, wa d v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, wa d v 7 1`] = `
+{
+  "_cmd": "de b 10, wa d v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa d v 8 1`] = `
+{
+  "_cmd": "de b 10, wa d v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa d v 9 1`] = `
+{
+  "_cmd": "de b 10, wa d v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa d v 10 1`] = `
+{
+  "_cmd": "de b 10, wa d v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa d v 11 1`] = `
+{
+  "_cmd": "de b 10, wa d v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, wa d v 12 1`] = `
+{
+  "_cmd": "de b 10, wa d v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, wa d v 13 1`] = `
+{
+  "_cmd": "de b 10, wa d v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, wa d v 14 1`] = `
+{
+  "_cmd": "de b 10, wa d v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, wa d v 15 1`] = `
+{
+  "_cmd": "de b 10, wa d v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, wa p 1 1`] = `
+{
+  "_cmd": "de b 10, wa p 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, wa p 2 1`] = `
+{
+  "_cmd": "de b 10, wa p 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, wa p 3 1`] = `
+{
+  "_cmd": "de b 10, wa p 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, wa p 4 1`] = `
+{
+  "_cmd": "de b 10, wa p 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, wa p 5 1`] = `
+{
+  "_cmd": "de b 10, wa p 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, wa p 6 1`] = `
+{
+  "_cmd": "de b 10, wa p 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa p 7 1`] = `
+{
+  "_cmd": "de b 10, wa p 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa p 8 1`] = `
+{
+  "_cmd": "de b 10, wa p 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa p 9 1`] = `
+{
+  "_cmd": "de b 10, wa p 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, wa p 10 1`] = `
+{
+  "_cmd": "de b 10, wa p 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa p v 1 1`] = `
+{
+  "_cmd": "de b 10, wa p v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, wa p v 2 1`] = `
+{
+  "_cmd": "de b 10, wa p v 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b 10, wa p v 3 1`] = `
+{
+  "_cmd": "de b 10, wa p v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, wa p v 4 1`] = `
+{
+  "_cmd": "de b 10, wa p v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, wa p v 5 1`] = `
+{
+  "_cmd": "de b 10, wa p v 5",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, wa p v 6 1`] = `
+{
+  "_cmd": "de b 10, wa p v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa p v 7 1`] = `
+{
+  "_cmd": "de b 10, wa p v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, wa p v 8 1`] = `
+{
+  "_cmd": "de b 10, wa p v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa p v 9 1`] = `
+{
+  "_cmd": "de b 10, wa p v 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa p v 10 1`] = `
+{
+  "_cmd": "de b 10, wa p v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa p v 11 1`] = `
+{
+  "_cmd": "de b 10, wa p v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa p v 12 1`] = `
+{
+  "_cmd": "de b 10, wa p v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, wa p v 13 1`] = `
+{
+  "_cmd": "de b 10, wa p v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, wa p v 14 1`] = `
+{
+  "_cmd": "de b 10, wa p v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, wa p v 15 1`] = `
+{
+  "_cmd": "de b 10, wa p v 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, wa v 1 1`] = `
+{
+  "_cmd": "de b 10, wa v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b 10, wa v 2 1`] = `
+{
+  "_cmd": "de b 10, wa v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, wa v 3 1`] = `
+{
+  "_cmd": "de b 10, wa v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b 10, wa v 4 1`] = `
+{
+  "_cmd": "de b 10, wa v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, wa v 5 1`] = `
+{
+  "_cmd": "de b 10, wa v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, wa v 6 1`] = `
+{
+  "_cmd": "de b 10, wa v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa v 7 1`] = `
+{
+  "_cmd": "de b 10, wa v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa v 8 1`] = `
+{
+  "_cmd": "de b 10, wa v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa v 9 1`] = `
+{
+  "_cmd": "de b 10, wa v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, wa v 10 1`] = `
+{
+  "_cmd": "de b 10, wa v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa v 11 1`] = `
+{
+  "_cmd": "de b 10, wa v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa v 12 1`] = `
+{
+  "_cmd": "de b 10, wa v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, wa v 13 1`] = `
+{
+  "_cmd": "de b 10, wa v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, wa v 14 1`] = `
+{
+  "_cmd": "de b 10, wa v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, wa v 15 1`] = `
+{
+  "_cmd": "de b 10, wa v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, wa w 1 1`] = `
+{
+  "_cmd": "de b 10, wa w 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, wa w 2 1`] = `
+{
+  "_cmd": "de b 10, wa w 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, wa w 3 1`] = `
+{
+  "_cmd": "de b 10, wa w 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b 10, wa w 4 1`] = `
+{
+  "_cmd": "de b 10, wa w 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa w 5 1`] = `
+{
+  "_cmd": "de b 10, wa w 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa w 6 1`] = `
+{
+  "_cmd": "de b 10, wa w 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b 10, wa w 7 1`] = `
+{
+  "_cmd": "de b 10, wa w 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, wa w 8 1`] = `
+{
+  "_cmd": "de b 10, wa w 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa w 9 1`] = `
+{
+  "_cmd": "de b 10, wa w 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa w 10 1`] = `
+{
+  "_cmd": "de b 10, wa w 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, wa w v 1 1`] = `
+{
+  "_cmd": "de b 10, wa w v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b 10, wa w v 2 1`] = `
+{
+  "_cmd": "de b 10, wa w v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b 10, wa w v 3 1`] = `
+{
+  "_cmd": "de b 10, wa w v 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b 10, wa w v 4 1`] = `
+{
+  "_cmd": "de b 10, wa w v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 10, wa w v 5 1`] = `
+{
+  "_cmd": "de b 10, wa w v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b 10, wa w v 6 1`] = `
+{
+  "_cmd": "de b 10, wa w v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b 10, wa w v 7 1`] = `
+{
+  "_cmd": "de b 10, wa w v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 10, wa w v 8 1`] = `
+{
+  "_cmd": "de b 10, wa w v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 10, wa w v 9 1`] = `
+{
+  "_cmd": "de b 10, wa w v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 10, wa w v 10 1`] = `
+{
+  "_cmd": "de b 10, wa w v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b 10, wa w v 11 1`] = `
+{
+  "_cmd": "de b 10, wa w v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b 10, wa w v 12 1`] = `
+{
+  "_cmd": "de b 10, wa w v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b 10, wa w v 13 1`] = `
+{
+  "_cmd": "de b 10, wa w v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b 10, wa w v 14 1`] = `
+{
+  "_cmd": "de b 10, wa w v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b 10, wa w v 15 1`] = `
+{
+  "_cmd": "de b 10, wa w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b 11, wa d 1 1`] = `
+{
+  "_cmd": "de b 11, wa d 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b 11, wa d 2 1`] = `
+{
+  "_cmd": "de b 11, wa d 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, wa d 3 1`] = `
+{
+  "_cmd": "de b 11, wa d 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa d 4 1`] = `
+{
+  "_cmd": "de b 11, wa d 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, wa d 5 1`] = `
+{
+  "_cmd": "de b 11, wa d 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa d 6 1`] = `
+{
+  "_cmd": "de b 11, wa d 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa d 7 1`] = `
+{
+  "_cmd": "de b 11, wa d 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa d 8 1`] = `
+{
+  "_cmd": "de b 11, wa d 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa d 9 1`] = `
+{
+  "_cmd": "de b 11, wa d 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, wa d 10 1`] = `
+{
+  "_cmd": "de b 11, wa d 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa d v 1 1`] = `
+{
+  "_cmd": "de b 11, wa d v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, wa d v 2 1`] = `
+{
+  "_cmd": "de b 11, wa d v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, wa d v 3 1`] = `
+{
+  "_cmd": "de b 11, wa d v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa d v 4 1`] = `
+{
+  "_cmd": "de b 11, wa d v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, wa d v 5 1`] = `
+{
+  "_cmd": "de b 11, wa d v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, wa d v 6 1`] = `
+{
+  "_cmd": "de b 11, wa d v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa d v 7 1`] = `
+{
+  "_cmd": "de b 11, wa d v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, wa d v 8 1`] = `
+{
+  "_cmd": "de b 11, wa d v 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa d v 9 1`] = `
+{
+  "_cmd": "de b 11, wa d v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa d v 10 1`] = `
+{
+  "_cmd": "de b 11, wa d v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa d v 11 1`] = `
+{
+  "_cmd": "de b 11, wa d v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, wa d v 12 1`] = `
+{
+  "_cmd": "de b 11, wa d v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, wa d v 13 1`] = `
+{
+  "_cmd": "de b 11, wa d v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, wa d v 14 1`] = `
+{
+  "_cmd": "de b 11, wa d v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, wa d v 15 1`] = `
+{
+  "_cmd": "de b 11, wa d v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, wa p 1 1`] = `
+{
+  "_cmd": "de b 11, wa p 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, wa p 2 1`] = `
+{
+  "_cmd": "de b 11, wa p 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, wa p 3 1`] = `
+{
+  "_cmd": "de b 11, wa p 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, wa p 4 1`] = `
+{
+  "_cmd": "de b 11, wa p 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, wa p 5 1`] = `
+{
+  "_cmd": "de b 11, wa p 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, wa p 6 1`] = `
+{
+  "_cmd": "de b 11, wa p 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa p 7 1`] = `
+{
+  "_cmd": "de b 11, wa p 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa p 8 1`] = `
+{
+  "_cmd": "de b 11, wa p 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa p 9 1`] = `
+{
+  "_cmd": "de b 11, wa p 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa p 10 1`] = `
+{
+  "_cmd": "de b 11, wa p 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, wa p v 1 1`] = `
+{
+  "_cmd": "de b 11, wa p v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, wa p v 2 1`] = `
+{
+  "_cmd": "de b 11, wa p v 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b 11, wa p v 3 1`] = `
+{
+  "_cmd": "de b 11, wa p v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, wa p v 4 1`] = `
+{
+  "_cmd": "de b 11, wa p v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa p v 5 1`] = `
+{
+  "_cmd": "de b 11, wa p v 5",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, wa p v 6 1`] = `
+{
+  "_cmd": "de b 11, wa p v 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa p v 7 1`] = `
+{
+  "_cmd": "de b 11, wa p v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa p v 8 1`] = `
+{
+  "_cmd": "de b 11, wa p v 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, wa p v 9 1`] = `
+{
+  "_cmd": "de b 11, wa p v 9",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa p v 10 1`] = `
+{
+  "_cmd": "de b 11, wa p v 10",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa p v 11 1`] = `
+{
+  "_cmd": "de b 11, wa p v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa p v 12 1`] = `
+{
+  "_cmd": "de b 11, wa p v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, wa p v 13 1`] = `
+{
+  "_cmd": "de b 11, wa p v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, wa p v 14 1`] = `
+{
+  "_cmd": "de b 11, wa p v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, wa p v 15 1`] = `
+{
+  "_cmd": "de b 11, wa p v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, wa v 1 1`] = `
+{
+  "_cmd": "de b 11, wa v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b 11, wa v 2 1`] = `
+{
+  "_cmd": "de b 11, wa v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, wa v 3 1`] = `
+{
+  "_cmd": "de b 11, wa v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b 11, wa v 4 1`] = `
+{
+  "_cmd": "de b 11, wa v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa v 5 1`] = `
+{
+  "_cmd": "de b 11, wa v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, wa v 6 1`] = `
+{
+  "_cmd": "de b 11, wa v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa v 7 1`] = `
+{
+  "_cmd": "de b 11, wa v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa v 8 1`] = `
+{
+  "_cmd": "de b 11, wa v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa v 9 1`] = `
+{
+  "_cmd": "de b 11, wa v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa v 10 1`] = `
+{
+  "_cmd": "de b 11, wa v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, wa v 11 1`] = `
+{
+  "_cmd": "de b 11, wa v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa v 12 1`] = `
+{
+  "_cmd": "de b 11, wa v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, wa v 13 1`] = `
+{
+  "_cmd": "de b 11, wa v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, wa v 14 1`] = `
+{
+  "_cmd": "de b 11, wa v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, wa v 15 1`] = `
+{
+  "_cmd": "de b 11, wa v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, wa w 1 1`] = `
+{
+  "_cmd": "de b 11, wa w 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b 11, wa w 2 1`] = `
+{
+  "_cmd": "de b 11, wa w 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa w 3 1`] = `
+{
+  "_cmd": "de b 11, wa w 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b 11, wa w 4 1`] = `
+{
+  "_cmd": "de b 11, wa w 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa w 5 1`] = `
+{
+  "_cmd": "de b 11, wa w 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, wa w 6 1`] = `
+{
+  "_cmd": "de b 11, wa w 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa w 7 1`] = `
+{
+  "_cmd": "de b 11, wa w 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b 11, wa w 8 1`] = `
+{
+  "_cmd": "de b 11, wa w 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, wa w 9 1`] = `
+{
+  "_cmd": "de b 11, wa w 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa w 10 1`] = `
+{
+  "_cmd": "de b 11, wa w 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, wa w v 1 1`] = `
+{
+  "_cmd": "de b 11, wa w v 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b 11, wa w v 2 1`] = `
+{
+  "_cmd": "de b 11, wa w v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b 11, wa w v 3 1`] = `
+{
+  "_cmd": "de b 11, wa w v 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b 11, wa w v 4 1`] = `
+{
+  "_cmd": "de b 11, wa w v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 11, wa w v 5 1`] = `
+{
+  "_cmd": "de b 11, wa w v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 11, wa w v 6 1`] = `
+{
+  "_cmd": "de b 11, wa w v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b 11, wa w v 7 1`] = `
+{
+  "_cmd": "de b 11, wa w v 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b 11, wa w v 8 1`] = `
+{
+  "_cmd": "de b 11, wa w v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 11, wa w v 9 1`] = `
+{
+  "_cmd": "de b 11, wa w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 11, wa w v 10 1`] = `
+{
+  "_cmd": "de b 11, wa w v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 11, wa w v 11 1`] = `
+{
+  "_cmd": "de b 11, wa w v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b 11, wa w v 12 1`] = `
+{
+  "_cmd": "de b 11, wa w v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b 11, wa w v 13 1`] = `
+{
+  "_cmd": "de b 11, wa w v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b 11, wa w v 14 1`] = `
+{
+  "_cmd": "de b 11, wa w v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b 11, wa w v 15 1`] = `
+{
+  "_cmd": "de b 11, wa w v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b 12, wa d 1 1`] = `
+{
+  "_cmd": "de b 12, wa d 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, wa d 2 1`] = `
+{
+  "_cmd": "de b 12, wa d 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, wa d 3 1`] = `
+{
+  "_cmd": "de b 12, wa d 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, wa d 4 1`] = `
+{
+  "_cmd": "de b 12, wa d 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa d 5 1`] = `
+{
+  "_cmd": "de b 12, wa d 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, wa d 6 1`] = `
+{
+  "_cmd": "de b 12, wa d 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa d 7 1`] = `
+{
+  "_cmd": "de b 12, wa d 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa d 8 1`] = `
+{
+  "_cmd": "de b 12, wa d 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa d 9 1`] = `
+{
+  "_cmd": "de b 12, wa d 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa d 10 1`] = `
+{
+  "_cmd": "de b 12, wa d 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, wa d v 1 1`] = `
+{
+  "_cmd": "de b 12, wa d v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, wa d v 2 1`] = `
+{
+  "_cmd": "de b 12, wa d v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, wa d v 3 1`] = `
+{
+  "_cmd": "de b 12, wa d v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, wa d v 4 1`] = `
+{
+  "_cmd": "de b 12, wa d v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, wa d v 5 1`] = `
+{
+  "_cmd": "de b 12, wa d v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa d v 6 1`] = `
+{
+  "_cmd": "de b 12, wa d v 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa d v 7 1`] = `
+{
+  "_cmd": "de b 12, wa d v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, wa d v 8 1`] = `
+{
+  "_cmd": "de b 12, wa d v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa d v 9 1`] = `
+{
+  "_cmd": "de b 12, wa d v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa d v 10 1`] = `
+{
+  "_cmd": "de b 12, wa d v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa d v 11 1`] = `
+{
+  "_cmd": "de b 12, wa d v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, wa d v 12 1`] = `
+{
+  "_cmd": "de b 12, wa d v 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, wa d v 13 1`] = `
+{
+  "_cmd": "de b 12, wa d v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, wa d v 14 1`] = `
+{
+  "_cmd": "de b 12, wa d v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, wa d v 15 1`] = `
+{
+  "_cmd": "de b 12, wa d v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, wa p 1 1`] = `
+{
+  "_cmd": "de b 12, wa p 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, wa p 2 1`] = `
+{
+  "_cmd": "de b 12, wa p 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, wa p 3 1`] = `
+{
+  "_cmd": "de b 12, wa p 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, wa p 4 1`] = `
+{
+  "_cmd": "de b 12, wa p 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, wa p 5 1`] = `
+{
+  "_cmd": "de b 12, wa p 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa p 6 1`] = `
+{
+  "_cmd": "de b 12, wa p 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, wa p 7 1`] = `
+{
+  "_cmd": "de b 12, wa p 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa p 8 1`] = `
+{
+  "_cmd": "de b 12, wa p 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa p 9 1`] = `
+{
+  "_cmd": "de b 12, wa p 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa p 10 1`] = `
+{
+  "_cmd": "de b 12, wa p 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa p v 1 1`] = `
+{
+  "_cmd": "de b 12, wa p v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, wa p v 2 1`] = `
+{
+  "_cmd": "de b 12, wa p v 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, wa p v 3 1`] = `
+{
+  "_cmd": "de b 12, wa p v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, wa p v 4 1`] = `
+{
+  "_cmd": "de b 12, wa p v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, wa p v 5 1`] = `
+{
+  "_cmd": "de b 12, wa p v 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, wa p v 6 1`] = `
+{
+  "_cmd": "de b 12, wa p v 6",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa p v 7 1`] = `
+{
+  "_cmd": "de b 12, wa p v 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa p v 8 1`] = `
+{
+  "_cmd": "de b 12, wa p v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, wa p v 9 1`] = `
+{
+  "_cmd": "de b 12, wa p v 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa p v 10 1`] = `
+{
+  "_cmd": "de b 12, wa p v 10",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa p v 11 1`] = `
+{
+  "_cmd": "de b 12, wa p v 11",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa p v 12 1`] = `
+{
+  "_cmd": "de b 12, wa p v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, wa p v 13 1`] = `
+{
+  "_cmd": "de b 12, wa p v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, wa p v 14 1`] = `
+{
+  "_cmd": "de b 12, wa p v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, wa p v 15 1`] = `
+{
+  "_cmd": "de b 12, wa p v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, wa v 1 1`] = `
+{
+  "_cmd": "de b 12, wa v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b 12, wa v 2 1`] = `
+{
+  "_cmd": "de b 12, wa v 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, wa v 3 1`] = `
+{
+  "_cmd": "de b 12, wa v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, wa v 4 1`] = `
+{
+  "_cmd": "de b 12, wa v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, wa v 5 1`] = `
+{
+  "_cmd": "de b 12, wa v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa v 6 1`] = `
+{
+  "_cmd": "de b 12, wa v 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, wa v 7 1`] = `
+{
+  "_cmd": "de b 12, wa v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa v 8 1`] = `
+{
+  "_cmd": "de b 12, wa v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, wa v 9 1`] = `
+{
+  "_cmd": "de b 12, wa v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa v 10 1`] = `
+{
+  "_cmd": "de b 12, wa v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa v 11 1`] = `
+{
+  "_cmd": "de b 12, wa v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, wa v 12 1`] = `
+{
+  "_cmd": "de b 12, wa v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, wa v 13 1`] = `
+{
+  "_cmd": "de b 12, wa v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, wa v 14 1`] = `
+{
+  "_cmd": "de b 12, wa v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, wa v 15 1`] = `
+{
+  "_cmd": "de b 12, wa v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, wa w 1 1`] = `
+{
+  "_cmd": "de b 12, wa w 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b 12, wa w 2 1`] = `
+{
+  "_cmd": "de b 12, wa w 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b 12, wa w 3 1`] = `
+{
+  "_cmd": "de b 12, wa w 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b 12, wa w 4 1`] = `
+{
+  "_cmd": "de b 12, wa w 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, wa w 5 1`] = `
+{
+  "_cmd": "de b 12, wa w 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa w 6 1`] = `
+{
+  "_cmd": "de b 12, wa w 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa w 7 1`] = `
+{
+  "_cmd": "de b 12, wa w 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b 12, wa w 8 1`] = `
+{
+  "_cmd": "de b 12, wa w 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa w 9 1`] = `
+{
+  "_cmd": "de b 12, wa w 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, wa w 10 1`] = `
+{
+  "_cmd": "de b 12, wa w 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, wa w v 1 1`] = `
+{
+  "_cmd": "de b 12, wa w v 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b 12, wa w v 2 1`] = `
+{
+  "_cmd": "de b 12, wa w v 2",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b 12, wa w v 3 1`] = `
+{
+  "_cmd": "de b 12, wa w v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b 12, wa w v 4 1`] = `
+{
+  "_cmd": "de b 12, wa w v 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b 12, wa w v 5 1`] = `
+{
+  "_cmd": "de b 12, wa w v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 12, wa w v 6 1`] = `
+{
+  "_cmd": "de b 12, wa w v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b 12, wa w v 7 1`] = `
+{
+  "_cmd": "de b 12, wa w v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b 12, wa w v 8 1`] = `
+{
+  "_cmd": "de b 12, wa w v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b 12, wa w v 9 1`] = `
+{
+  "_cmd": "de b 12, wa w v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 12, wa w v 10 1`] = `
+{
+  "_cmd": "de b 12, wa w v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 12, wa w v 11 1`] = `
+{
+  "_cmd": "de b 12, wa w v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b 12, wa w v 12 1`] = `
+{
+  "_cmd": "de b 12, wa w v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b 12, wa w v 13 1`] = `
+{
+  "_cmd": "de b 12, wa w v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b 12, wa w v 14 1`] = `
+{
+  "_cmd": "de b 12, wa w v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b 12, wa w v 15 1`] = `
+{
+  "_cmd": "de b 12, wa w v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b 13, wa d 1 1`] = `
+{
+  "_cmd": "de b 13, wa d 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, wa d 2 1`] = `
+{
+  "_cmd": "de b 13, wa d 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, wa d 3 1`] = `
+{
+  "_cmd": "de b 13, wa d 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, wa d 4 1`] = `
+{
+  "_cmd": "de b 13, wa d 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, wa d 5 1`] = `
+{
+  "_cmd": "de b 13, wa d 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, wa d 6 1`] = `
+{
+  "_cmd": "de b 13, wa d 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa d 7 1`] = `
+{
+  "_cmd": "de b 13, wa d 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa d 8 1`] = `
+{
+  "_cmd": "de b 13, wa d 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa d 9 1`] = `
+{
+  "_cmd": "de b 13, wa d 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa d 10 1`] = `
+{
+  "_cmd": "de b 13, wa d 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa d v 1 1`] = `
+{
+  "_cmd": "de b 13, wa d v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, wa d v 2 1`] = `
+{
+  "_cmd": "de b 13, wa d v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, wa d v 3 1`] = `
+{
+  "_cmd": "de b 13, wa d v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, wa d v 4 1`] = `
+{
+  "_cmd": "de b 13, wa d v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, wa d v 5 1`] = `
+{
+  "_cmd": "de b 13, wa d v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa d v 6 1`] = `
+{
+  "_cmd": "de b 13, wa d v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, wa d v 7 1`] = `
+{
+  "_cmd": "de b 13, wa d v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa d v 8 1`] = `
+{
+  "_cmd": "de b 13, wa d v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, wa d v 9 1`] = `
+{
+  "_cmd": "de b 13, wa d v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa d v 10 1`] = `
+{
+  "_cmd": "de b 13, wa d v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa d v 11 1`] = `
+{
+  "_cmd": "de b 13, wa d v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa d v 12 1`] = `
+{
+  "_cmd": "de b 13, wa d v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, wa d v 13 1`] = `
+{
+  "_cmd": "de b 13, wa d v 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, wa d v 14 1`] = `
+{
+  "_cmd": "de b 13, wa d v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, wa d v 15 1`] = `
+{
+  "_cmd": "de b 13, wa d v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, wa p 1 1`] = `
+{
+  "_cmd": "de b 13, wa p 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, wa p 2 1`] = `
+{
+  "_cmd": "de b 13, wa p 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, wa p 3 1`] = `
+{
+  "_cmd": "de b 13, wa p 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, wa p 4 1`] = `
+{
+  "_cmd": "de b 13, wa p 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, wa p 5 1`] = `
+{
+  "_cmd": "de b 13, wa p 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa p 6 1`] = `
+{
+  "_cmd": "de b 13, wa p 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, wa p 7 1`] = `
+{
+  "_cmd": "de b 13, wa p 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa p 8 1`] = `
+{
+  "_cmd": "de b 13, wa p 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa p 9 1`] = `
+{
+  "_cmd": "de b 13, wa p 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa p 10 1`] = `
+{
+  "_cmd": "de b 13, wa p 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa p v 1 1`] = `
+{
+  "_cmd": "de b 13, wa p v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, wa p v 2 1`] = `
+{
+  "_cmd": "de b 13, wa p v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, wa p v 3 1`] = `
+{
+  "_cmd": "de b 13, wa p v 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, wa p v 4 1`] = `
+{
+  "_cmd": "de b 13, wa p v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, wa p v 5 1`] = `
+{
+  "_cmd": "de b 13, wa p v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, wa p v 6 1`] = `
+{
+  "_cmd": "de b 13, wa p v 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa p v 7 1`] = `
+{
+  "_cmd": "de b 13, wa p v 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa p v 8 1`] = `
+{
+  "_cmd": "de b 13, wa p v 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa p v 9 1`] = `
+{
+  "_cmd": "de b 13, wa p v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, wa p v 10 1`] = `
+{
+  "_cmd": "de b 13, wa p v 10",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa p v 11 1`] = `
+{
+  "_cmd": "de b 13, wa p v 11",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa p v 12 1`] = `
+{
+  "_cmd": "de b 13, wa p v 12",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa p v 13 1`] = `
+{
+  "_cmd": "de b 13, wa p v 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, wa p v 14 1`] = `
+{
+  "_cmd": "de b 13, wa p v 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, wa p v 15 1`] = `
+{
+  "_cmd": "de b 13, wa p v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, wa v 1 1`] = `
+{
+  "_cmd": "de b 13, wa v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b 13, wa v 2 1`] = `
+{
+  "_cmd": "de b 13, wa v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, wa v 3 1`] = `
+{
+  "_cmd": "de b 13, wa v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, wa v 4 1`] = `
+{
+  "_cmd": "de b 13, wa v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, wa v 5 1`] = `
+{
+  "_cmd": "de b 13, wa v 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa v 6 1`] = `
+{
+  "_cmd": "de b 13, wa v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, wa v 7 1`] = `
+{
+  "_cmd": "de b 13, wa v 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa v 8 1`] = `
+{
+  "_cmd": "de b 13, wa v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa v 9 1`] = `
+{
+  "_cmd": "de b 13, wa v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, wa v 10 1`] = `
+{
+  "_cmd": "de b 13, wa v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa v 11 1`] = `
+{
+  "_cmd": "de b 13, wa v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa v 12 1`] = `
+{
+  "_cmd": "de b 13, wa v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, wa v 13 1`] = `
+{
+  "_cmd": "de b 13, wa v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, wa v 14 1`] = `
+{
+  "_cmd": "de b 13, wa v 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, wa v 15 1`] = `
+{
+  "_cmd": "de b 13, wa v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, wa w 1 1`] = `
+{
+  "_cmd": "de b 13, wa w 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b 13, wa w 2 1`] = `
+{
+  "_cmd": "de b 13, wa w 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b 13, wa w 3 1`] = `
+{
+  "_cmd": "de b 13, wa w 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa w 4 1`] = `
+{
+  "_cmd": "de b 13, wa w 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b 13, wa w 5 1`] = `
+{
+  "_cmd": "de b 13, wa w 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa w 6 1`] = `
+{
+  "_cmd": "de b 13, wa w 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, wa w 7 1`] = `
+{
+  "_cmd": "de b 13, wa w 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa w 8 1`] = `
+{
+  "_cmd": "de b 13, wa w 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b 13, wa w 9 1`] = `
+{
+  "_cmd": "de b 13, wa w 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa w 10 1`] = `
+{
+  "_cmd": "de b 13, wa w 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, wa w v 1 1`] = `
+{
+  "_cmd": "de b 13, wa w v 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b 13, wa w v 2 1`] = `
+{
+  "_cmd": "de b 13, wa w v 2",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b 13, wa w v 3 1`] = `
+{
+  "_cmd": "de b 13, wa w v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b 13, wa w v 4 1`] = `
+{
+  "_cmd": "de b 13, wa w v 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b 13, wa w v 5 1`] = `
+{
+  "_cmd": "de b 13, wa w v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 13, wa w v 6 1`] = `
+{
+  "_cmd": "de b 13, wa w v 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 13, wa w v 7 1`] = `
+{
+  "_cmd": "de b 13, wa w v 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b 13, wa w v 8 1`] = `
+{
+  "_cmd": "de b 13, wa w v 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b 13, wa w v 9 1`] = `
+{
+  "_cmd": "de b 13, wa w v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 13, wa w v 10 1`] = `
+{
+  "_cmd": "de b 13, wa w v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 13, wa w v 11 1`] = `
+{
+  "_cmd": "de b 13, wa w v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b 13, wa w v 12 1`] = `
+{
+  "_cmd": "de b 13, wa w v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b 13, wa w v 13 1`] = `
+{
+  "_cmd": "de b 13, wa w v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b 13, wa w v 14 1`] = `
+{
+  "_cmd": "de b 13, wa w v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b 13, wa w v 15 1`] = `
+{
+  "_cmd": "de b 13, wa w v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b 14, wa d 1 1`] = `
+{
+  "_cmd": "de b 14, wa d 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, wa d 2 1`] = `
+{
+  "_cmd": "de b 14, wa d 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, wa d 3 1`] = `
+{
+  "_cmd": "de b 14, wa d 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, wa d 4 1`] = `
+{
+  "_cmd": "de b 14, wa d 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa d 5 1`] = `
+{
+  "_cmd": "de b 14, wa d 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa d 6 1`] = `
+{
+  "_cmd": "de b 14, wa d 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, wa d 7 1`] = `
+{
+  "_cmd": "de b 14, wa d 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa d 8 1`] = `
+{
+  "_cmd": "de b 14, wa d 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, wa d 9 1`] = `
+{
+  "_cmd": "de b 14, wa d 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa d 10 1`] = `
+{
+  "_cmd": "de b 14, wa d 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, wa d v 1 1`] = `
+{
+  "_cmd": "de b 14, wa d v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, wa d v 2 1`] = `
+{
+  "_cmd": "de b 14, wa d v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, wa d v 3 1`] = `
+{
+  "_cmd": "de b 14, wa d v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, wa d v 4 1`] = `
+{
+  "_cmd": "de b 14, wa d v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa d v 5 1`] = `
+{
+  "_cmd": "de b 14, wa d v 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, wa d v 6 1`] = `
+{
+  "_cmd": "de b 14, wa d v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa d v 7 1`] = `
+{
+  "_cmd": "de b 14, wa d v 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa d v 8 1`] = `
+{
+  "_cmd": "de b 14, wa d v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, wa d v 9 1`] = `
+{
+  "_cmd": "de b 14, wa d v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, wa d v 10 1`] = `
+{
+  "_cmd": "de b 14, wa d v 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa d v 11 1`] = `
+{
+  "_cmd": "de b 14, wa d v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, wa d v 12 1`] = `
+{
+  "_cmd": "de b 14, wa d v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, wa d v 13 1`] = `
+{
+  "_cmd": "de b 14, wa d v 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, wa d v 14 1`] = `
+{
+  "_cmd": "de b 14, wa d v 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, wa d v 15 1`] = `
+{
+  "_cmd": "de b 14, wa d v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, wa p 1 1`] = `
+{
+  "_cmd": "de b 14, wa p 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, wa p 2 1`] = `
+{
+  "_cmd": "de b 14, wa p 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, wa p 3 1`] = `
+{
+  "_cmd": "de b 14, wa p 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, wa p 4 1`] = `
+{
+  "_cmd": "de b 14, wa p 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, wa p 5 1`] = `
+{
+  "_cmd": "de b 14, wa p 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa p 6 1`] = `
+{
+  "_cmd": "de b 14, wa p 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa p 7 1`] = `
+{
+  "_cmd": "de b 14, wa p 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, wa p 8 1`] = `
+{
+  "_cmd": "de b 14, wa p 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa p 9 1`] = `
+{
+  "_cmd": "de b 14, wa p 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, wa p 10 1`] = `
+{
+  "_cmd": "de b 14, wa p 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa p v 1 1`] = `
+{
+  "_cmd": "de b 14, wa p v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, wa p v 2 1`] = `
+{
+  "_cmd": "de b 14, wa p v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, wa p v 3 1`] = `
+{
+  "_cmd": "de b 14, wa p v 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, wa p v 4 1`] = `
+{
+  "_cmd": "de b 14, wa p v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, wa p v 5 1`] = `
+{
+  "_cmd": "de b 14, wa p v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa p v 6 1`] = `
+{
+  "_cmd": "de b 14, wa p v 6",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, wa p v 7 1`] = `
+{
+  "_cmd": "de b 14, wa p v 7",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa p v 8 1`] = `
+{
+  "_cmd": "de b 14, wa p v 8",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa p v 9 1`] = `
+{
+  "_cmd": "de b 14, wa p v 9",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, wa p v 10 1`] = `
+{
+  "_cmd": "de b 14, wa p v 10",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, wa p v 11 1`] = `
+{
+  "_cmd": "de b 14, wa p v 11",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa p v 12 1`] = `
+{
+  "_cmd": "de b 14, wa p v 12",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, wa p v 13 1`] = `
+{
+  "_cmd": "de b 14, wa p v 13",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, wa p v 14 1`] = `
+{
+  "_cmd": "de b 14, wa p v 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, wa p v 15 1`] = `
+{
+  "_cmd": "de b 14, wa p v 15",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, wa v 1 1`] = `
+{
+  "_cmd": "de b 14, wa v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b 14, wa v 2 1`] = `
+{
+  "_cmd": "de b 14, wa v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, wa v 3 1`] = `
+{
+  "_cmd": "de b 14, wa v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, wa v 4 1`] = `
+{
+  "_cmd": "de b 14, wa v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, wa v 5 1`] = `
+{
+  "_cmd": "de b 14, wa v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa v 6 1`] = `
+{
+  "_cmd": "de b 14, wa v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa v 7 1`] = `
+{
+  "_cmd": "de b 14, wa v 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, wa v 8 1`] = `
+{
+  "_cmd": "de b 14, wa v 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa v 9 1`] = `
+{
+  "_cmd": "de b 14, wa v 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, wa v 10 1`] = `
+{
+  "_cmd": "de b 14, wa v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa v 11 1`] = `
+{
+  "_cmd": "de b 14, wa v 11",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, wa v 12 1`] = `
+{
+  "_cmd": "de b 14, wa v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, wa v 13 1`] = `
+{
+  "_cmd": "de b 14, wa v 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, wa v 14 1`] = `
+{
+  "_cmd": "de b 14, wa v 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, wa v 15 1`] = `
+{
+  "_cmd": "de b 14, wa v 15",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, wa w 1 1`] = `
+{
+  "_cmd": "de b 14, wa w 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b 14, wa w 2 1`] = `
+{
+  "_cmd": "de b 14, wa w 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b 14, wa w 3 1`] = `
+{
+  "_cmd": "de b 14, wa w 3",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, wa w 4 1`] = `
+{
+  "_cmd": "de b 14, wa w 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b 14, wa w 5 1`] = `
+{
+  "_cmd": "de b 14, wa w 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, wa w 6 1`] = `
+{
+  "_cmd": "de b 14, wa w 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa w 7 1`] = `
+{
+  "_cmd": "de b 14, wa w 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, wa w 8 1`] = `
+{
+  "_cmd": "de b 14, wa w 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa w 9 1`] = `
+{
+  "_cmd": "de b 14, wa w 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b 14, wa w 10 1`] = `
+{
+  "_cmd": "de b 14, wa w 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, wa w v 1 1`] = `
+{
+  "_cmd": "de b 14, wa w v 1",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b 14, wa w v 2 1`] = `
+{
+  "_cmd": "de b 14, wa w v 2",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b 14, wa w v 3 1`] = `
+{
+  "_cmd": "de b 14, wa w v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b 14, wa w v 4 1`] = `
+{
+  "_cmd": "de b 14, wa w v 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b 14, wa w v 5 1`] = `
+{
+  "_cmd": "de b 14, wa w v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 14, wa w v 6 1`] = `
+{
+  "_cmd": "de b 14, wa w v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 14, wa w v 7 1`] = `
+{
+  "_cmd": "de b 14, wa w v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b 14, wa w v 8 1`] = `
+{
+  "_cmd": "de b 14, wa w v 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b 14, wa w v 9 1`] = `
+{
+  "_cmd": "de b 14, wa w v 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b 14, wa w v 10 1`] = `
+{
+  "_cmd": "de b 14, wa w v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b 14, wa w v 11 1`] = `
+{
+  "_cmd": "de b 14, wa w v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b 14, wa w v 12 1`] = `
+{
+  "_cmd": "de b 14, wa w v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b 14, wa w v 13 1`] = `
+{
+  "_cmd": "de b 14, wa w v 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b 14, wa w v 14 1`] = `
+{
+  "_cmd": "de b 14, wa w v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b 14, wa w v 15 1`] = `
+{
+  "_cmd": "de b 14, wa w v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b 15, wa d 1 1`] = `
+{
+  "_cmd": "de b 15, wa d 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, wa d 2 1`] = `
+{
+  "_cmd": "de b 15, wa d 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, wa d 3 1`] = `
+{
+  "_cmd": "de b 15, wa d 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, wa d 4 1`] = `
+{
+  "_cmd": "de b 15, wa d 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa d 5 1`] = `
+{
+  "_cmd": "de b 15, wa d 5",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa d 6 1`] = `
+{
+  "_cmd": "de b 15, wa d 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa d 7 1`] = `
+{
+  "_cmd": "de b 15, wa d 7",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa d 8 1`] = `
+{
+  "_cmd": "de b 15, wa d 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa d 9 1`] = `
+{
+  "_cmd": "de b 15, wa d 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa d 10 1`] = `
+{
+  "_cmd": "de b 15, wa d 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, wa d v 1 1`] = `
+{
+  "_cmd": "de b 15, wa d v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, wa d v 2 1`] = `
+{
+  "_cmd": "de b 15, wa d v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, wa d v 3 1`] = `
+{
+  "_cmd": "de b 15, wa d v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, wa d v 4 1`] = `
+{
+  "_cmd": "de b 15, wa d v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa d v 5 1`] = `
+{
+  "_cmd": "de b 15, wa d v 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, wa d v 6 1`] = `
+{
+  "_cmd": "de b 15, wa d v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa d v 7 1`] = `
+{
+  "_cmd": "de b 15, wa d v 7",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa d v 8 1`] = `
+{
+  "_cmd": "de b 15, wa d v 8",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa d v 9 1`] = `
+{
+  "_cmd": "de b 15, wa d v 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, wa d v 10 1`] = `
+{
+  "_cmd": "de b 15, wa d v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa d v 11 1`] = `
+{
+  "_cmd": "de b 15, wa d v 11",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, wa d v 12 1`] = `
+{
+  "_cmd": "de b 15, wa d v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, wa d v 13 1`] = `
+{
+  "_cmd": "de b 15, wa d v 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, wa d v 14 1`] = `
+{
+  "_cmd": "de b 15, wa d v 14",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, wa d v 15 1`] = `
+{
+  "_cmd": "de b 15, wa d v 15",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, wa p 1 1`] = `
+{
+  "_cmd": "de b 15, wa p 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, wa p 2 1`] = `
+{
+  "_cmd": "de b 15, wa p 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, wa p 3 1`] = `
+{
+  "_cmd": "de b 15, wa p 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, wa p 4 1`] = `
+{
+  "_cmd": "de b 15, wa p 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, wa p 5 1`] = `
+{
+  "_cmd": "de b 15, wa p 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa p 6 1`] = `
+{
+  "_cmd": "de b 15, wa p 6",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa p 7 1`] = `
+{
+  "_cmd": "de b 15, wa p 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa p 8 1`] = `
+{
+  "_cmd": "de b 15, wa p 8",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa p 9 1`] = `
+{
+  "_cmd": "de b 15, wa p 9",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa p 10 1`] = `
+{
+  "_cmd": "de b 15, wa p 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa p v 1 1`] = `
+{
+  "_cmd": "de b 15, wa p v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, wa p v 2 1`] = `
+{
+  "_cmd": "de b 15, wa p v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, wa p v 3 1`] = `
+{
+  "_cmd": "de b 15, wa p v 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, wa p v 4 1`] = `
+{
+  "_cmd": "de b 15, wa p v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, wa p v 5 1`] = `
+{
+  "_cmd": "de b 15, wa p v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa p v 6 1`] = `
+{
+  "_cmd": "de b 15, wa p v 6",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, wa p v 7 1`] = `
+{
+  "_cmd": "de b 15, wa p v 7",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa p v 8 1`] = `
+{
+  "_cmd": "de b 15, wa p v 8",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa p v 9 1`] = `
+{
+  "_cmd": "de b 15, wa p v 9",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa p v 10 1`] = `
+{
+  "_cmd": "de b 15, wa p v 10",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, wa p v 11 1`] = `
+{
+  "_cmd": "de b 15, wa p v 11",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa p v 12 1`] = `
+{
+  "_cmd": "de b 15, wa p v 12",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, wa p v 13 1`] = `
+{
+  "_cmd": "de b 15, wa p v 13",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, wa p v 14 1`] = `
+{
+  "_cmd": "de b 15, wa p v 14",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, wa p v 15 1`] = `
+{
+  "_cmd": "de b 15, wa p v 15",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, wa v 1 1`] = `
+{
+  "_cmd": "de b 15, wa v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b 15, wa v 2 1`] = `
+{
+  "_cmd": "de b 15, wa v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, wa v 3 1`] = `
+{
+  "_cmd": "de b 15, wa v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, wa v 4 1`] = `
+{
+  "_cmd": "de b 15, wa v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, wa v 5 1`] = `
+{
+  "_cmd": "de b 15, wa v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa v 6 1`] = `
+{
+  "_cmd": "de b 15, wa v 6",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa v 7 1`] = `
+{
+  "_cmd": "de b 15, wa v 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa v 8 1`] = `
+{
+  "_cmd": "de b 15, wa v 8",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa v 9 1`] = `
+{
+  "_cmd": "de b 15, wa v 9",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa v 10 1`] = `
+{
+  "_cmd": "de b 15, wa v 10",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, wa v 11 1`] = `
+{
+  "_cmd": "de b 15, wa v 11",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, wa v 12 1`] = `
+{
+  "_cmd": "de b 15, wa v 12",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, wa v 13 1`] = `
+{
+  "_cmd": "de b 15, wa v 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, wa v 14 1`] = `
+{
+  "_cmd": "de b 15, wa v 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, wa v 15 1`] = `
+{
+  "_cmd": "de b 15, wa v 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, wa w 1 1`] = `
+{
+  "_cmd": "de b 15, wa w 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b 15, wa w 2 1`] = `
+{
+  "_cmd": "de b 15, wa w 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b 15, wa w 3 1`] = `
+{
+  "_cmd": "de b 15, wa w 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa w 4 1`] = `
+{
+  "_cmd": "de b 15, wa w 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b 15, wa w 5 1`] = `
+{
+  "_cmd": "de b 15, wa w 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa w 6 1`] = `
+{
+  "_cmd": "de b 15, wa w 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa w 7 1`] = `
+{
+  "_cmd": "de b 15, wa w 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, wa w 8 1`] = `
+{
+  "_cmd": "de b 15, wa w 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa w 9 1`] = `
+{
+  "_cmd": "de b 15, wa w 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b 15, wa w 10 1`] = `
+{
+  "_cmd": "de b 15, wa w 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, wa w v 1 1`] = `
+{
+  "_cmd": "de b 15, wa w v 1",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b 15, wa w v 2 1`] = `
+{
+  "_cmd": "de b 15, wa w v 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b 15, wa w v 3 1`] = `
+{
+  "_cmd": "de b 15, wa w v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b 15, wa w v 4 1`] = `
+{
+  "_cmd": "de b 15, wa w v 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b 15, wa w v 5 1`] = `
+{
+  "_cmd": "de b 15, wa w v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b 15, wa w v 6 1`] = `
+{
+  "_cmd": "de b 15, wa w v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b 15, wa w v 7 1`] = `
+{
+  "_cmd": "de b 15, wa w v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b 15, wa w v 8 1`] = `
+{
+  "_cmd": "de b 15, wa w v 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b 15, wa w v 9 1`] = `
+{
+  "_cmd": "de b 15, wa w v 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b 15, wa w v 10 1`] = `
+{
+  "_cmd": "de b 15, wa w v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b 15, wa w v 11 1`] = `
+{
+  "_cmd": "de b 15, wa w v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b 15, wa w v 12 1`] = `
+{
+  "_cmd": "de b 15, wa w v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b 15, wa w v 13 1`] = `
+{
+  "_cmd": "de b 15, wa w v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b 15, wa w v 14 1`] = `
+{
+  "_cmd": "de b 15, wa w v 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b 15, wa w v 15 1`] = `
+{
+  "_cmd": "de b 15, wa w v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, wa d 1 1`] = `
+{
+  "_cmd": "de b v 1, wa d 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, wa d 2 1`] = `
+{
+  "_cmd": "de b v 1, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, wa d 3 1`] = `
+{
+  "_cmd": "de b v 1, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa d 4 1`] = `
+{
+  "_cmd": "de b v 1, wa d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa d 5 1`] = `
+{
+  "_cmd": "de b v 1, wa d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa d 6 1`] = `
+{
+  "_cmd": "de b v 1, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa d 7 1`] = `
+{
+  "_cmd": "de b v 1, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa d 8 1`] = `
+{
+  "_cmd": "de b v 1, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa d 9 1`] = `
+{
+  "_cmd": "de b v 1, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa d 10 1`] = `
+{
+  "_cmd": "de b v 1, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 1, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, wa p 1 1`] = `
+{
+  "_cmd": "de b v 1, wa p 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, wa p 2 1`] = `
+{
+  "_cmd": "de b v 1, wa p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, wa p 3 1`] = `
+{
+  "_cmd": "de b v 1, wa p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa p 4 1`] = `
+{
+  "_cmd": "de b v 1, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa p 5 1`] = `
+{
+  "_cmd": "de b v 1, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa p 6 1`] = `
+{
+  "_cmd": "de b v 1, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa p 7 1`] = `
+{
+  "_cmd": "de b v 1, wa p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa p 8 1`] = `
+{
+  "_cmd": "de b v 1, wa p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa p 9 1`] = `
+{
+  "_cmd": "de b v 1, wa p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa p 10 1`] = `
+{
+  "_cmd": "de b v 1, wa p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 1, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 1, wa p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, wa v 1 1`] = `
+{
+  "_cmd": "de b v 1, wa v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 1, wa v 2 1`] = `
+{
+  "_cmd": "de b v 1, wa v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 1, wa v 3 1`] = `
+{
+  "_cmd": "de b v 1, wa v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa v 4 1`] = `
+{
+  "_cmd": "de b v 1, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa v 5 1`] = `
+{
+  "_cmd": "de b v 1, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa v 6 1`] = `
+{
+  "_cmd": "de b v 1, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa v 7 1`] = `
+{
+  "_cmd": "de b v 1, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa v 8 1`] = `
+{
+  "_cmd": "de b v 1, wa v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa v 9 1`] = `
+{
+  "_cmd": "de b v 1, wa v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa v 10 1`] = `
+{
+  "_cmd": "de b v 1, wa v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa v 11 1`] = `
+{
+  "_cmd": "de b v 1, wa v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, wa v 12 1`] = `
+{
+  "_cmd": "de b v 1, wa v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, wa v 13 1`] = `
+{
+  "_cmd": "de b v 1, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, wa v 14 1`] = `
+{
+  "_cmd": "de b v 1, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, wa v 15 1`] = `
+{
+  "_cmd": "de b v 1, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 1, wa w 1 1`] = `
+{
+  "_cmd": "de b v 1, wa w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, wa w 2 1`] = `
+{
+  "_cmd": "de b v 1, wa w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa w 3 1`] = `
+{
+  "_cmd": "de b v 1, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa w 4 1`] = `
+{
+  "_cmd": "de b v 1, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa w 5 1`] = `
+{
+  "_cmd": "de b v 1, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa w 6 1`] = `
+{
+  "_cmd": "de b v 1, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa w 7 1`] = `
+{
+  "_cmd": "de b v 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa w 8 1`] = `
+{
+  "_cmd": "de b v 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa w 9 1`] = `
+{
+  "_cmd": "de b v 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa w 10 1`] = `
+{
+  "_cmd": "de b v 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 1, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 1, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 1, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 1, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 1, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 1, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 1, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 1, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 1, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 1, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 1, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 1, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 1, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 1, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, wa d 1 1`] = `
+{
+  "_cmd": "de b v 2, wa d 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 2, wa d 2 1`] = `
+{
+  "_cmd": "de b v 2, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa d 3 1`] = `
+{
+  "_cmd": "de b v 2, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, wa d 4 1`] = `
+{
+  "_cmd": "de b v 2, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa d 5 1`] = `
+{
+  "_cmd": "de b v 2, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa d 6 1`] = `
+{
+  "_cmd": "de b v 2, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa d 7 1`] = `
+{
+  "_cmd": "de b v 2, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa d 8 1`] = `
+{
+  "_cmd": "de b v 2, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa d 9 1`] = `
+{
+  "_cmd": "de b v 2, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa d 10 1`] = `
+{
+  "_cmd": "de b v 2, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 2, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 2, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, wa p 1 1`] = `
+{
+  "_cmd": "de b v 2, wa p 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 2, wa p 2 1`] = `
+{
+  "_cmd": "de b v 2, wa p 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, wa p 3 1`] = `
+{
+  "_cmd": "de b v 2, wa p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa p 4 1`] = `
+{
+  "_cmd": "de b v 2, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa p 5 1`] = `
+{
+  "_cmd": "de b v 2, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa p 6 1`] = `
+{
+  "_cmd": "de b v 2, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa p 7 1`] = `
+{
+  "_cmd": "de b v 2, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa p 8 1`] = `
+{
+  "_cmd": "de b v 2, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa p 9 1`] = `
+{
+  "_cmd": "de b v 2, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa p 10 1`] = `
+{
+  "_cmd": "de b v 2, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 2, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 2, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 2, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, wa v 1 1`] = `
+{
+  "_cmd": "de b v 2, wa v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 2, wa v 2 1`] = `
+{
+  "_cmd": "de b v 2, wa v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, wa v 3 1`] = `
+{
+  "_cmd": "de b v 2, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa v 4 1`] = `
+{
+  "_cmd": "de b v 2, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa v 5 1`] = `
+{
+  "_cmd": "de b v 2, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa v 6 1`] = `
+{
+  "_cmd": "de b v 2, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa v 7 1`] = `
+{
+  "_cmd": "de b v 2, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa v 8 1`] = `
+{
+  "_cmd": "de b v 2, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa v 9 1`] = `
+{
+  "_cmd": "de b v 2, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa v 10 1`] = `
+{
+  "_cmd": "de b v 2, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa v 11 1`] = `
+{
+  "_cmd": "de b v 2, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa v 12 1`] = `
+{
+  "_cmd": "de b v 2, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, wa v 13 1`] = `
+{
+  "_cmd": "de b v 2, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, wa v 14 1`] = `
+{
+  "_cmd": "de b v 2, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, wa v 15 1`] = `
+{
+  "_cmd": "de b v 2, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 2, wa w 1 1`] = `
+{
+  "_cmd": "de b v 2, wa w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, wa w 2 1`] = `
+{
+  "_cmd": "de b v 2, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa w 3 1`] = `
+{
+  "_cmd": "de b v 2, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 2, wa w 4 1`] = `
+{
+  "_cmd": "de b v 2, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa w 5 1`] = `
+{
+  "_cmd": "de b v 2, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa w 6 1`] = `
+{
+  "_cmd": "de b v 2, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa w 7 1`] = `
+{
+  "_cmd": "de b v 2, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa w 8 1`] = `
+{
+  "_cmd": "de b v 2, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa w 9 1`] = `
+{
+  "_cmd": "de b v 2, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa w 10 1`] = `
+{
+  "_cmd": "de b v 2, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 2, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 2, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 2, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 2, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 2, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 2, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 2, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 2, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 2, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 2, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 2, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 2, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 2, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 2, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 2, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, wa d 1 1`] = `
+{
+  "_cmd": "de b v 3, wa d 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 3, wa d 2 1`] = `
+{
+  "_cmd": "de b v 3, wa d 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, wa d 3 1`] = `
+{
+  "_cmd": "de b v 3, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, wa d 4 1`] = `
+{
+  "_cmd": "de b v 3, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa d 5 1`] = `
+{
+  "_cmd": "de b v 3, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, wa d 6 1`] = `
+{
+  "_cmd": "de b v 3, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa d 7 1`] = `
+{
+  "_cmd": "de b v 3, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa d 8 1`] = `
+{
+  "_cmd": "de b v 3, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa d 9 1`] = `
+{
+  "_cmd": "de b v 3, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa d 10 1`] = `
+{
+  "_cmd": "de b v 3, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 3, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 3, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 3, wa p 1 1`] = `
+{
+  "_cmd": "de b v 3, wa p 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 3, wa p 2 1`] = `
+{
+  "_cmd": "de b v 3, wa p 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, wa p 3 1`] = `
+{
+  "_cmd": "de b v 3, wa p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa p 4 1`] = `
+{
+  "_cmd": "de b v 3, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, wa p 5 1`] = `
+{
+  "_cmd": "de b v 3, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa p 6 1`] = `
+{
+  "_cmd": "de b v 3, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa p 7 1`] = `
+{
+  "_cmd": "de b v 3, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa p 8 1`] = `
+{
+  "_cmd": "de b v 3, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa p 9 1`] = `
+{
+  "_cmd": "de b v 3, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa p 10 1`] = `
+{
+  "_cmd": "de b v 3, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 3, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 3, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 3, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, wa v 1 1`] = `
+{
+  "_cmd": "de b v 3, wa v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 3, wa v 2 1`] = `
+{
+  "_cmd": "de b v 3, wa v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, wa v 3 1`] = `
+{
+  "_cmd": "de b v 3, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa v 4 1`] = `
+{
+  "_cmd": "de b v 3, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, wa v 5 1`] = `
+{
+  "_cmd": "de b v 3, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa v 6 1`] = `
+{
+  "_cmd": "de b v 3, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa v 7 1`] = `
+{
+  "_cmd": "de b v 3, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa v 8 1`] = `
+{
+  "_cmd": "de b v 3, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa v 9 1`] = `
+{
+  "_cmd": "de b v 3, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa v 10 1`] = `
+{
+  "_cmd": "de b v 3, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa v 11 1`] = `
+{
+  "_cmd": "de b v 3, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa v 12 1`] = `
+{
+  "_cmd": "de b v 3, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, wa v 13 1`] = `
+{
+  "_cmd": "de b v 3, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, wa v 14 1`] = `
+{
+  "_cmd": "de b v 3, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, wa v 15 1`] = `
+{
+  "_cmd": "de b v 3, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, wa w 1 1`] = `
+{
+  "_cmd": "de b v 3, wa w 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 3, wa w 2 1`] = `
+{
+  "_cmd": "de b v 3, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa w 3 1`] = `
+{
+  "_cmd": "de b v 3, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, wa w 4 1`] = `
+{
+  "_cmd": "de b v 3, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, wa w 5 1`] = `
+{
+  "_cmd": "de b v 3, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 3, wa w 6 1`] = `
+{
+  "_cmd": "de b v 3, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa w 7 1`] = `
+{
+  "_cmd": "de b v 3, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa w 8 1`] = `
+{
+  "_cmd": "de b v 3, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa w 9 1`] = `
+{
+  "_cmd": "de b v 3, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa w 10 1`] = `
+{
+  "_cmd": "de b v 3, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 3, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 3, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 3, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 3, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 3, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 3, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 3, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 3, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 3, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 3, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 3, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 3, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 3, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 3, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 3, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 4, wa d 1 1`] = `
+{
+  "_cmd": "de b v 4, wa d 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 4, wa d 2 1`] = `
+{
+  "_cmd": "de b v 4, wa d 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, wa d 3 1`] = `
+{
+  "_cmd": "de b v 4, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, wa d 4 1`] = `
+{
+  "_cmd": "de b v 4, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa d 5 1`] = `
+{
+  "_cmd": "de b v 4, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, wa d 6 1`] = `
+{
+  "_cmd": "de b v 4, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa d 7 1`] = `
+{
+  "_cmd": "de b v 4, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, wa d 8 1`] = `
+{
+  "_cmd": "de b v 4, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa d 9 1`] = `
+{
+  "_cmd": "de b v 4, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa d 10 1`] = `
+{
+  "_cmd": "de b v 4, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 4, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 4, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, wa p 1 1`] = `
+{
+  "_cmd": "de b v 4, wa p 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, wa p 2 1`] = `
+{
+  "_cmd": "de b v 4, wa p 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, wa p 3 1`] = `
+{
+  "_cmd": "de b v 4, wa p 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, wa p 4 1`] = `
+{
+  "_cmd": "de b v 4, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa p 5 1`] = `
+{
+  "_cmd": "de b v 4, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa p 6 1`] = `
+{
+  "_cmd": "de b v 4, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, wa p 7 1`] = `
+{
+  "_cmd": "de b v 4, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa p 8 1`] = `
+{
+  "_cmd": "de b v 4, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa p 9 1`] = `
+{
+  "_cmd": "de b v 4, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa p 10 1`] = `
+{
+  "_cmd": "de b v 4, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 4, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 4, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, wa v 1 1`] = `
+{
+  "_cmd": "de b v 4, wa v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 4, wa v 2 1`] = `
+{
+  "_cmd": "de b v 4, wa v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 4, wa v 3 1`] = `
+{
+  "_cmd": "de b v 4, wa v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 4, wa v 4 1`] = `
+{
+  "_cmd": "de b v 4, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa v 5 1`] = `
+{
+  "_cmd": "de b v 4, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa v 6 1`] = `
+{
+  "_cmd": "de b v 4, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, wa v 7 1`] = `
+{
+  "_cmd": "de b v 4, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa v 8 1`] = `
+{
+  "_cmd": "de b v 4, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa v 9 1`] = `
+{
+  "_cmd": "de b v 4, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa v 10 1`] = `
+{
+  "_cmd": "de b v 4, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa v 11 1`] = `
+{
+  "_cmd": "de b v 4, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, wa v 12 1`] = `
+{
+  "_cmd": "de b v 4, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, wa v 13 1`] = `
+{
+  "_cmd": "de b v 4, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, wa v 14 1`] = `
+{
+  "_cmd": "de b v 4, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, wa v 15 1`] = `
+{
+  "_cmd": "de b v 4, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, wa w 1 1`] = `
+{
+  "_cmd": "de b v 4, wa w 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, wa w 2 1`] = `
+{
+  "_cmd": "de b v 4, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, wa w 3 1`] = `
+{
+  "_cmd": "de b v 4, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa w 4 1`] = `
+{
+  "_cmd": "de b v 4, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa w 5 1`] = `
+{
+  "_cmd": "de b v 4, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa w 6 1`] = `
+{
+  "_cmd": "de b v 4, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, wa w 7 1`] = `
+{
+  "_cmd": "de b v 4, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 4, wa w 8 1`] = `
+{
+  "_cmd": "de b v 4, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa w 9 1`] = `
+{
+  "_cmd": "de b v 4, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa w 10 1`] = `
+{
+  "_cmd": "de b v 4, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 4, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 4, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 4, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 4, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 4, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 4, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 4, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 4, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 4, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 4, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 4, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 4, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 4, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 4, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 4, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 5, wa d 1 1`] = `
+{
+  "_cmd": "de b v 5, wa d 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 5, wa d 2 1`] = `
+{
+  "_cmd": "de b v 5, wa d 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, wa d 3 1`] = `
+{
+  "_cmd": "de b v 5, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, wa d 4 1`] = `
+{
+  "_cmd": "de b v 5, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, wa d 5 1`] = `
+{
+  "_cmd": "de b v 5, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa d 6 1`] = `
+{
+  "_cmd": "de b v 5, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, wa d 7 1`] = `
+{
+  "_cmd": "de b v 5, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa d 8 1`] = `
+{
+  "_cmd": "de b v 5, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa d 9 1`] = `
+{
+  "_cmd": "de b v 5, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, wa d 10 1`] = `
+{
+  "_cmd": "de b v 5, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 5, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 5, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, wa p 1 1`] = `
+{
+  "_cmd": "de b v 5, wa p 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, wa p 2 1`] = `
+{
+  "_cmd": "de b v 5, wa p 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, wa p 3 1`] = `
+{
+  "_cmd": "de b v 5, wa p 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, wa p 4 1`] = `
+{
+  "_cmd": "de b v 5, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, wa p 5 1`] = `
+{
+  "_cmd": "de b v 5, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa p 6 1`] = `
+{
+  "_cmd": "de b v 5, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa p 7 1`] = `
+{
+  "_cmd": "de b v 5, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, wa p 8 1`] = `
+{
+  "_cmd": "de b v 5, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa p 9 1`] = `
+{
+  "_cmd": "de b v 5, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa p 10 1`] = `
+{
+  "_cmd": "de b v 5, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 5, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 5, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, wa v 1 1`] = `
+{
+  "_cmd": "de b v 5, wa v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 5, wa v 2 1`] = `
+{
+  "_cmd": "de b v 5, wa v 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, wa v 3 1`] = `
+{
+  "_cmd": "de b v 5, wa v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, wa v 4 1`] = `
+{
+  "_cmd": "de b v 5, wa v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, wa v 5 1`] = `
+{
+  "_cmd": "de b v 5, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa v 6 1`] = `
+{
+  "_cmd": "de b v 5, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa v 7 1`] = `
+{
+  "_cmd": "de b v 5, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, wa v 8 1`] = `
+{
+  "_cmd": "de b v 5, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa v 9 1`] = `
+{
+  "_cmd": "de b v 5, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa v 10 1`] = `
+{
+  "_cmd": "de b v 5, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa v 11 1`] = `
+{
+  "_cmd": "de b v 5, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, wa v 12 1`] = `
+{
+  "_cmd": "de b v 5, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, wa v 13 1`] = `
+{
+  "_cmd": "de b v 5, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, wa v 14 1`] = `
+{
+  "_cmd": "de b v 5, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, wa v 15 1`] = `
+{
+  "_cmd": "de b v 5, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, wa w 1 1`] = `
+{
+  "_cmd": "de b v 5, wa w 1",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 5, wa w 2 1`] = `
+{
+  "_cmd": "de b v 5, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 5, wa w 3 1`] = `
+{
+  "_cmd": "de b v 5, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, wa w 4 1`] = `
+{
+  "_cmd": "de b v 5, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa w 5 1`] = `
+{
+  "_cmd": "de b v 5, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa w 6 1`] = `
+{
+  "_cmd": "de b v 5, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa w 7 1`] = `
+{
+  "_cmd": "de b v 5, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa w 8 1`] = `
+{
+  "_cmd": "de b v 5, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 5, wa w 9 1`] = `
+{
+  "_cmd": "de b v 5, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa w 10 1`] = `
+{
+  "_cmd": "de b v 5, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 5, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 5, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 5, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 5, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 5, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 5, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 5, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 5, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 5, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 5, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 5, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 5, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 5, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 5, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 5, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 6, wa d 1 1`] = `
+{
+  "_cmd": "de b v 6, wa d 1",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 6, wa d 2 1`] = `
+{
+  "_cmd": "de b v 6, wa d 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, wa d 3 1`] = `
+{
+  "_cmd": "de b v 6, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, wa d 4 1`] = `
+{
+  "_cmd": "de b v 6, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa d 5 1`] = `
+{
+  "_cmd": "de b v 6, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, wa d 6 1`] = `
+{
+  "_cmd": "de b v 6, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa d 7 1`] = `
+{
+  "_cmd": "de b v 6, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, wa d 8 1`] = `
+{
+  "_cmd": "de b v 6, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa d 9 1`] = `
+{
+  "_cmd": "de b v 6, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa d 10 1`] = `
+{
+  "_cmd": "de b v 6, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 6, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, wa p 1 1`] = `
+{
+  "_cmd": "de b v 6, wa p 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, wa p 2 1`] = `
+{
+  "_cmd": "de b v 6, wa p 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, wa p 3 1`] = `
+{
+  "_cmd": "de b v 6, wa p 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, wa p 4 1`] = `
+{
+  "_cmd": "de b v 6, wa p 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, wa p 5 1`] = `
+{
+  "_cmd": "de b v 6, wa p 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa p 6 1`] = `
+{
+  "_cmd": "de b v 6, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa p 7 1`] = `
+{
+  "_cmd": "de b v 6, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa p 8 1`] = `
+{
+  "_cmd": "de b v 6, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, wa p 9 1`] = `
+{
+  "_cmd": "de b v 6, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa p 10 1`] = `
+{
+  "_cmd": "de b v 6, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 6, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 6, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 6, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, wa v 1 1`] = `
+{
+  "_cmd": "de b v 6, wa v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 6, wa v 2 1`] = `
+{
+  "_cmd": "de b v 6, wa v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, wa v 3 1`] = `
+{
+  "_cmd": "de b v 6, wa v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, wa v 4 1`] = `
+{
+  "_cmd": "de b v 6, wa v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, wa v 5 1`] = `
+{
+  "_cmd": "de b v 6, wa v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa v 6 1`] = `
+{
+  "_cmd": "de b v 6, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa v 7 1`] = `
+{
+  "_cmd": "de b v 6, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa v 8 1`] = `
+{
+  "_cmd": "de b v 6, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, wa v 9 1`] = `
+{
+  "_cmd": "de b v 6, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa v 10 1`] = `
+{
+  "_cmd": "de b v 6, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa v 11 1`] = `
+{
+  "_cmd": "de b v 6, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa v 12 1`] = `
+{
+  "_cmd": "de b v 6, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, wa v 13 1`] = `
+{
+  "_cmd": "de b v 6, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, wa v 14 1`] = `
+{
+  "_cmd": "de b v 6, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, wa v 15 1`] = `
+{
+  "_cmd": "de b v 6, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, wa w 1 1`] = `
+{
+  "_cmd": "de b v 6, wa w 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 6, wa w 2 1`] = `
+{
+  "_cmd": "de b v 6, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 6, wa w 3 1`] = `
+{
+  "_cmd": "de b v 6, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa w 4 1`] = `
+{
+  "_cmd": "de b v 6, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, wa w 5 1`] = `
+{
+  "_cmd": "de b v 6, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa w 6 1`] = `
+{
+  "_cmd": "de b v 6, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa w 7 1`] = `
+{
+  "_cmd": "de b v 6, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, wa w 8 1`] = `
+{
+  "_cmd": "de b v 6, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa w 9 1`] = `
+{
+  "_cmd": "de b v 6, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa w 10 1`] = `
+{
+  "_cmd": "de b v 6, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 6, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 6, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 6, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 6, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 6, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 6, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 6, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 6, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 6, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 6, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 6, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 6, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 6, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 6, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 6, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 6, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 7, wa d 1 1`] = `
+{
+  "_cmd": "de b v 7, wa d 1",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 7, wa d 2 1`] = `
+{
+  "_cmd": "de b v 7, wa d 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, wa d 3 1`] = `
+{
+  "_cmd": "de b v 7, wa d 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa d 4 1`] = `
+{
+  "_cmd": "de b v 7, wa d 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, wa d 5 1`] = `
+{
+  "_cmd": "de b v 7, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa d 6 1`] = `
+{
+  "_cmd": "de b v 7, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, wa d 7 1`] = `
+{
+  "_cmd": "de b v 7, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa d 8 1`] = `
+{
+  "_cmd": "de b v 7, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa d 9 1`] = `
+{
+  "_cmd": "de b v 7, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, wa d 10 1`] = `
+{
+  "_cmd": "de b v 7, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 7, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, wa p 1 1`] = `
+{
+  "_cmd": "de b v 7, wa p 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, wa p 2 1`] = `
+{
+  "_cmd": "de b v 7, wa p 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, wa p 3 1`] = `
+{
+  "_cmd": "de b v 7, wa p 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, wa p 4 1`] = `
+{
+  "_cmd": "de b v 7, wa p 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa p 5 1`] = `
+{
+  "_cmd": "de b v 7, wa p 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, wa p 6 1`] = `
+{
+  "_cmd": "de b v 7, wa p 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa p 7 1`] = `
+{
+  "_cmd": "de b v 7, wa p 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa p 8 1`] = `
+{
+  "_cmd": "de b v 7, wa p 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa p 9 1`] = `
+{
+  "_cmd": "de b v 7, wa p 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa p 10 1`] = `
+{
+  "_cmd": "de b v 7, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 7, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 7, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 7, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 7, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, wa v 1 1`] = `
+{
+  "_cmd": "de b v 7, wa v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 7, wa v 2 1`] = `
+{
+  "_cmd": "de b v 7, wa v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, wa v 3 1`] = `
+{
+  "_cmd": "de b v 7, wa v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 7, wa v 4 1`] = `
+{
+  "_cmd": "de b v 7, wa v 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa v 5 1`] = `
+{
+  "_cmd": "de b v 7, wa v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, wa v 6 1`] = `
+{
+  "_cmd": "de b v 7, wa v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa v 7 1`] = `
+{
+  "_cmd": "de b v 7, wa v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa v 8 1`] = `
+{
+  "_cmd": "de b v 7, wa v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa v 9 1`] = `
+{
+  "_cmd": "de b v 7, wa v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa v 10 1`] = `
+{
+  "_cmd": "de b v 7, wa v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, wa v 11 1`] = `
+{
+  "_cmd": "de b v 7, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa v 12 1`] = `
+{
+  "_cmd": "de b v 7, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, wa v 13 1`] = `
+{
+  "_cmd": "de b v 7, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, wa v 14 1`] = `
+{
+  "_cmd": "de b v 7, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, wa v 15 1`] = `
+{
+  "_cmd": "de b v 7, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, wa w 1 1`] = `
+{
+  "_cmd": "de b v 7, wa w 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, wa w 2 1`] = `
+{
+  "_cmd": "de b v 7, wa w 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, wa w 3 1`] = `
+{
+  "_cmd": "de b v 7, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 7, wa w 4 1`] = `
+{
+  "_cmd": "de b v 7, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa w 5 1`] = `
+{
+  "_cmd": "de b v 7, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, wa w 6 1`] = `
+{
+  "_cmd": "de b v 7, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa w 7 1`] = `
+{
+  "_cmd": "de b v 7, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa w 8 1`] = `
+{
+  "_cmd": "de b v 7, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa w 9 1`] = `
+{
+  "_cmd": "de b v 7, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa w 10 1`] = `
+{
+  "_cmd": "de b v 7, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 7, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 7, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 7, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 7, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 7, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 7, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 7, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 7, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 7, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 7, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 7, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 7, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 7, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 7, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 7, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 8, wa d 1 1`] = `
+{
+  "_cmd": "de b v 8, wa d 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, wa d 2 1`] = `
+{
+  "_cmd": "de b v 8, wa d 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, wa d 3 1`] = `
+{
+  "_cmd": "de b v 8, wa d 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa d 4 1`] = `
+{
+  "_cmd": "de b v 8, wa d 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, wa d 5 1`] = `
+{
+  "_cmd": "de b v 8, wa d 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa d 6 1`] = `
+{
+  "_cmd": "de b v 8, wa d 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa d 7 1`] = `
+{
+  "_cmd": "de b v 8, wa d 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, wa d 8 1`] = `
+{
+  "_cmd": "de b v 8, wa d 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa d 9 1`] = `
+{
+  "_cmd": "de b v 8, wa d 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa d 10 1`] = `
+{
+  "_cmd": "de b v 8, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 8, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 8, wa p 1 1`] = `
+{
+  "_cmd": "de b v 8, wa p 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 8, wa p 2 1`] = `
+{
+  "_cmd": "de b v 8, wa p 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, wa p 3 1`] = `
+{
+  "_cmd": "de b v 8, wa p 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, wa p 4 1`] = `
+{
+  "_cmd": "de b v 8, wa p 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, wa p 5 1`] = `
+{
+  "_cmd": "de b v 8, wa p 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, wa p 6 1`] = `
+{
+  "_cmd": "de b v 8, wa p 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa p 7 1`] = `
+{
+  "_cmd": "de b v 8, wa p 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa p 8 1`] = `
+{
+  "_cmd": "de b v 8, wa p 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa p 9 1`] = `
+{
+  "_cmd": "de b v 8, wa p 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa p 10 1`] = `
+{
+  "_cmd": "de b v 8, wa p 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 8, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 8, wa p v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, wa v 1 1`] = `
+{
+  "_cmd": "de b v 8, wa v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 8, wa v 2 1`] = `
+{
+  "_cmd": "de b v 8, wa v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, wa v 3 1`] = `
+{
+  "_cmd": "de b v 8, wa v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 8, wa v 4 1`] = `
+{
+  "_cmd": "de b v 8, wa v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa v 5 1`] = `
+{
+  "_cmd": "de b v 8, wa v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, wa v 6 1`] = `
+{
+  "_cmd": "de b v 8, wa v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa v 7 1`] = `
+{
+  "_cmd": "de b v 8, wa v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa v 8 1`] = `
+{
+  "_cmd": "de b v 8, wa v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa v 9 1`] = `
+{
+  "_cmd": "de b v 8, wa v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa v 10 1`] = `
+{
+  "_cmd": "de b v 8, wa v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa v 11 1`] = `
+{
+  "_cmd": "de b v 8, wa v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, wa v 12 1`] = `
+{
+  "_cmd": "de b v 8, wa v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, wa v 13 1`] = `
+{
+  "_cmd": "de b v 8, wa v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, wa v 14 1`] = `
+{
+  "_cmd": "de b v 8, wa v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, wa v 15 1`] = `
+{
+  "_cmd": "de b v 8, wa v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, wa w 1 1`] = `
+{
+  "_cmd": "de b v 8, wa w 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 8, wa w 2 1`] = `
+{
+  "_cmd": "de b v 8, wa w 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa w 3 1`] = `
+{
+  "_cmd": "de b v 8, wa w 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 8, wa w 4 1`] = `
+{
+  "_cmd": "de b v 8, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa w 5 1`] = `
+{
+  "_cmd": "de b v 8, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa w 6 1`] = `
+{
+  "_cmd": "de b v 8, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, wa w 7 1`] = `
+{
+  "_cmd": "de b v 8, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa w 8 1`] = `
+{
+  "_cmd": "de b v 8, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa w 9 1`] = `
+{
+  "_cmd": "de b v 8, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa w 10 1`] = `
+{
+  "_cmd": "de b v 8, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 1",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 8, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 8, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 8, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 8, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 8, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 8, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 8, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 8, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 8, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 8, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 8, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 8, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 8, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 8, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 8, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de b v 9, wa d 1 1`] = `
+{
+  "_cmd": "de b v 9, wa d 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 9, wa d 2 1`] = `
+{
+  "_cmd": "de b v 9, wa d 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, wa d 3 1`] = `
+{
+  "_cmd": "de b v 9, wa d 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, wa d 4 1`] = `
+{
+  "_cmd": "de b v 9, wa d 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa d 5 1`] = `
+{
+  "_cmd": "de b v 9, wa d 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, wa d 6 1`] = `
+{
+  "_cmd": "de b v 9, wa d 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa d 7 1`] = `
+{
+  "_cmd": "de b v 9, wa d 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa d 8 1`] = `
+{
+  "_cmd": "de b v 9, wa d 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa d 9 1`] = `
+{
+  "_cmd": "de b v 9, wa d 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa d 10 1`] = `
+{
+  "_cmd": "de b v 9, wa d 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 9, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 9, wa d v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 9, wa p 1 1`] = `
+{
+  "_cmd": "de b v 9, wa p 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, wa p 2 1`] = `
+{
+  "_cmd": "de b v 9, wa p 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, wa p 3 1`] = `
+{
+  "_cmd": "de b v 9, wa p 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, wa p 4 1`] = `
+{
+  "_cmd": "de b v 9, wa p 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, wa p 5 1`] = `
+{
+  "_cmd": "de b v 9, wa p 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa p 6 1`] = `
+{
+  "_cmd": "de b v 9, wa p 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, wa p 7 1`] = `
+{
+  "_cmd": "de b v 9, wa p 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa p 8 1`] = `
+{
+  "_cmd": "de b v 9, wa p 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa p 9 1`] = `
+{
+  "_cmd": "de b v 9, wa p 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa p 10 1`] = `
+{
+  "_cmd": "de b v 9, wa p 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 9, wa p v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, wa v 1 1`] = `
+{
+  "_cmd": "de b v 9, wa v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 9, wa v 2 1`] = `
+{
+  "_cmd": "de b v 9, wa v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, wa v 3 1`] = `
+{
+  "_cmd": "de b v 9, wa v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, wa v 4 1`] = `
+{
+  "_cmd": "de b v 9, wa v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, wa v 5 1`] = `
+{
+  "_cmd": "de b v 9, wa v 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa v 6 1`] = `
+{
+  "_cmd": "de b v 9, wa v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, wa v 7 1`] = `
+{
+  "_cmd": "de b v 9, wa v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa v 8 1`] = `
+{
+  "_cmd": "de b v 9, wa v 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa v 9 1`] = `
+{
+  "_cmd": "de b v 9, wa v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa v 10 1`] = `
+{
+  "_cmd": "de b v 9, wa v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa v 11 1`] = `
+{
+  "_cmd": "de b v 9, wa v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa v 12 1`] = `
+{
+  "_cmd": "de b v 9, wa v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, wa v 13 1`] = `
+{
+  "_cmd": "de b v 9, wa v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, wa v 14 1`] = `
+{
+  "_cmd": "de b v 9, wa v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, wa v 15 1`] = `
+{
+  "_cmd": "de b v 9, wa v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, wa w 1 1`] = `
+{
+  "_cmd": "de b v 9, wa w 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 9, wa w 2 1`] = `
+{
+  "_cmd": "de b v 9, wa w 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 9, wa w 3 1`] = `
+{
+  "_cmd": "de b v 9, wa w 3",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa w 4 1`] = `
+{
+  "_cmd": "de b v 9, wa w 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 9, wa w 5 1`] = `
+{
+  "_cmd": "de b v 9, wa w 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa w 6 1`] = `
+{
+  "_cmd": "de b v 9, wa w 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa w 7 1`] = `
+{
+  "_cmd": "de b v 9, wa w 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, wa w 8 1`] = `
+{
+  "_cmd": "de b v 9, wa w 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa w 9 1`] = `
+{
+  "_cmd": "de b v 9, wa w 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa w 10 1`] = `
+{
+  "_cmd": "de b v 9, wa w 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 9, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 9, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 9, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 9, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 9, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 9, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 9, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 9, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 9, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 9, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 9, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 9, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 9, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 9, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 9, wa w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, wa d 1 1`] = `
+{
+  "_cmd": "de b v 10, wa d 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 10, wa d 2 1`] = `
+{
+  "_cmd": "de b v 10, wa d 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, wa d 3 1`] = `
+{
+  "_cmd": "de b v 10, wa d 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, wa d 4 1`] = `
+{
+  "_cmd": "de b v 10, wa d 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa d 5 1`] = `
+{
+  "_cmd": "de b v 10, wa d 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa d 6 1`] = `
+{
+  "_cmd": "de b v 10, wa d 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, wa d 7 1`] = `
+{
+  "_cmd": "de b v 10, wa d 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa d 8 1`] = `
+{
+  "_cmd": "de b v 10, wa d 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa d 9 1`] = `
+{
+  "_cmd": "de b v 10, wa d 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa d 10 1`] = `
+{
+  "_cmd": "de b v 10, wa d 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 1",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 10, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 10, wa d v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 10, wa p 1 1`] = `
+{
+  "_cmd": "de b v 10, wa p 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, wa p 2 1`] = `
+{
+  "_cmd": "de b v 10, wa p 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, wa p 3 1`] = `
+{
+  "_cmd": "de b v 10, wa p 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, wa p 4 1`] = `
+{
+  "_cmd": "de b v 10, wa p 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, wa p 5 1`] = `
+{
+  "_cmd": "de b v 10, wa p 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, wa p 6 1`] = `
+{
+  "_cmd": "de b v 10, wa p 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa p 7 1`] = `
+{
+  "_cmd": "de b v 10, wa p 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, wa p 8 1`] = `
+{
+  "_cmd": "de b v 10, wa p 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa p 9 1`] = `
+{
+  "_cmd": "de b v 10, wa p 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa p 10 1`] = `
+{
+  "_cmd": "de b v 10, wa p 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 10, wa p v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, wa v 1 1`] = `
+{
+  "_cmd": "de b v 10, wa v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 10, wa v 2 1`] = `
+{
+  "_cmd": "de b v 10, wa v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, wa v 3 1`] = `
+{
+  "_cmd": "de b v 10, wa v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, wa v 4 1`] = `
+{
+  "_cmd": "de b v 10, wa v 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, wa v 5 1`] = `
+{
+  "_cmd": "de b v 10, wa v 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa v 6 1`] = `
+{
+  "_cmd": "de b v 10, wa v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa v 7 1`] = `
+{
+  "_cmd": "de b v 10, wa v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, wa v 8 1`] = `
+{
+  "_cmd": "de b v 10, wa v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa v 9 1`] = `
+{
+  "_cmd": "de b v 10, wa v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa v 10 1`] = `
+{
+  "_cmd": "de b v 10, wa v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa v 11 1`] = `
+{
+  "_cmd": "de b v 10, wa v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa v 12 1`] = `
+{
+  "_cmd": "de b v 10, wa v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, wa v 13 1`] = `
+{
+  "_cmd": "de b v 10, wa v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, wa v 14 1`] = `
+{
+  "_cmd": "de b v 10, wa v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, wa v 15 1`] = `
+{
+  "_cmd": "de b v 10, wa v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, wa w 1 1`] = `
+{
+  "_cmd": "de b v 10, wa w 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 10, wa w 2 1`] = `
+{
+  "_cmd": "de b v 10, wa w 2",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 10, wa w 3 1`] = `
+{
+  "_cmd": "de b v 10, wa w 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa w 4 1`] = `
+{
+  "_cmd": "de b v 10, wa w 4",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 10, wa w 5 1`] = `
+{
+  "_cmd": "de b v 10, wa w 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, wa w 6 1`] = `
+{
+  "_cmd": "de b v 10, wa w 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa w 7 1`] = `
+{
+  "_cmd": "de b v 10, wa w 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa w 8 1`] = `
+{
+  "_cmd": "de b v 10, wa w 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, wa w 9 1`] = `
+{
+  "_cmd": "de b v 10, wa w 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa w 10 1`] = `
+{
+  "_cmd": "de b v 10, wa w 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 10, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 10, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 10, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 10, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 10, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 10, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 10, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 10, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 10, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 10, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 10, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 10, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 10, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 10, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 10, wa w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, wa d 1 1`] = `
+{
+  "_cmd": "de b v 11, wa d 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 11, wa d 2 1`] = `
+{
+  "_cmd": "de b v 11, wa d 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, wa d 3 1`] = `
+{
+  "_cmd": "de b v 11, wa d 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, wa d 4 1`] = `
+{
+  "_cmd": "de b v 11, wa d 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa d 5 1`] = `
+{
+  "_cmd": "de b v 11, wa d 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa d 6 1`] = `
+{
+  "_cmd": "de b v 11, wa d 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa d 7 1`] = `
+{
+  "_cmd": "de b v 11, wa d 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, wa d 8 1`] = `
+{
+  "_cmd": "de b v 11, wa d 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa d 9 1`] = `
+{
+  "_cmd": "de b v 11, wa d 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa d 10 1`] = `
+{
+  "_cmd": "de b v 11, wa d 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 1",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 11, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 11, wa d v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 11, wa p 1 1`] = `
+{
+  "_cmd": "de b v 11, wa p 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, wa p 2 1`] = `
+{
+  "_cmd": "de b v 11, wa p 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, wa p 3 1`] = `
+{
+  "_cmd": "de b v 11, wa p 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, wa p 4 1`] = `
+{
+  "_cmd": "de b v 11, wa p 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, wa p 5 1`] = `
+{
+  "_cmd": "de b v 11, wa p 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa p 6 1`] = `
+{
+  "_cmd": "de b v 11, wa p 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa p 7 1`] = `
+{
+  "_cmd": "de b v 11, wa p 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa p 8 1`] = `
+{
+  "_cmd": "de b v 11, wa p 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, wa p 9 1`] = `
+{
+  "_cmd": "de b v 11, wa p 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa p 10 1`] = `
+{
+  "_cmd": "de b v 11, wa p 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 11, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 11, wa p v 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, wa v 1 1`] = `
+{
+  "_cmd": "de b v 11, wa v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 11, wa v 2 1`] = `
+{
+  "_cmd": "de b v 11, wa v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, wa v 3 1`] = `
+{
+  "_cmd": "de b v 11, wa v 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, wa v 4 1`] = `
+{
+  "_cmd": "de b v 11, wa v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, wa v 5 1`] = `
+{
+  "_cmd": "de b v 11, wa v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa v 6 1`] = `
+{
+  "_cmd": "de b v 11, wa v 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa v 7 1`] = `
+{
+  "_cmd": "de b v 11, wa v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa v 8 1`] = `
+{
+  "_cmd": "de b v 11, wa v 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, wa v 9 1`] = `
+{
+  "_cmd": "de b v 11, wa v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa v 10 1`] = `
+{
+  "_cmd": "de b v 11, wa v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa v 11 1`] = `
+{
+  "_cmd": "de b v 11, wa v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa v 12 1`] = `
+{
+  "_cmd": "de b v 11, wa v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, wa v 13 1`] = `
+{
+  "_cmd": "de b v 11, wa v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, wa v 14 1`] = `
+{
+  "_cmd": "de b v 11, wa v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, wa v 15 1`] = `
+{
+  "_cmd": "de b v 11, wa v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, wa w 1 1`] = `
+{
+  "_cmd": "de b v 11, wa w 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 11, wa w 2 1`] = `
+{
+  "_cmd": "de b v 11, wa w 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 11, wa w 3 1`] = `
+{
+  "_cmd": "de b v 11, wa w 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa w 4 1`] = `
+{
+  "_cmd": "de b v 11, wa w 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa w 5 1`] = `
+{
+  "_cmd": "de b v 11, wa w 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 11, wa w 6 1`] = `
+{
+  "_cmd": "de b v 11, wa w 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, wa w 7 1`] = `
+{
+  "_cmd": "de b v 11, wa w 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa w 8 1`] = `
+{
+  "_cmd": "de b v 11, wa w 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa w 9 1`] = `
+{
+  "_cmd": "de b v 11, wa w 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, wa w 10 1`] = `
+{
+  "_cmd": "de b v 11, wa w 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 11, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 11, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 11, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 11, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 11, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 11, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 11, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 11, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 11, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 11, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 11, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 11, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 11, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 11, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 11, wa w v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 12, wa d 1 1`] = `
+{
+  "_cmd": "de b v 12, wa d 1",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 12, wa d 2 1`] = `
+{
+  "_cmd": "de b v 12, wa d 2",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, wa d 3 1`] = `
+{
+  "_cmd": "de b v 12, wa d 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, wa d 4 1`] = `
+{
+  "_cmd": "de b v 12, wa d 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa d 5 1`] = `
+{
+  "_cmd": "de b v 12, wa d 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, wa d 6 1`] = `
+{
+  "_cmd": "de b v 12, wa d 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa d 7 1`] = `
+{
+  "_cmd": "de b v 12, wa d 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, wa d 8 1`] = `
+{
+  "_cmd": "de b v 12, wa d 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa d 9 1`] = `
+{
+  "_cmd": "de b v 12, wa d 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa d 10 1`] = `
+{
+  "_cmd": "de b v 12, wa d 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 12, wa d v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, wa p 1 1`] = `
+{
+  "_cmd": "de b v 12, wa p 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, wa p 2 1`] = `
+{
+  "_cmd": "de b v 12, wa p 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, wa p 3 1`] = `
+{
+  "_cmd": "de b v 12, wa p 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, wa p 4 1`] = `
+{
+  "_cmd": "de b v 12, wa p 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, wa p 5 1`] = `
+{
+  "_cmd": "de b v 12, wa p 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa p 6 1`] = `
+{
+  "_cmd": "de b v 12, wa p 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, wa p 7 1`] = `
+{
+  "_cmd": "de b v 12, wa p 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa p 8 1`] = `
+{
+  "_cmd": "de b v 12, wa p 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, wa p 9 1`] = `
+{
+  "_cmd": "de b v 12, wa p 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa p 10 1`] = `
+{
+  "_cmd": "de b v 12, wa p 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 12, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 12, wa p v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, wa v 1 1`] = `
+{
+  "_cmd": "de b v 12, wa v 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 12, wa v 2 1`] = `
+{
+  "_cmd": "de b v 12, wa v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, wa v 3 1`] = `
+{
+  "_cmd": "de b v 12, wa v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 12, wa v 4 1`] = `
+{
+  "_cmd": "de b v 12, wa v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, wa v 5 1`] = `
+{
+  "_cmd": "de b v 12, wa v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa v 6 1`] = `
+{
+  "_cmd": "de b v 12, wa v 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, wa v 7 1`] = `
+{
+  "_cmd": "de b v 12, wa v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa v 8 1`] = `
+{
+  "_cmd": "de b v 12, wa v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, wa v 9 1`] = `
+{
+  "_cmd": "de b v 12, wa v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa v 10 1`] = `
+{
+  "_cmd": "de b v 12, wa v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa v 11 1`] = `
+{
+  "_cmd": "de b v 12, wa v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa v 12 1`] = `
+{
+  "_cmd": "de b v 12, wa v 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, wa v 13 1`] = `
+{
+  "_cmd": "de b v 12, wa v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, wa v 14 1`] = `
+{
+  "_cmd": "de b v 12, wa v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, wa v 15 1`] = `
+{
+  "_cmd": "de b v 12, wa v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, wa w 1 1`] = `
+{
+  "_cmd": "de b v 12, wa w 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, wa w 2 1`] = `
+{
+  "_cmd": "de b v 12, wa w 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 12, wa w 3 1`] = `
+{
+  "_cmd": "de b v 12, wa w 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa w 4 1`] = `
+{
+  "_cmd": "de b v 12, wa w 4",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, wa w 5 1`] = `
+{
+  "_cmd": "de b v 12, wa w 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 12, wa w 6 1`] = `
+{
+  "_cmd": "de b v 12, wa w 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, wa w 7 1`] = `
+{
+  "_cmd": "de b v 12, wa w 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa w 8 1`] = `
+{
+  "_cmd": "de b v 12, wa w 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa w 9 1`] = `
+{
+  "_cmd": "de b v 12, wa w 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa w 10 1`] = `
+{
+  "_cmd": "de b v 12, wa w 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 12, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 12, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 12, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 12, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 12, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 12, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 12, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 12, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 12, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 12, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 12, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 12, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 12, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 12, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 12, wa w v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 13, wa d 1 1`] = `
+{
+  "_cmd": "de b v 13, wa d 1",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 13, wa d 2 1`] = `
+{
+  "_cmd": "de b v 13, wa d 2",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, wa d 3 1`] = `
+{
+  "_cmd": "de b v 13, wa d 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, wa d 4 1`] = `
+{
+  "_cmd": "de b v 13, wa d 4",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, wa d 5 1`] = `
+{
+  "_cmd": "de b v 13, wa d 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa d 6 1`] = `
+{
+  "_cmd": "de b v 13, wa d 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa d 7 1`] = `
+{
+  "_cmd": "de b v 13, wa d 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa d 8 1`] = `
+{
+  "_cmd": "de b v 13, wa d 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, wa d 9 1`] = `
+{
+  "_cmd": "de b v 13, wa d 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa d 10 1`] = `
+{
+  "_cmd": "de b v 13, wa d 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 13, wa d v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, wa p 1 1`] = `
+{
+  "_cmd": "de b v 13, wa p 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, wa p 2 1`] = `
+{
+  "_cmd": "de b v 13, wa p 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, wa p 3 1`] = `
+{
+  "_cmd": "de b v 13, wa p 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, wa p 4 1`] = `
+{
+  "_cmd": "de b v 13, wa p 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, wa p 5 1`] = `
+{
+  "_cmd": "de b v 13, wa p 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, wa p 6 1`] = `
+{
+  "_cmd": "de b v 13, wa p 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa p 7 1`] = `
+{
+  "_cmd": "de b v 13, wa p 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa p 8 1`] = `
+{
+  "_cmd": "de b v 13, wa p 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa p 9 1`] = `
+{
+  "_cmd": "de b v 13, wa p 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, wa p 10 1`] = `
+{
+  "_cmd": "de b v 13, wa p 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 13, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 12",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 13, wa p v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, wa v 1 1`] = `
+{
+  "_cmd": "de b v 13, wa v 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 13, wa v 2 1`] = `
+{
+  "_cmd": "de b v 13, wa v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, wa v 3 1`] = `
+{
+  "_cmd": "de b v 13, wa v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 13, wa v 4 1`] = `
+{
+  "_cmd": "de b v 13, wa v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, wa v 5 1`] = `
+{
+  "_cmd": "de b v 13, wa v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, wa v 6 1`] = `
+{
+  "_cmd": "de b v 13, wa v 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa v 7 1`] = `
+{
+  "_cmd": "de b v 13, wa v 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa v 8 1`] = `
+{
+  "_cmd": "de b v 13, wa v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa v 9 1`] = `
+{
+  "_cmd": "de b v 13, wa v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, wa v 10 1`] = `
+{
+  "_cmd": "de b v 13, wa v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa v 11 1`] = `
+{
+  "_cmd": "de b v 13, wa v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa v 12 1`] = `
+{
+  "_cmd": "de b v 13, wa v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, wa v 13 1`] = `
+{
+  "_cmd": "de b v 13, wa v 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, wa v 14 1`] = `
+{
+  "_cmd": "de b v 13, wa v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, wa v 15 1`] = `
+{
+  "_cmd": "de b v 13, wa v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, wa w 1 1`] = `
+{
+  "_cmd": "de b v 13, wa w 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, wa w 2 1`] = `
+{
+  "_cmd": "de b v 13, wa w 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, wa w 3 1`] = `
+{
+  "_cmd": "de b v 13, wa w 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 13, wa w 4 1`] = `
+{
+  "_cmd": "de b v 13, wa w 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa w 5 1`] = `
+{
+  "_cmd": "de b v 13, wa w 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa w 6 1`] = `
+{
+  "_cmd": "de b v 13, wa w 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 13, wa w 7 1`] = `
+{
+  "_cmd": "de b v 13, wa w 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, wa w 8 1`] = `
+{
+  "_cmd": "de b v 13, wa w 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa w 9 1`] = `
+{
+  "_cmd": "de b v 13, wa w 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa w 10 1`] = `
+{
+  "_cmd": "de b v 13, wa w 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 13, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 13, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 13, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 13, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 13, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 13, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 13, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 13, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 13, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 13, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 13, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 13, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 13, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 13, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 13, wa w v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 14, wa d 1 1`] = `
+{
+  "_cmd": "de b v 14, wa d 1",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 14, wa d 2 1`] = `
+{
+  "_cmd": "de b v 14, wa d 2",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, wa d 3 1`] = `
+{
+  "_cmd": "de b v 14, wa d 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, wa d 4 1`] = `
+{
+  "_cmd": "de b v 14, wa d 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, wa d 5 1`] = `
+{
+  "_cmd": "de b v 14, wa d 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa d 6 1`] = `
+{
+  "_cmd": "de b v 14, wa d 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa d 7 1`] = `
+{
+  "_cmd": "de b v 14, wa d 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa d 8 1`] = `
+{
+  "_cmd": "de b v 14, wa d 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa d 9 1`] = `
+{
+  "_cmd": "de b v 14, wa d 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa d 10 1`] = `
+{
+  "_cmd": "de b v 14, wa d 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 5",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 14, wa d v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, wa p 1 1`] = `
+{
+  "_cmd": "de b v 14, wa p 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, wa p 2 1`] = `
+{
+  "_cmd": "de b v 14, wa p 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, wa p 3 1`] = `
+{
+  "_cmd": "de b v 14, wa p 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, wa p 4 1`] = `
+{
+  "_cmd": "de b v 14, wa p 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, wa p 5 1`] = `
+{
+  "_cmd": "de b v 14, wa p 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, wa p 6 1`] = `
+{
+  "_cmd": "de b v 14, wa p 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa p 7 1`] = `
+{
+  "_cmd": "de b v 14, wa p 7",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa p 8 1`] = `
+{
+  "_cmd": "de b v 14, wa p 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa p 9 1`] = `
+{
+  "_cmd": "de b v 14, wa p 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa p 10 1`] = `
+{
+  "_cmd": "de b v 14, wa p 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 14, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 10",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 11",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 13",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 14, wa p v 15",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, wa v 1 1`] = `
+{
+  "_cmd": "de b v 14, wa v 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 14, wa v 2 1`] = `
+{
+  "_cmd": "de b v 14, wa v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, wa v 3 1`] = `
+{
+  "_cmd": "de b v 14, wa v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 14, wa v 4 1`] = `
+{
+  "_cmd": "de b v 14, wa v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, wa v 5 1`] = `
+{
+  "_cmd": "de b v 14, wa v 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, wa v 6 1`] = `
+{
+  "_cmd": "de b v 14, wa v 6",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa v 7 1`] = `
+{
+  "_cmd": "de b v 14, wa v 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, wa v 8 1`] = `
+{
+  "_cmd": "de b v 14, wa v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa v 9 1`] = `
+{
+  "_cmd": "de b v 14, wa v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa v 10 1`] = `
+{
+  "_cmd": "de b v 14, wa v 10",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa v 11 1`] = `
+{
+  "_cmd": "de b v 14, wa v 11",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa v 12 1`] = `
+{
+  "_cmd": "de b v 14, wa v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, wa v 13 1`] = `
+{
+  "_cmd": "de b v 14, wa v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, wa v 14 1`] = `
+{
+  "_cmd": "de b v 14, wa v 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, wa v 15 1`] = `
+{
+  "_cmd": "de b v 14, wa v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, wa w 1 1`] = `
+{
+  "_cmd": "de b v 14, wa w 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, wa w 2 1`] = `
+{
+  "_cmd": "de b v 14, wa w 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, wa w 3 1`] = `
+{
+  "_cmd": "de b v 14, wa w 3",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 14, wa w 4 1`] = `
+{
+  "_cmd": "de b v 14, wa w 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa w 5 1`] = `
+{
+  "_cmd": "de b v 14, wa w 5",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa w 6 1`] = `
+{
+  "_cmd": "de b v 14, wa w 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 14, wa w 7 1`] = `
+{
+  "_cmd": "de b v 14, wa w 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa w 8 1`] = `
+{
+  "_cmd": "de b v 14, wa w 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa w 9 1`] = `
+{
+  "_cmd": "de b v 14, wa w 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa w 10 1`] = `
+{
+  "_cmd": "de b v 14, wa w 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 14, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 14, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 14, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 14, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 14, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 14, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 14, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 14, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 14, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 14, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 14, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 14, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 14, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 14, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 14, wa w v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 15, wa d 1 1`] = `
+{
+  "_cmd": "de b v 15, wa d 1",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 15, wa d 2 1`] = `
+{
+  "_cmd": "de b v 15, wa d 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, wa d 3 1`] = `
+{
+  "_cmd": "de b v 15, wa d 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa d 4 1`] = `
+{
+  "_cmd": "de b v 15, wa d 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa d 5 1`] = `
+{
+  "_cmd": "de b v 15, wa d 5",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, wa d 6 1`] = `
+{
+  "_cmd": "de b v 15, wa d 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa d 7 1`] = `
+{
+  "_cmd": "de b v 15, wa d 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa d 8 1`] = `
+{
+  "_cmd": "de b v 15, wa d 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa d 9 1`] = `
+{
+  "_cmd": "de b v 15, wa d 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa d 10 1`] = `
+{
+  "_cmd": "de b v 15, wa d 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 5",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 7",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 8",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 12",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 14",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 15, wa d v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, wa p 1 1`] = `
+{
+  "_cmd": "de b v 15, wa p 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, wa p 2 1`] = `
+{
+  "_cmd": "de b v 15, wa p 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, wa p 3 1`] = `
+{
+  "_cmd": "de b v 15, wa p 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, wa p 4 1`] = `
+{
+  "_cmd": "de b v 15, wa p 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa p 5 1`] = `
+{
+  "_cmd": "de b v 15, wa p 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa p 6 1`] = `
+{
+  "_cmd": "de b v 15, wa p 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, wa p 7 1`] = `
+{
+  "_cmd": "de b v 15, wa p 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa p 8 1`] = `
+{
+  "_cmd": "de b v 15, wa p 8",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa p 9 1`] = `
+{
+  "_cmd": "de b v 15, wa p 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa p 10 1`] = `
+{
+  "_cmd": "de b v 15, wa p 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 15, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 6",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 8",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 9",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 10",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 11",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 12",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 14",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 15, wa p v 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, wa v 1 1`] = `
+{
+  "_cmd": "de b v 15, wa v 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 15, wa v 2 1`] = `
+{
+  "_cmd": "de b v 15, wa v 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, wa v 3 1`] = `
+{
+  "_cmd": "de b v 15, wa v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 15, wa v 4 1`] = `
+{
+  "_cmd": "de b v 15, wa v 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa v 5 1`] = `
+{
+  "_cmd": "de b v 15, wa v 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa v 6 1`] = `
+{
+  "_cmd": "de b v 15, wa v 6",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, wa v 7 1`] = `
+{
+  "_cmd": "de b v 15, wa v 7",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa v 8 1`] = `
+{
+  "_cmd": "de b v 15, wa v 8",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa v 9 1`] = `
+{
+  "_cmd": "de b v 15, wa v 9",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa v 10 1`] = `
+{
+  "_cmd": "de b v 15, wa v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa v 11 1`] = `
+{
+  "_cmd": "de b v 15, wa v 11",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, wa v 12 1`] = `
+{
+  "_cmd": "de b v 15, wa v 12",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, wa v 13 1`] = `
+{
+  "_cmd": "de b v 15, wa v 13",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, wa v 14 1`] = `
+{
+  "_cmd": "de b v 15, wa v 14",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, wa v 15 1`] = `
+{
+  "_cmd": "de b v 15, wa v 15",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, wa w 1 1`] = `
+{
+  "_cmd": "de b v 15, wa w 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 15, wa w 2 1`] = `
+{
+  "_cmd": "de b v 15, wa w 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa w 3 1`] = `
+{
+  "_cmd": "de b v 15, wa w 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 15, wa w 4 1`] = `
+{
+  "_cmd": "de b v 15, wa w 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, wa w 5 1`] = `
+{
+  "_cmd": "de b v 15, wa w 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, wa w 6 1`] = `
+{
+  "_cmd": "de b v 15, wa w 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa w 7 1`] = `
+{
+  "_cmd": "de b v 15, wa w 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 15, wa w 8 1`] = `
+{
+  "_cmd": "de b v 15, wa w 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa w 9 1`] = `
+{
+  "_cmd": "de b v 15, wa w 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, wa w 10 1`] = `
+{
+  "_cmd": "de b v 15, wa w 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 1",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 15, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 15, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 15, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 15, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 15, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 15, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 15, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 15, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 15, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 15, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 15, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 15, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 15, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 15, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 15, wa w v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 16, wa d 1 1`] = `
+{
+  "_cmd": "de b v 16, wa d 1",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, wa d 2 1`] = `
+{
+  "_cmd": "de b v 16, wa d 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, wa d 3 1`] = `
+{
+  "_cmd": "de b v 16, wa d 3",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, wa d 4 1`] = `
+{
+  "_cmd": "de b v 16, wa d 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa d 5 1`] = `
+{
+  "_cmd": "de b v 16, wa d 5",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, wa d 6 1`] = `
+{
+  "_cmd": "de b v 16, wa d 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa d 7 1`] = `
+{
+  "_cmd": "de b v 16, wa d 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa d 8 1`] = `
+{
+  "_cmd": "de b v 16, wa d 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa d 9 1`] = `
+{
+  "_cmd": "de b v 16, wa d 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa d 10 1`] = `
+{
+  "_cmd": "de b v 16, wa d 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 4",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 5",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 7",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 8",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 10",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 13",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 14",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 16, wa d v 15",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, wa p 1 1`] = `
+{
+  "_cmd": "de b v 16, wa p 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, wa p 2 1`] = `
+{
+  "_cmd": "de b v 16, wa p 2",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, wa p 3 1`] = `
+{
+  "_cmd": "de b v 16, wa p 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, wa p 4 1`] = `
+{
+  "_cmd": "de b v 16, wa p 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, wa p 5 1`] = `
+{
+  "_cmd": "de b v 16, wa p 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa p 6 1`] = `
+{
+  "_cmd": "de b v 16, wa p 6",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, wa p 7 1`] = `
+{
+  "_cmd": "de b v 16, wa p 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa p 8 1`] = `
+{
+  "_cmd": "de b v 16, wa p 8",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa p 9 1`] = `
+{
+  "_cmd": "de b v 16, wa p 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa p 10 1`] = `
+{
+  "_cmd": "de b v 16, wa p 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 2",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 5",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 6",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 9",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 10",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 11",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 12",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 13",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 14",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 16, wa p v 15",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, wa v 1 1`] = `
+{
+  "_cmd": "de b v 16, wa v 1",
+  "attacker": 16,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 16, wa v 2 1`] = `
+{
+  "_cmd": "de b v 16, wa v 2",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, wa v 3 1`] = `
+{
+  "_cmd": "de b v 16, wa v 3",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, wa v 4 1`] = `
+{
+  "_cmd": "de b v 16, wa v 4",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, wa v 5 1`] = `
+{
+  "_cmd": "de b v 16, wa v 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa v 6 1`] = `
+{
+  "_cmd": "de b v 16, wa v 6",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, wa v 7 1`] = `
+{
+  "_cmd": "de b v 16, wa v 7",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa v 8 1`] = `
+{
+  "_cmd": "de b v 16, wa v 8",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, wa v 9 1`] = `
+{
+  "_cmd": "de b v 16, wa v 9",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa v 10 1`] = `
+{
+  "_cmd": "de b v 16, wa v 10",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa v 11 1`] = `
+{
+  "_cmd": "de b v 16, wa v 11",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, wa v 12 1`] = `
+{
+  "_cmd": "de b v 16, wa v 12",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, wa v 13 1`] = `
+{
+  "_cmd": "de b v 16, wa v 13",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, wa v 14 1`] = `
+{
+  "_cmd": "de b v 16, wa v 14",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, wa v 15 1`] = `
+{
+  "_cmd": "de b v 16, wa v 15",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, wa w 1 1`] = `
+{
+  "_cmd": "de b v 16, wa w 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 16, wa w 2 1`] = `
+{
+  "_cmd": "de b v 16, wa w 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 16, wa w 3 1`] = `
+{
+  "_cmd": "de b v 16, wa w 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 16, wa w 4 1`] = `
+{
+  "_cmd": "de b v 16, wa w 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, wa w 5 1`] = `
+{
+  "_cmd": "de b v 16, wa w 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa w 6 1`] = `
+{
+  "_cmd": "de b v 16, wa w 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa w 7 1`] = `
+{
+  "_cmd": "de b v 16, wa w 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 16, wa w 8 1`] = `
+{
+  "_cmd": "de b v 16, wa w 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa w 9 1`] = `
+{
+  "_cmd": "de b v 16, wa w 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, wa w 10 1`] = `
+{
+  "_cmd": "de b v 16, wa w 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 1",
+  "attacker": 16,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 16, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 2",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 16, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 16, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 4",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 16, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 16, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 16, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 16, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 16, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 16, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 16, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 16, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 16, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 16, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 16, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 16, wa w v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 17, wa d 1 1`] = `
+{
+  "_cmd": "de b v 17, wa d 1",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, wa d 2 1`] = `
+{
+  "_cmd": "de b v 17, wa d 2",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, wa d 3 1`] = `
+{
+  "_cmd": "de b v 17, wa d 3",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, wa d 4 1`] = `
+{
+  "_cmd": "de b v 17, wa d 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa d 5 1`] = `
+{
+  "_cmd": "de b v 17, wa d 5",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, wa d 6 1`] = `
+{
+  "_cmd": "de b v 17, wa d 6",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa d 7 1`] = `
+{
+  "_cmd": "de b v 17, wa d 7",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa d 8 1`] = `
+{
+  "_cmd": "de b v 17, wa d 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa d 9 1`] = `
+{
+  "_cmd": "de b v 17, wa d 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa d 10 1`] = `
+{
+  "_cmd": "de b v 17, wa d 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 2",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 4",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 5",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 6",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 7",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 8",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 9",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 11",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 14",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 17, wa d v 15",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, wa p 1 1`] = `
+{
+  "_cmd": "de b v 17, wa p 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, wa p 2 1`] = `
+{
+  "_cmd": "de b v 17, wa p 2",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, wa p 3 1`] = `
+{
+  "_cmd": "de b v 17, wa p 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, wa p 4 1`] = `
+{
+  "_cmd": "de b v 17, wa p 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, wa p 5 1`] = `
+{
+  "_cmd": "de b v 17, wa p 5",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa p 6 1`] = `
+{
+  "_cmd": "de b v 17, wa p 6",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, wa p 7 1`] = `
+{
+  "_cmd": "de b v 17, wa p 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa p 8 1`] = `
+{
+  "_cmd": "de b v 17, wa p 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa p 9 1`] = `
+{
+  "_cmd": "de b v 17, wa p 9",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa p 10 1`] = `
+{
+  "_cmd": "de b v 17, wa p 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 2",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 3",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 5",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 6",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 7",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 9",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 10",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 11",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 12",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 13",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 14",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 17, wa p v 15",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, wa v 1 1`] = `
+{
+  "_cmd": "de b v 17, wa v 1",
+  "attacker": 17,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 17, wa v 2 1`] = `
+{
+  "_cmd": "de b v 17, wa v 2",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, wa v 3 1`] = `
+{
+  "_cmd": "de b v 17, wa v 3",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, wa v 4 1`] = `
+{
+  "_cmd": "de b v 17, wa v 4",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, wa v 5 1`] = `
+{
+  "_cmd": "de b v 17, wa v 5",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa v 6 1`] = `
+{
+  "_cmd": "de b v 17, wa v 6",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, wa v 7 1`] = `
+{
+  "_cmd": "de b v 17, wa v 7",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa v 8 1`] = `
+{
+  "_cmd": "de b v 17, wa v 8",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa v 9 1`] = `
+{
+  "_cmd": "de b v 17, wa v 9",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa v 10 1`] = `
+{
+  "_cmd": "de b v 17, wa v 10",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa v 11 1`] = `
+{
+  "_cmd": "de b v 17, wa v 11",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, wa v 12 1`] = `
+{
+  "_cmd": "de b v 17, wa v 12",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, wa v 13 1`] = `
+{
+  "_cmd": "de b v 17, wa v 13",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, wa v 14 1`] = `
+{
+  "_cmd": "de b v 17, wa v 14",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, wa v 15 1`] = `
+{
+  "_cmd": "de b v 17, wa v 15",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, wa w 1 1`] = `
+{
+  "_cmd": "de b v 17, wa w 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 17, wa w 2 1`] = `
+{
+  "_cmd": "de b v 17, wa w 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 17, wa w 3 1`] = `
+{
+  "_cmd": "de b v 17, wa w 3",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa w 4 1`] = `
+{
+  "_cmd": "de b v 17, wa w 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 17, wa w 5 1`] = `
+{
+  "_cmd": "de b v 17, wa w 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa w 6 1`] = `
+{
+  "_cmd": "de b v 17, wa w 6",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, wa w 7 1`] = `
+{
+  "_cmd": "de b v 17, wa w 7",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa w 8 1`] = `
+{
+  "_cmd": "de b v 17, wa w 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 17, wa w 9 1`] = `
+{
+  "_cmd": "de b v 17, wa w 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, wa w 10 1`] = `
+{
+  "_cmd": "de b v 17, wa w 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 1",
+  "attacker": 17,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 17, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 2",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 17, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 17, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 17, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 17, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 17, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 17, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 17, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 17, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 17, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 11",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 17, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 17, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 17, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 17, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 17, wa w v 15",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 18, wa d 1 1`] = `
+{
+  "_cmd": "de b v 18, wa d 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, wa d 2 1`] = `
+{
+  "_cmd": "de b v 18, wa d 2",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, wa d 3 1`] = `
+{
+  "_cmd": "de b v 18, wa d 3",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, wa d 4 1`] = `
+{
+  "_cmd": "de b v 18, wa d 4",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, wa d 5 1`] = `
+{
+  "_cmd": "de b v 18, wa d 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa d 6 1`] = `
+{
+  "_cmd": "de b v 18, wa d 6",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, wa d 7 1`] = `
+{
+  "_cmd": "de b v 18, wa d 7",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa d 8 1`] = `
+{
+  "_cmd": "de b v 18, wa d 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa d 9 1`] = `
+{
+  "_cmd": "de b v 18, wa d 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa d 10 1`] = `
+{
+  "_cmd": "de b v 18, wa d 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 2",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 4",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 5",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 6",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 7",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 8",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 9",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 10",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 11",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 12",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 13",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 14",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 18, wa d v 15",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, wa p 1 1`] = `
+{
+  "_cmd": "de b v 18, wa p 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, wa p 2 1`] = `
+{
+  "_cmd": "de b v 18, wa p 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, wa p 3 1`] = `
+{
+  "_cmd": "de b v 18, wa p 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, wa p 4 1`] = `
+{
+  "_cmd": "de b v 18, wa p 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, wa p 5 1`] = `
+{
+  "_cmd": "de b v 18, wa p 5",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, wa p 6 1`] = `
+{
+  "_cmd": "de b v 18, wa p 6",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa p 7 1`] = `
+{
+  "_cmd": "de b v 18, wa p 7",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, wa p 8 1`] = `
+{
+  "_cmd": "de b v 18, wa p 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa p 9 1`] = `
+{
+  "_cmd": "de b v 18, wa p 9",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa p 10 1`] = `
+{
+  "_cmd": "de b v 18, wa p 10",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 3",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 5",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 6",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 7",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 8",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 9",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 10",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 11",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 12",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 13",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 14",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 18, wa p v 15",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, wa v 1 1`] = `
+{
+  "_cmd": "de b v 18, wa v 1",
+  "attacker": 18,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 18, wa v 2 1`] = `
+{
+  "_cmd": "de b v 18, wa v 2",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, wa v 3 1`] = `
+{
+  "_cmd": "de b v 18, wa v 3",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, wa v 4 1`] = `
+{
+  "_cmd": "de b v 18, wa v 4",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, wa v 5 1`] = `
+{
+  "_cmd": "de b v 18, wa v 5",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, wa v 6 1`] = `
+{
+  "_cmd": "de b v 18, wa v 6",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa v 7 1`] = `
+{
+  "_cmd": "de b v 18, wa v 7",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, wa v 8 1`] = `
+{
+  "_cmd": "de b v 18, wa v 8",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa v 9 1`] = `
+{
+  "_cmd": "de b v 18, wa v 9",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, wa v 10 1`] = `
+{
+  "_cmd": "de b v 18, wa v 10",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa v 11 1`] = `
+{
+  "_cmd": "de b v 18, wa v 11",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa v 12 1`] = `
+{
+  "_cmd": "de b v 18, wa v 12",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, wa v 13 1`] = `
+{
+  "_cmd": "de b v 18, wa v 13",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, wa v 14 1`] = `
+{
+  "_cmd": "de b v 18, wa v 14",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, wa v 15 1`] = `
+{
+  "_cmd": "de b v 18, wa v 15",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, wa w 1 1`] = `
+{
+  "_cmd": "de b v 18, wa w 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 18, wa w 2 1`] = `
+{
+  "_cmd": "de b v 18, wa w 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 18, wa w 3 1`] = `
+{
+  "_cmd": "de b v 18, wa w 3",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, wa w 4 1`] = `
+{
+  "_cmd": "de b v 18, wa w 4",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 18, wa w 5 1`] = `
+{
+  "_cmd": "de b v 18, wa w 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, wa w 6 1`] = `
+{
+  "_cmd": "de b v 18, wa w 6",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, wa w 7 1`] = `
+{
+  "_cmd": "de b v 18, wa w 7",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa w 8 1`] = `
+{
+  "_cmd": "de b v 18, wa w 8",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 18, wa w 9 1`] = `
+{
+  "_cmd": "de b v 18, wa w 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa w 10 1`] = `
+{
+  "_cmd": "de b v 18, wa w 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 1",
+  "attacker": 18,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 18, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 2",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 18, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 18, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 18, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 18, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 18, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 18, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 18, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 18, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 18, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 11",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 18, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 12",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 18, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 18, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 18, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 18, wa w v 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 19, wa d 1 1`] = `
+{
+  "_cmd": "de b v 19, wa d 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, wa d 2 1`] = `
+{
+  "_cmd": "de b v 19, wa d 2",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, wa d 3 1`] = `
+{
+  "_cmd": "de b v 19, wa d 3",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, wa d 4 1`] = `
+{
+  "_cmd": "de b v 19, wa d 4",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa d 5 1`] = `
+{
+  "_cmd": "de b v 19, wa d 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa d 6 1`] = `
+{
+  "_cmd": "de b v 19, wa d 6",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, wa d 7 1`] = `
+{
+  "_cmd": "de b v 19, wa d 7",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa d 8 1`] = `
+{
+  "_cmd": "de b v 19, wa d 8",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa d 9 1`] = `
+{
+  "_cmd": "de b v 19, wa d 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa d 10 1`] = `
+{
+  "_cmd": "de b v 19, wa d 10",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 2",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 4",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 5",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 6",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 7",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 8",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 9",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 10",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 11",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 12",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 13",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 14",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 19, wa d v 15",
+  "attacker": 13,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, wa p 1 1`] = `
+{
+  "_cmd": "de b v 19, wa p 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, wa p 2 1`] = `
+{
+  "_cmd": "de b v 19, wa p 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, wa p 3 1`] = `
+{
+  "_cmd": "de b v 19, wa p 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, wa p 4 1`] = `
+{
+  "_cmd": "de b v 19, wa p 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, wa p 5 1`] = `
+{
+  "_cmd": "de b v 19, wa p 5",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa p 6 1`] = `
+{
+  "_cmd": "de b v 19, wa p 6",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa p 7 1`] = `
+{
+  "_cmd": "de b v 19, wa p 7",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, wa p 8 1`] = `
+{
+  "_cmd": "de b v 19, wa p 8",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa p 9 1`] = `
+{
+  "_cmd": "de b v 19, wa p 9",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa p 10 1`] = `
+{
+  "_cmd": "de b v 19, wa p 10",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 3",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 5",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 6",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 7",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 8",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 9",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 10",
+  "attacker": 15,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 11",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 12",
+  "attacker": 15,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 13",
+  "attacker": 15,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 14",
+  "attacker": 15,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 19, wa p v 15",
+  "attacker": 15,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, wa v 1 1`] = `
+{
+  "_cmd": "de b v 19, wa v 1",
+  "attacker": 19,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 19, wa v 2 1`] = `
+{
+  "_cmd": "de b v 19, wa v 2",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, wa v 3 1`] = `
+{
+  "_cmd": "de b v 19, wa v 3",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, wa v 4 1`] = `
+{
+  "_cmd": "de b v 19, wa v 4",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, wa v 5 1`] = `
+{
+  "_cmd": "de b v 19, wa v 5",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa v 6 1`] = `
+{
+  "_cmd": "de b v 19, wa v 6",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa v 7 1`] = `
+{
+  "_cmd": "de b v 19, wa v 7",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, wa v 8 1`] = `
+{
+  "_cmd": "de b v 19, wa v 8",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa v 9 1`] = `
+{
+  "_cmd": "de b v 19, wa v 9",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa v 10 1`] = `
+{
+  "_cmd": "de b v 19, wa v 10",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa v 11 1`] = `
+{
+  "_cmd": "de b v 19, wa v 11",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, wa v 12 1`] = `
+{
+  "_cmd": "de b v 19, wa v 12",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, wa v 13 1`] = `
+{
+  "_cmd": "de b v 19, wa v 13",
+  "attacker": 14,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, wa v 14 1`] = `
+{
+  "_cmd": "de b v 19, wa v 14",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, wa v 15 1`] = `
+{
+  "_cmd": "de b v 19, wa v 15",
+  "attacker": 14,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, wa w 1 1`] = `
+{
+  "_cmd": "de b v 19, wa w 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 19, wa w 2 1`] = `
+{
+  "_cmd": "de b v 19, wa w 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 19, wa w 3 1`] = `
+{
+  "_cmd": "de b v 19, wa w 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa w 4 1`] = `
+{
+  "_cmd": "de b v 19, wa w 4",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 19, wa w 5 1`] = `
+{
+  "_cmd": "de b v 19, wa w 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, wa w 6 1`] = `
+{
+  "_cmd": "de b v 19, wa w 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa w 7 1`] = `
+{
+  "_cmd": "de b v 19, wa w 7",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, wa w 8 1`] = `
+{
+  "_cmd": "de b v 19, wa w 8",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa w 9 1`] = `
+{
+  "_cmd": "de b v 19, wa w 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 19, wa w 10 1`] = `
+{
+  "_cmd": "de b v 19, wa w 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 1",
+  "attacker": 19,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 19, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 2",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 19, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 19, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 19, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 19, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 19, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 19, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 19, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 19, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 19, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 11",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 19, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 12",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 19, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 13",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 19, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 14",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 19, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 19, wa w v 15",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de b v 20, wa d 1 1`] = `
+{
+  "_cmd": "de b v 20, wa d 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, wa d 2 1`] = `
+{
+  "_cmd": "de b v 20, wa d 2",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, wa d 3 1`] = `
+{
+  "_cmd": "de b v 20, wa d 3",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, wa d 4 1`] = `
+{
+  "_cmd": "de b v 20, wa d 4",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa d 5 1`] = `
+{
+  "_cmd": "de b v 20, wa d 5",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa d 6 1`] = `
+{
+  "_cmd": "de b v 20, wa d 6",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa d 7 1`] = `
+{
+  "_cmd": "de b v 20, wa d 7",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa d 8 1`] = `
+{
+  "_cmd": "de b v 20, wa d 8",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa d 9 1`] = `
+{
+  "_cmd": "de b v 20, wa d 9",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa d 10 1`] = `
+{
+  "_cmd": "de b v 20, wa d 10",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, wa d v 1 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, wa d v 2 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 2",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, wa d v 3 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, wa d v 4 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 4",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa d v 5 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 5",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, wa d v 6 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 6",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa d v 7 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 7",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa d v 8 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 8",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa d v 9 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 9",
+  "attacker": 15,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, wa d v 10 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 10",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa d v 11 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 11",
+  "attacker": 15,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, wa d v 12 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 12",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, wa d v 13 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 13",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, wa d v 14 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 14",
+  "attacker": 14,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, wa d v 15 1`] = `
+{
+  "_cmd": "de b v 20, wa d v 15",
+  "attacker": 14,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, wa p 1 1`] = `
+{
+  "_cmd": "de b v 20, wa p 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, wa p 2 1`] = `
+{
+  "_cmd": "de b v 20, wa p 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, wa p 3 1`] = `
+{
+  "_cmd": "de b v 20, wa p 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, wa p 4 1`] = `
+{
+  "_cmd": "de b v 20, wa p 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, wa p 5 1`] = `
+{
+  "_cmd": "de b v 20, wa p 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa p 6 1`] = `
+{
+  "_cmd": "de b v 20, wa p 6",
+  "attacker": 17,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa p 7 1`] = `
+{
+  "_cmd": "de b v 20, wa p 7",
+  "attacker": 16,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa p 8 1`] = `
+{
+  "_cmd": "de b v 20, wa p 8",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa p 9 1`] = `
+{
+  "_cmd": "de b v 20, wa p 9",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa p 10 1`] = `
+{
+  "_cmd": "de b v 20, wa p 10",
+  "attacker": 16,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa p v 1 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, wa p v 2 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, wa p v 3 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 3",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, wa p v 4 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, wa p v 5 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa p v 6 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 6",
+  "attacker": 18,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, wa p v 7 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 7",
+  "attacker": 17,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa p v 8 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 8",
+  "attacker": 17,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa p v 9 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 9",
+  "attacker": 17,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa p v 10 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 10",
+  "attacker": 17,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, wa p v 11 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 11",
+  "attacker": 16,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa p v 12 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 12",
+  "attacker": 16,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, wa p v 13 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 13",
+  "attacker": 16,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, wa p v 14 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 14",
+  "attacker": 16,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, wa p v 15 1`] = `
+{
+  "_cmd": "de b v 20, wa p v 15",
+  "attacker": 16,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, wa v 1 1`] = `
+{
+  "_cmd": "de b v 20, wa v 1",
+  "attacker": 20,
+  "defender": -5,
+}
+`;
+
+exports[`de b v 20, wa v 2 1`] = `
+{
+  "_cmd": "de b v 20, wa v 2",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, wa v 3 1`] = `
+{
+  "_cmd": "de b v 20, wa v 3",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, wa v 4 1`] = `
+{
+  "_cmd": "de b v 20, wa v 4",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, wa v 5 1`] = `
+{
+  "_cmd": "de b v 20, wa v 5",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa v 6 1`] = `
+{
+  "_cmd": "de b v 20, wa v 6",
+  "attacker": 17,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa v 7 1`] = `
+{
+  "_cmd": "de b v 20, wa v 7",
+  "attacker": 17,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa v 8 1`] = `
+{
+  "_cmd": "de b v 20, wa v 8",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa v 9 1`] = `
+{
+  "_cmd": "de b v 20, wa v 9",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa v 10 1`] = `
+{
+  "_cmd": "de b v 20, wa v 10",
+  "attacker": 16,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, wa v 11 1`] = `
+{
+  "_cmd": "de b v 20, wa v 11",
+  "attacker": 16,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, wa v 12 1`] = `
+{
+  "_cmd": "de b v 20, wa v 12",
+  "attacker": 15,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, wa v 13 1`] = `
+{
+  "_cmd": "de b v 20, wa v 13",
+  "attacker": 15,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, wa v 14 1`] = `
+{
+  "_cmd": "de b v 20, wa v 14",
+  "attacker": 15,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, wa v 15 1`] = `
+{
+  "_cmd": "de b v 20, wa v 15",
+  "attacker": 15,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, wa w 1 1`] = `
+{
+  "_cmd": "de b v 20, wa w 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de b v 20, wa w 2 1`] = `
+{
+  "_cmd": "de b v 20, wa w 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de b v 20, wa w 3 1`] = `
+{
+  "_cmd": "de b v 20, wa w 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa w 4 1`] = `
+{
+  "_cmd": "de b v 20, wa w 4",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de b v 20, wa w 5 1`] = `
+{
+  "_cmd": "de b v 20, wa w 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa w 6 1`] = `
+{
+  "_cmd": "de b v 20, wa w 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa w 7 1`] = `
+{
+  "_cmd": "de b v 20, wa w 7",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, wa w 8 1`] = `
+{
+  "_cmd": "de b v 20, wa w 8",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa w 9 1`] = `
+{
+  "_cmd": "de b v 20, wa w 9",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de b v 20, wa w 10 1`] = `
+{
+  "_cmd": "de b v 20, wa w 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, wa w v 1 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 1",
+  "attacker": 20,
+  "defender": -4,
+}
+`;
+
+exports[`de b v 20, wa w v 2 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de b v 20, wa w v 3 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de b v 20, wa w v 4 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de b v 20, wa w v 5 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 5",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de b v 20, wa w v 6 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de b v 20, wa w v 7 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 7",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de b v 20, wa w v 8 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de b v 20, wa w v 9 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de b v 20, wa w v 10 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 10",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de b v 20, wa w v 11 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 11",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de b v 20, wa w v 12 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 12",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de b v 20, wa w v 13 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 13",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de b v 20, wa w v 14 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 14",
+  "attacker": 13,
+  "defender": 13,
+}
+`;
+
+exports[`de b v 20, wa w v 15 1`] = `
+{
+  "_cmd": "de b v 20, wa w v 15",
+  "attacker": 12,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, wa d 1 1`] = `
+{
+  "_cmd": "de v 1, wa d 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, wa d 2 1`] = `
+{
+  "_cmd": "de v 1, wa d 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, wa d 3 1`] = `
+{
+  "_cmd": "de v 1, wa d 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa d 4 1`] = `
+{
+  "_cmd": "de v 1, wa d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa d 5 1`] = `
+{
+  "_cmd": "de v 1, wa d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa d 6 1`] = `
+{
+  "_cmd": "de v 1, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa d 7 1`] = `
+{
+  "_cmd": "de v 1, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa d 8 1`] = `
+{
+  "_cmd": "de v 1, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa d 9 1`] = `
+{
+  "_cmd": "de v 1, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa d 10 1`] = `
+{
+  "_cmd": "de v 1, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa d v 1 1`] = `
+{
+  "_cmd": "de v 1, wa d v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, wa d v 2 1`] = `
+{
+  "_cmd": "de v 1, wa d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa d v 3 1`] = `
+{
+  "_cmd": "de v 1, wa d v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa d v 4 1`] = `
+{
+  "_cmd": "de v 1, wa d v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa d v 5 1`] = `
+{
+  "_cmd": "de v 1, wa d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa d v 6 1`] = `
+{
+  "_cmd": "de v 1, wa d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa d v 7 1`] = `
+{
+  "_cmd": "de v 1, wa d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa d v 8 1`] = `
+{
+  "_cmd": "de v 1, wa d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa d v 9 1`] = `
+{
+  "_cmd": "de v 1, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa d v 10 1`] = `
+{
+  "_cmd": "de v 1, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa d v 11 1`] = `
+{
+  "_cmd": "de v 1, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, wa d v 12 1`] = `
+{
+  "_cmd": "de v 1, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, wa d v 13 1`] = `
+{
+  "_cmd": "de v 1, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, wa d v 14 1`] = `
+{
+  "_cmd": "de v 1, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, wa d v 15 1`] = `
+{
+  "_cmd": "de v 1, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, wa p 1 1`] = `
+{
+  "_cmd": "de v 1, wa p 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, wa p 2 1`] = `
+{
+  "_cmd": "de v 1, wa p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa p 3 1`] = `
+{
+  "_cmd": "de v 1, wa p 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa p 4 1`] = `
+{
+  "_cmd": "de v 1, wa p 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa p 5 1`] = `
+{
+  "_cmd": "de v 1, wa p 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa p 6 1`] = `
+{
+  "_cmd": "de v 1, wa p 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa p 7 1`] = `
+{
+  "_cmd": "de v 1, wa p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa p 8 1`] = `
+{
+  "_cmd": "de v 1, wa p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa p 9 1`] = `
+{
+  "_cmd": "de v 1, wa p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa p 10 1`] = `
+{
+  "_cmd": "de v 1, wa p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa p v 1 1`] = `
+{
+  "_cmd": "de v 1, wa p v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`de v 1, wa p v 2 1`] = `
+{
+  "_cmd": "de v 1, wa p v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa p v 3 1`] = `
+{
+  "_cmd": "de v 1, wa p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, wa p v 4 1`] = `
+{
+  "_cmd": "de v 1, wa p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa p v 5 1`] = `
+{
+  "_cmd": "de v 1, wa p v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa p v 6 1`] = `
+{
+  "_cmd": "de v 1, wa p v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa p v 7 1`] = `
+{
+  "_cmd": "de v 1, wa p v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa p v 8 1`] = `
+{
+  "_cmd": "de v 1, wa p v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa p v 9 1`] = `
+{
+  "_cmd": "de v 1, wa p v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa p v 10 1`] = `
+{
+  "_cmd": "de v 1, wa p v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa p v 11 1`] = `
+{
+  "_cmd": "de v 1, wa p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, wa p v 12 1`] = `
+{
+  "_cmd": "de v 1, wa p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, wa p v 13 1`] = `
+{
+  "_cmd": "de v 1, wa p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, wa p v 14 1`] = `
+{
+  "_cmd": "de v 1, wa p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, wa p v 15 1`] = `
+{
+  "_cmd": "de v 1, wa p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, wa v 1 1`] = `
+{
+  "_cmd": "de v 1, wa v 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`de v 1, wa v 2 1`] = `
+{
+  "_cmd": "de v 1, wa v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa v 3 1`] = `
+{
+  "_cmd": "de v 1, wa v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, wa v 4 1`] = `
+{
+  "_cmd": "de v 1, wa v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa v 5 1`] = `
+{
+  "_cmd": "de v 1, wa v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa v 6 1`] = `
+{
+  "_cmd": "de v 1, wa v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa v 7 1`] = `
+{
+  "_cmd": "de v 1, wa v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa v 8 1`] = `
+{
+  "_cmd": "de v 1, wa v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa v 9 1`] = `
+{
+  "_cmd": "de v 1, wa v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa v 10 1`] = `
+{
+  "_cmd": "de v 1, wa v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa v 11 1`] = `
+{
+  "_cmd": "de v 1, wa v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, wa v 12 1`] = `
+{
+  "_cmd": "de v 1, wa v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, wa v 13 1`] = `
+{
+  "_cmd": "de v 1, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, wa v 14 1`] = `
+{
+  "_cmd": "de v 1, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, wa v 15 1`] = `
+{
+  "_cmd": "de v 1, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 1, wa w 1 1`] = `
+{
+  "_cmd": "de v 1, wa w 1",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa w 2 1`] = `
+{
+  "_cmd": "de v 1, wa w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, wa w 3 1`] = `
+{
+  "_cmd": "de v 1, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa w 4 1`] = `
+{
+  "_cmd": "de v 1, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa w 5 1`] = `
+{
+  "_cmd": "de v 1, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa w 6 1`] = `
+{
+  "_cmd": "de v 1, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa w 7 1`] = `
+{
+  "_cmd": "de v 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa w 8 1`] = `
+{
+  "_cmd": "de v 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa w 9 1`] = `
+{
+  "_cmd": "de v 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa w 10 1`] = `
+{
+  "_cmd": "de v 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa w v 1 1`] = `
+{
+  "_cmd": "de v 1, wa w v 1",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 1, wa w v 2 1`] = `
+{
+  "_cmd": "de v 1, wa w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 1, wa w v 3 1`] = `
+{
+  "_cmd": "de v 1, wa w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 1, wa w v 4 1`] = `
+{
+  "_cmd": "de v 1, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 1, wa w v 5 1`] = `
+{
+  "_cmd": "de v 1, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 1, wa w v 6 1`] = `
+{
+  "_cmd": "de v 1, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 1, wa w v 7 1`] = `
+{
+  "_cmd": "de v 1, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 1, wa w v 8 1`] = `
+{
+  "_cmd": "de v 1, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 1, wa w v 9 1`] = `
+{
+  "_cmd": "de v 1, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 1, wa w v 10 1`] = `
+{
+  "_cmd": "de v 1, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 1, wa w v 11 1`] = `
+{
+  "_cmd": "de v 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 1, wa w v 12 1`] = `
+{
+  "_cmd": "de v 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 1, wa w v 13 1`] = `
+{
+  "_cmd": "de v 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 1, wa w v 14 1`] = `
+{
+  "_cmd": "de v 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 1, wa w v 15 1`] = `
+{
+  "_cmd": "de v 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, wa d 1 1`] = `
+{
+  "_cmd": "de v 2, wa d 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, wa d 2 1`] = `
+{
+  "_cmd": "de v 2, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, wa d 3 1`] = `
+{
+  "_cmd": "de v 2, wa d 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa d 4 1`] = `
+{
+  "_cmd": "de v 2, wa d 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa d 5 1`] = `
+{
+  "_cmd": "de v 2, wa d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa d 6 1`] = `
+{
+  "_cmd": "de v 2, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa d 7 1`] = `
+{
+  "_cmd": "de v 2, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa d 8 1`] = `
+{
+  "_cmd": "de v 2, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa d 9 1`] = `
+{
+  "_cmd": "de v 2, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa d 10 1`] = `
+{
+  "_cmd": "de v 2, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa d v 1 1`] = `
+{
+  "_cmd": "de v 2, wa d v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, wa d v 2 1`] = `
+{
+  "_cmd": "de v 2, wa d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, wa d v 3 1`] = `
+{
+  "_cmd": "de v 2, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa d v 4 1`] = `
+{
+  "_cmd": "de v 2, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa d v 5 1`] = `
+{
+  "_cmd": "de v 2, wa d v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa d v 6 1`] = `
+{
+  "_cmd": "de v 2, wa d v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa d v 7 1`] = `
+{
+  "_cmd": "de v 2, wa d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa d v 8 1`] = `
+{
+  "_cmd": "de v 2, wa d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa d v 9 1`] = `
+{
+  "_cmd": "de v 2, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa d v 10 1`] = `
+{
+  "_cmd": "de v 2, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa d v 11 1`] = `
+{
+  "_cmd": "de v 2, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, wa d v 12 1`] = `
+{
+  "_cmd": "de v 2, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, wa d v 13 1`] = `
+{
+  "_cmd": "de v 2, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, wa d v 14 1`] = `
+{
+  "_cmd": "de v 2, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, wa d v 15 1`] = `
+{
+  "_cmd": "de v 2, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, wa p 1 1`] = `
+{
+  "_cmd": "de v 2, wa p 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, wa p 2 1`] = `
+{
+  "_cmd": "de v 2, wa p 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, wa p 3 1`] = `
+{
+  "_cmd": "de v 2, wa p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa p 4 1`] = `
+{
+  "_cmd": "de v 2, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa p 5 1`] = `
+{
+  "_cmd": "de v 2, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa p 6 1`] = `
+{
+  "_cmd": "de v 2, wa p 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa p 7 1`] = `
+{
+  "_cmd": "de v 2, wa p 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa p 8 1`] = `
+{
+  "_cmd": "de v 2, wa p 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa p 9 1`] = `
+{
+  "_cmd": "de v 2, wa p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa p 10 1`] = `
+{
+  "_cmd": "de v 2, wa p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa p v 1 1`] = `
+{
+  "_cmd": "de v 2, wa p v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, wa p v 2 1`] = `
+{
+  "_cmd": "de v 2, wa p v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, wa p v 3 1`] = `
+{
+  "_cmd": "de v 2, wa p v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa p v 4 1`] = `
+{
+  "_cmd": "de v 2, wa p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa p v 5 1`] = `
+{
+  "_cmd": "de v 2, wa p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa p v 6 1`] = `
+{
+  "_cmd": "de v 2, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa p v 7 1`] = `
+{
+  "_cmd": "de v 2, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa p v 8 1`] = `
+{
+  "_cmd": "de v 2, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa p v 9 1`] = `
+{
+  "_cmd": "de v 2, wa p v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa p v 10 1`] = `
+{
+  "_cmd": "de v 2, wa p v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa p v 11 1`] = `
+{
+  "_cmd": "de v 2, wa p v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, wa p v 12 1`] = `
+{
+  "_cmd": "de v 2, wa p v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, wa p v 13 1`] = `
+{
+  "_cmd": "de v 2, wa p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, wa p v 14 1`] = `
+{
+  "_cmd": "de v 2, wa p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, wa p v 15 1`] = `
+{
+  "_cmd": "de v 2, wa p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, wa v 1 1`] = `
+{
+  "_cmd": "de v 2, wa v 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`de v 2, wa v 2 1`] = `
+{
+  "_cmd": "de v 2, wa v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 2, wa v 3 1`] = `
+{
+  "_cmd": "de v 2, wa v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa v 4 1`] = `
+{
+  "_cmd": "de v 2, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa v 5 1`] = `
+{
+  "_cmd": "de v 2, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa v 6 1`] = `
+{
+  "_cmd": "de v 2, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa v 7 1`] = `
+{
+  "_cmd": "de v 2, wa v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa v 8 1`] = `
+{
+  "_cmd": "de v 2, wa v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa v 9 1`] = `
+{
+  "_cmd": "de v 2, wa v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa v 10 1`] = `
+{
+  "_cmd": "de v 2, wa v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa v 11 1`] = `
+{
+  "_cmd": "de v 2, wa v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, wa v 12 1`] = `
+{
+  "_cmd": "de v 2, wa v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, wa v 13 1`] = `
+{
+  "_cmd": "de v 2, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, wa v 14 1`] = `
+{
+  "_cmd": "de v 2, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, wa v 15 1`] = `
+{
+  "_cmd": "de v 2, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 2, wa w 1 1`] = `
+{
+  "_cmd": "de v 2, wa w 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, wa w 2 1`] = `
+{
+  "_cmd": "de v 2, wa w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa w 3 1`] = `
+{
+  "_cmd": "de v 2, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa w 4 1`] = `
+{
+  "_cmd": "de v 2, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa w 5 1`] = `
+{
+  "_cmd": "de v 2, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa w 6 1`] = `
+{
+  "_cmd": "de v 2, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa w 7 1`] = `
+{
+  "_cmd": "de v 2, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa w 8 1`] = `
+{
+  "_cmd": "de v 2, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa w 9 1`] = `
+{
+  "_cmd": "de v 2, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa w 10 1`] = `
+{
+  "_cmd": "de v 2, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa w v 1 1`] = `
+{
+  "_cmd": "de v 2, wa w v 1",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`de v 2, wa w v 2 1`] = `
+{
+  "_cmd": "de v 2, wa w v 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 2, wa w v 3 1`] = `
+{
+  "_cmd": "de v 2, wa w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 2, wa w v 4 1`] = `
+{
+  "_cmd": "de v 2, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 2, wa w v 5 1`] = `
+{
+  "_cmd": "de v 2, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 2, wa w v 6 1`] = `
+{
+  "_cmd": "de v 2, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 2, wa w v 7 1`] = `
+{
+  "_cmd": "de v 2, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 2, wa w v 8 1`] = `
+{
+  "_cmd": "de v 2, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 2, wa w v 9 1`] = `
+{
+  "_cmd": "de v 2, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 2, wa w v 10 1`] = `
+{
+  "_cmd": "de v 2, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 2, wa w v 11 1`] = `
+{
+  "_cmd": "de v 2, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 2, wa w v 12 1`] = `
+{
+  "_cmd": "de v 2, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 2, wa w v 13 1`] = `
+{
+  "_cmd": "de v 2, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 2, wa w v 14 1`] = `
+{
+  "_cmd": "de v 2, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 2, wa w v 15 1`] = `
+{
+  "_cmd": "de v 2, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, wa d 1 1`] = `
+{
+  "_cmd": "de v 3, wa d 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, wa d 2 1`] = `
+{
+  "_cmd": "de v 3, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, wa d 3 1`] = `
+{
+  "_cmd": "de v 3, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, wa d 4 1`] = `
+{
+  "_cmd": "de v 3, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa d 5 1`] = `
+{
+  "_cmd": "de v 3, wa d 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa d 6 1`] = `
+{
+  "_cmd": "de v 3, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa d 7 1`] = `
+{
+  "_cmd": "de v 3, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa d 8 1`] = `
+{
+  "_cmd": "de v 3, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa d 9 1`] = `
+{
+  "_cmd": "de v 3, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa d 10 1`] = `
+{
+  "_cmd": "de v 3, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa d v 1 1`] = `
+{
+  "_cmd": "de v 3, wa d v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, wa d v 2 1`] = `
+{
+  "_cmd": "de v 3, wa d v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, wa d v 3 1`] = `
+{
+  "_cmd": "de v 3, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, wa d v 4 1`] = `
+{
+  "_cmd": "de v 3, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa d v 5 1`] = `
+{
+  "_cmd": "de v 3, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa d v 6 1`] = `
+{
+  "_cmd": "de v 3, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa d v 7 1`] = `
+{
+  "_cmd": "de v 3, wa d v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa d v 8 1`] = `
+{
+  "_cmd": "de v 3, wa d v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa d v 9 1`] = `
+{
+  "_cmd": "de v 3, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa d v 10 1`] = `
+{
+  "_cmd": "de v 3, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa d v 11 1`] = `
+{
+  "_cmd": "de v 3, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, wa d v 12 1`] = `
+{
+  "_cmd": "de v 3, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, wa d v 13 1`] = `
+{
+  "_cmd": "de v 3, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, wa d v 14 1`] = `
+{
+  "_cmd": "de v 3, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, wa d v 15 1`] = `
+{
+  "_cmd": "de v 3, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, wa p 1 1`] = `
+{
+  "_cmd": "de v 3, wa p 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, wa p 2 1`] = `
+{
+  "_cmd": "de v 3, wa p 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, wa p 3 1`] = `
+{
+  "_cmd": "de v 3, wa p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, wa p 4 1`] = `
+{
+  "_cmd": "de v 3, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa p 5 1`] = `
+{
+  "_cmd": "de v 3, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa p 6 1`] = `
+{
+  "_cmd": "de v 3, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa p 7 1`] = `
+{
+  "_cmd": "de v 3, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa p 8 1`] = `
+{
+  "_cmd": "de v 3, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa p 9 1`] = `
+{
+  "_cmd": "de v 3, wa p 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa p 10 1`] = `
+{
+  "_cmd": "de v 3, wa p 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa p v 1 1`] = `
+{
+  "_cmd": "de v 3, wa p v 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`de v 3, wa p v 2 1`] = `
+{
+  "_cmd": "de v 3, wa p v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, wa p v 3 1`] = `
+{
+  "_cmd": "de v 3, wa p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, wa p v 4 1`] = `
+{
+  "_cmd": "de v 3, wa p v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa p v 5 1`] = `
+{
+  "_cmd": "de v 3, wa p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa p v 6 1`] = `
+{
+  "_cmd": "de v 3, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa p v 7 1`] = `
+{
+  "_cmd": "de v 3, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa p v 8 1`] = `
+{
+  "_cmd": "de v 3, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa p v 9 1`] = `
+{
+  "_cmd": "de v 3, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa p v 10 1`] = `
+{
+  "_cmd": "de v 3, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa p v 11 1`] = `
+{
+  "_cmd": "de v 3, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa p v 12 1`] = `
+{
+  "_cmd": "de v 3, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, wa p v 13 1`] = `
+{
+  "_cmd": "de v 3, wa p v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, wa p v 14 1`] = `
+{
+  "_cmd": "de v 3, wa p v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, wa p v 15 1`] = `
+{
+  "_cmd": "de v 3, wa p v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, wa v 1 1`] = `
+{
+  "_cmd": "de v 3, wa v 1",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`de v 3, wa v 2 1`] = `
+{
+  "_cmd": "de v 3, wa v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, wa v 3 1`] = `
+{
+  "_cmd": "de v 3, wa v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, wa v 4 1`] = `
+{
+  "_cmd": "de v 3, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa v 5 1`] = `
+{
+  "_cmd": "de v 3, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa v 6 1`] = `
+{
+  "_cmd": "de v 3, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa v 7 1`] = `
+{
+  "_cmd": "de v 3, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa v 8 1`] = `
+{
+  "_cmd": "de v 3, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa v 9 1`] = `
+{
+  "_cmd": "de v 3, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa v 10 1`] = `
+{
+  "_cmd": "de v 3, wa v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa v 11 1`] = `
+{
+  "_cmd": "de v 3, wa v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, wa v 12 1`] = `
+{
+  "_cmd": "de v 3, wa v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, wa v 13 1`] = `
+{
+  "_cmd": "de v 3, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, wa v 14 1`] = `
+{
+  "_cmd": "de v 3, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, wa v 15 1`] = `
+{
+  "_cmd": "de v 3, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 3, wa w 1 1`] = `
+{
+  "_cmd": "de v 3, wa w 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, wa w 2 1`] = `
+{
+  "_cmd": "de v 3, wa w 2",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 3, wa w 3 1`] = `
+{
+  "_cmd": "de v 3, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa w 4 1`] = `
+{
+  "_cmd": "de v 3, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa w 5 1`] = `
+{
+  "_cmd": "de v 3, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa w 6 1`] = `
+{
+  "_cmd": "de v 3, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa w 7 1`] = `
+{
+  "_cmd": "de v 3, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa w 8 1`] = `
+{
+  "_cmd": "de v 3, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa w 9 1`] = `
+{
+  "_cmd": "de v 3, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa w 10 1`] = `
+{
+  "_cmd": "de v 3, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa w v 1 1`] = `
+{
+  "_cmd": "de v 3, wa w v 1",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`de v 3, wa w v 2 1`] = `
+{
+  "_cmd": "de v 3, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 3, wa w v 3 1`] = `
+{
+  "_cmd": "de v 3, wa w v 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 3, wa w v 4 1`] = `
+{
+  "_cmd": "de v 3, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 3, wa w v 5 1`] = `
+{
+  "_cmd": "de v 3, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 3, wa w v 6 1`] = `
+{
+  "_cmd": "de v 3, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 3, wa w v 7 1`] = `
+{
+  "_cmd": "de v 3, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 3, wa w v 8 1`] = `
+{
+  "_cmd": "de v 3, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 3, wa w v 9 1`] = `
+{
+  "_cmd": "de v 3, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 3, wa w v 10 1`] = `
+{
+  "_cmd": "de v 3, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 3, wa w v 11 1`] = `
+{
+  "_cmd": "de v 3, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 3, wa w v 12 1`] = `
+{
+  "_cmd": "de v 3, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 3, wa w v 13 1`] = `
+{
+  "_cmd": "de v 3, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 3, wa w v 14 1`] = `
+{
+  "_cmd": "de v 3, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 3, wa w v 15 1`] = `
+{
+  "_cmd": "de v 3, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, wa d 1 1`] = `
+{
+  "_cmd": "de v 4, wa d 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de v 4, wa d 2 1`] = `
+{
+  "_cmd": "de v 4, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, wa d 3 1`] = `
+{
+  "_cmd": "de v 4, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, wa d 4 1`] = `
+{
+  "_cmd": "de v 4, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, wa d 5 1`] = `
+{
+  "_cmd": "de v 4, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa d 6 1`] = `
+{
+  "_cmd": "de v 4, wa d 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa d 7 1`] = `
+{
+  "_cmd": "de v 4, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa d 8 1`] = `
+{
+  "_cmd": "de v 4, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa d 9 1`] = `
+{
+  "_cmd": "de v 4, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa d 10 1`] = `
+{
+  "_cmd": "de v 4, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa d v 1 1`] = `
+{
+  "_cmd": "de v 4, wa d v 1",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`de v 4, wa d v 2 1`] = `
+{
+  "_cmd": "de v 4, wa d v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa d v 3 1`] = `
+{
+  "_cmd": "de v 4, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, wa d v 4 1`] = `
+{
+  "_cmd": "de v 4, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, wa d v 5 1`] = `
+{
+  "_cmd": "de v 4, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa d v 6 1`] = `
+{
+  "_cmd": "de v 4, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa d v 7 1`] = `
+{
+  "_cmd": "de v 4, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa d v 8 1`] = `
+{
+  "_cmd": "de v 4, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa d v 9 1`] = `
+{
+  "_cmd": "de v 4, wa d v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa d v 10 1`] = `
+{
+  "_cmd": "de v 4, wa d v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa d v 11 1`] = `
+{
+  "_cmd": "de v 4, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, wa d v 12 1`] = `
+{
+  "_cmd": "de v 4, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, wa d v 13 1`] = `
+{
+  "_cmd": "de v 4, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, wa d v 14 1`] = `
+{
+  "_cmd": "de v 4, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, wa d v 15 1`] = `
+{
+  "_cmd": "de v 4, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, wa p 1 1`] = `
+{
+  "_cmd": "de v 4, wa p 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, wa p 2 1`] = `
+{
+  "_cmd": "de v 4, wa p 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa p 3 1`] = `
+{
+  "_cmd": "de v 4, wa p 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, wa p 4 1`] = `
+{
+  "_cmd": "de v 4, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, wa p 5 1`] = `
+{
+  "_cmd": "de v 4, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa p 6 1`] = `
+{
+  "_cmd": "de v 4, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa p 7 1`] = `
+{
+  "_cmd": "de v 4, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa p 8 1`] = `
+{
+  "_cmd": "de v 4, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa p 9 1`] = `
+{
+  "_cmd": "de v 4, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa p 10 1`] = `
+{
+  "_cmd": "de v 4, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa p v 1 1`] = `
+{
+  "_cmd": "de v 4, wa p v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, wa p v 2 1`] = `
+{
+  "_cmd": "de v 4, wa p v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa p v 3 1`] = `
+{
+  "_cmd": "de v 4, wa p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, wa p v 4 1`] = `
+{
+  "_cmd": "de v 4, wa p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, wa p v 5 1`] = `
+{
+  "_cmd": "de v 4, wa p v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa p v 6 1`] = `
+{
+  "_cmd": "de v 4, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa p v 7 1`] = `
+{
+  "_cmd": "de v 4, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa p v 8 1`] = `
+{
+  "_cmd": "de v 4, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa p v 9 1`] = `
+{
+  "_cmd": "de v 4, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa p v 10 1`] = `
+{
+  "_cmd": "de v 4, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa p v 11 1`] = `
+{
+  "_cmd": "de v 4, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa p v 12 1`] = `
+{
+  "_cmd": "de v 4, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, wa p v 13 1`] = `
+{
+  "_cmd": "de v 4, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, wa p v 14 1`] = `
+{
+  "_cmd": "de v 4, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, wa p v 15 1`] = `
+{
+  "_cmd": "de v 4, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, wa v 1 1`] = `
+{
+  "_cmd": "de v 4, wa v 1",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`de v 4, wa v 2 1`] = `
+{
+  "_cmd": "de v 4, wa v 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa v 3 1`] = `
+{
+  "_cmd": "de v 4, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, wa v 4 1`] = `
+{
+  "_cmd": "de v 4, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, wa v 5 1`] = `
+{
+  "_cmd": "de v 4, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa v 6 1`] = `
+{
+  "_cmd": "de v 4, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa v 7 1`] = `
+{
+  "_cmd": "de v 4, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa v 8 1`] = `
+{
+  "_cmd": "de v 4, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa v 9 1`] = `
+{
+  "_cmd": "de v 4, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa v 10 1`] = `
+{
+  "_cmd": "de v 4, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa v 11 1`] = `
+{
+  "_cmd": "de v 4, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa v 12 1`] = `
+{
+  "_cmd": "de v 4, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, wa v 13 1`] = `
+{
+  "_cmd": "de v 4, wa v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, wa v 14 1`] = `
+{
+  "_cmd": "de v 4, wa v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, wa v 15 1`] = `
+{
+  "_cmd": "de v 4, wa v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 4, wa w 1 1`] = `
+{
+  "_cmd": "de v 4, wa w 1",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa w 2 1`] = `
+{
+  "_cmd": "de v 4, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, wa w 3 1`] = `
+{
+  "_cmd": "de v 4, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 4, wa w 4 1`] = `
+{
+  "_cmd": "de v 4, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa w 5 1`] = `
+{
+  "_cmd": "de v 4, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa w 6 1`] = `
+{
+  "_cmd": "de v 4, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa w 7 1`] = `
+{
+  "_cmd": "de v 4, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa w 8 1`] = `
+{
+  "_cmd": "de v 4, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa w 9 1`] = `
+{
+  "_cmd": "de v 4, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa w 10 1`] = `
+{
+  "_cmd": "de v 4, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa w v 1 1`] = `
+{
+  "_cmd": "de v 4, wa w v 1",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`de v 4, wa w v 2 1`] = `
+{
+  "_cmd": "de v 4, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 4, wa w v 3 1`] = `
+{
+  "_cmd": "de v 4, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 4, wa w v 4 1`] = `
+{
+  "_cmd": "de v 4, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 4, wa w v 5 1`] = `
+{
+  "_cmd": "de v 4, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 4, wa w v 6 1`] = `
+{
+  "_cmd": "de v 4, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 4, wa w v 7 1`] = `
+{
+  "_cmd": "de v 4, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 4, wa w v 8 1`] = `
+{
+  "_cmd": "de v 4, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 4, wa w v 9 1`] = `
+{
+  "_cmd": "de v 4, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 4, wa w v 10 1`] = `
+{
+  "_cmd": "de v 4, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 4, wa w v 11 1`] = `
+{
+  "_cmd": "de v 4, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 4, wa w v 12 1`] = `
+{
+  "_cmd": "de v 4, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 4, wa w v 13 1`] = `
+{
+  "_cmd": "de v 4, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 4, wa w v 14 1`] = `
+{
+  "_cmd": "de v 4, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 4, wa w v 15 1`] = `
+{
+  "_cmd": "de v 4, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, wa d 1 1`] = `
+{
+  "_cmd": "de v 5, wa d 1",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de v 5, wa d 2 1`] = `
+{
+  "_cmd": "de v 5, wa d 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa d 3 1`] = `
+{
+  "_cmd": "de v 5, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, wa d 4 1`] = `
+{
+  "_cmd": "de v 5, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa d 5 1`] = `
+{
+  "_cmd": "de v 5, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa d 6 1`] = `
+{
+  "_cmd": "de v 5, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa d 7 1`] = `
+{
+  "_cmd": "de v 5, wa d 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa d 8 1`] = `
+{
+  "_cmd": "de v 5, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa d 9 1`] = `
+{
+  "_cmd": "de v 5, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa d 10 1`] = `
+{
+  "_cmd": "de v 5, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, wa d v 1 1`] = `
+{
+  "_cmd": "de v 5, wa d v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, wa d v 2 1`] = `
+{
+  "_cmd": "de v 5, wa d v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, wa d v 3 1`] = `
+{
+  "_cmd": "de v 5, wa d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, wa d v 4 1`] = `
+{
+  "_cmd": "de v 5, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa d v 5 1`] = `
+{
+  "_cmd": "de v 5, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa d v 6 1`] = `
+{
+  "_cmd": "de v 5, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa d v 7 1`] = `
+{
+  "_cmd": "de v 5, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa d v 8 1`] = `
+{
+  "_cmd": "de v 5, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa d v 9 1`] = `
+{
+  "_cmd": "de v 5, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa d v 10 1`] = `
+{
+  "_cmd": "de v 5, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa d v 11 1`] = `
+{
+  "_cmd": "de v 5, wa d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, wa d v 12 1`] = `
+{
+  "_cmd": "de v 5, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, wa d v 13 1`] = `
+{
+  "_cmd": "de v 5, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, wa d v 14 1`] = `
+{
+  "_cmd": "de v 5, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, wa d v 15 1`] = `
+{
+  "_cmd": "de v 5, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 5, wa p 1 1`] = `
+{
+  "_cmd": "de v 5, wa p 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, wa p 2 1`] = `
+{
+  "_cmd": "de v 5, wa p 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, wa p 3 1`] = `
+{
+  "_cmd": "de v 5, wa p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa p 4 1`] = `
+{
+  "_cmd": "de v 5, wa p 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa p 5 1`] = `
+{
+  "_cmd": "de v 5, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa p 6 1`] = `
+{
+  "_cmd": "de v 5, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa p 7 1`] = `
+{
+  "_cmd": "de v 5, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa p 8 1`] = `
+{
+  "_cmd": "de v 5, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa p 9 1`] = `
+{
+  "_cmd": "de v 5, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa p 10 1`] = `
+{
+  "_cmd": "de v 5, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa p v 1 1`] = `
+{
+  "_cmd": "de v 5, wa p v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, wa p v 2 1`] = `
+{
+  "_cmd": "de v 5, wa p v 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`de v 5, wa p v 3 1`] = `
+{
+  "_cmd": "de v 5, wa p v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa p v 4 1`] = `
+{
+  "_cmd": "de v 5, wa p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, wa p v 5 1`] = `
+{
+  "_cmd": "de v 5, wa p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa p v 6 1`] = `
+{
+  "_cmd": "de v 5, wa p v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa p v 7 1`] = `
+{
+  "_cmd": "de v 5, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa p v 8 1`] = `
+{
+  "_cmd": "de v 5, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa p v 9 1`] = `
+{
+  "_cmd": "de v 5, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa p v 10 1`] = `
+{
+  "_cmd": "de v 5, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa p v 11 1`] = `
+{
+  "_cmd": "de v 5, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, wa p v 12 1`] = `
+{
+  "_cmd": "de v 5, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, wa p v 13 1`] = `
+{
+  "_cmd": "de v 5, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, wa p v 14 1`] = `
+{
+  "_cmd": "de v 5, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, wa p v 15 1`] = `
+{
+  "_cmd": "de v 5, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, wa v 1 1`] = `
+{
+  "_cmd": "de v 5, wa v 1",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`de v 5, wa v 2 1`] = `
+{
+  "_cmd": "de v 5, wa v 2",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, wa v 3 1`] = `
+{
+  "_cmd": "de v 5, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa v 4 1`] = `
+{
+  "_cmd": "de v 5, wa v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa v 5 1`] = `
+{
+  "_cmd": "de v 5, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa v 6 1`] = `
+{
+  "_cmd": "de v 5, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa v 7 1`] = `
+{
+  "_cmd": "de v 5, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa v 8 1`] = `
+{
+  "_cmd": "de v 5, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa v 9 1`] = `
+{
+  "_cmd": "de v 5, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa v 10 1`] = `
+{
+  "_cmd": "de v 5, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa v 11 1`] = `
+{
+  "_cmd": "de v 5, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, wa v 12 1`] = `
+{
+  "_cmd": "de v 5, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, wa v 13 1`] = `
+{
+  "_cmd": "de v 5, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, wa v 14 1`] = `
+{
+  "_cmd": "de v 5, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, wa v 15 1`] = `
+{
+  "_cmd": "de v 5, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, wa w 1 1`] = `
+{
+  "_cmd": "de v 5, wa w 1",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, wa w 2 1`] = `
+{
+  "_cmd": "de v 5, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa w 3 1`] = `
+{
+  "_cmd": "de v 5, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 5, wa w 4 1`] = `
+{
+  "_cmd": "de v 5, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa w 5 1`] = `
+{
+  "_cmd": "de v 5, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa w 6 1`] = `
+{
+  "_cmd": "de v 5, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa w 7 1`] = `
+{
+  "_cmd": "de v 5, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa w 8 1`] = `
+{
+  "_cmd": "de v 5, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa w 9 1`] = `
+{
+  "_cmd": "de v 5, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa w 10 1`] = `
+{
+  "_cmd": "de v 5, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, wa w v 1 1`] = `
+{
+  "_cmd": "de v 5, wa w v 1",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`de v 5, wa w v 2 1`] = `
+{
+  "_cmd": "de v 5, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 5, wa w v 3 1`] = `
+{
+  "_cmd": "de v 5, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 5, wa w v 4 1`] = `
+{
+  "_cmd": "de v 5, wa w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 5, wa w v 5 1`] = `
+{
+  "_cmd": "de v 5, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 5, wa w v 6 1`] = `
+{
+  "_cmd": "de v 5, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 5, wa w v 7 1`] = `
+{
+  "_cmd": "de v 5, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 5, wa w v 8 1`] = `
+{
+  "_cmd": "de v 5, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 5, wa w v 9 1`] = `
+{
+  "_cmd": "de v 5, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 5, wa w v 10 1`] = `
+{
+  "_cmd": "de v 5, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 5, wa w v 11 1`] = `
+{
+  "_cmd": "de v 5, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 5, wa w v 12 1`] = `
+{
+  "_cmd": "de v 5, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 5, wa w v 13 1`] = `
+{
+  "_cmd": "de v 5, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 5, wa w v 14 1`] = `
+{
+  "_cmd": "de v 5, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 5, wa w v 15 1`] = `
+{
+  "_cmd": "de v 5, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, wa d 1 1`] = `
+{
+  "_cmd": "de v 6, wa d 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, wa d 2 1`] = `
+{
+  "_cmd": "de v 6, wa d 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, wa d 3 1`] = `
+{
+  "_cmd": "de v 6, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa d 4 1`] = `
+{
+  "_cmd": "de v 6, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, wa d 5 1`] = `
+{
+  "_cmd": "de v 6, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa d 6 1`] = `
+{
+  "_cmd": "de v 6, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa d 7 1`] = `
+{
+  "_cmd": "de v 6, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa d 8 1`] = `
+{
+  "_cmd": "de v 6, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa d 9 1`] = `
+{
+  "_cmd": "de v 6, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa d 10 1`] = `
+{
+  "_cmd": "de v 6, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa d v 1 1`] = `
+{
+  "_cmd": "de v 6, wa d v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, wa d v 2 1`] = `
+{
+  "_cmd": "de v 6, wa d v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, wa d v 3 1`] = `
+{
+  "_cmd": "de v 6, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa d v 4 1`] = `
+{
+  "_cmd": "de v 6, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, wa d v 5 1`] = `
+{
+  "_cmd": "de v 6, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa d v 6 1`] = `
+{
+  "_cmd": "de v 6, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa d v 7 1`] = `
+{
+  "_cmd": "de v 6, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa d v 8 1`] = `
+{
+  "_cmd": "de v 6, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa d v 9 1`] = `
+{
+  "_cmd": "de v 6, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa d v 10 1`] = `
+{
+  "_cmd": "de v 6, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa d v 11 1`] = `
+{
+  "_cmd": "de v 6, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa d v 12 1`] = `
+{
+  "_cmd": "de v 6, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, wa d v 13 1`] = `
+{
+  "_cmd": "de v 6, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, wa d v 14 1`] = `
+{
+  "_cmd": "de v 6, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, wa d v 15 1`] = `
+{
+  "_cmd": "de v 6, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 6, wa p 1 1`] = `
+{
+  "_cmd": "de v 6, wa p 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, wa p 2 1`] = `
+{
+  "_cmd": "de v 6, wa p 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, wa p 3 1`] = `
+{
+  "_cmd": "de v 6, wa p 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa p 4 1`] = `
+{
+  "_cmd": "de v 6, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa p 5 1`] = `
+{
+  "_cmd": "de v 6, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa p 6 1`] = `
+{
+  "_cmd": "de v 6, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa p 7 1`] = `
+{
+  "_cmd": "de v 6, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa p 8 1`] = `
+{
+  "_cmd": "de v 6, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa p 9 1`] = `
+{
+  "_cmd": "de v 6, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa p 10 1`] = `
+{
+  "_cmd": "de v 6, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa p v 1 1`] = `
+{
+  "_cmd": "de v 6, wa p v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, wa p v 2 1`] = `
+{
+  "_cmd": "de v 6, wa p v 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, wa p v 3 1`] = `
+{
+  "_cmd": "de v 6, wa p v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa p v 4 1`] = `
+{
+  "_cmd": "de v 6, wa p v 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa p v 5 1`] = `
+{
+  "_cmd": "de v 6, wa p v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, wa p v 6 1`] = `
+{
+  "_cmd": "de v 6, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa p v 7 1`] = `
+{
+  "_cmd": "de v 6, wa p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa p v 8 1`] = `
+{
+  "_cmd": "de v 6, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa p v 9 1`] = `
+{
+  "_cmd": "de v 6, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa p v 10 1`] = `
+{
+  "_cmd": "de v 6, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa p v 11 1`] = `
+{
+  "_cmd": "de v 6, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa p v 12 1`] = `
+{
+  "_cmd": "de v 6, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, wa p v 13 1`] = `
+{
+  "_cmd": "de v 6, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, wa p v 14 1`] = `
+{
+  "_cmd": "de v 6, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, wa p v 15 1`] = `
+{
+  "_cmd": "de v 6, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, wa v 1 1`] = `
+{
+  "_cmd": "de v 6, wa v 1",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`de v 6, wa v 2 1`] = `
+{
+  "_cmd": "de v 6, wa v 2",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, wa v 3 1`] = `
+{
+  "_cmd": "de v 6, wa v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa v 4 1`] = `
+{
+  "_cmd": "de v 6, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa v 5 1`] = `
+{
+  "_cmd": "de v 6, wa v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa v 6 1`] = `
+{
+  "_cmd": "de v 6, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa v 7 1`] = `
+{
+  "_cmd": "de v 6, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa v 8 1`] = `
+{
+  "_cmd": "de v 6, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa v 9 1`] = `
+{
+  "_cmd": "de v 6, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa v 10 1`] = `
+{
+  "_cmd": "de v 6, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa v 11 1`] = `
+{
+  "_cmd": "de v 6, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa v 12 1`] = `
+{
+  "_cmd": "de v 6, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, wa v 13 1`] = `
+{
+  "_cmd": "de v 6, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, wa v 14 1`] = `
+{
+  "_cmd": "de v 6, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, wa v 15 1`] = `
+{
+  "_cmd": "de v 6, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, wa w 1 1`] = `
+{
+  "_cmd": "de v 6, wa w 1",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`de v 6, wa w 2 1`] = `
+{
+  "_cmd": "de v 6, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa w 3 1`] = `
+{
+  "_cmd": "de v 6, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa w 4 1`] = `
+{
+  "_cmd": "de v 6, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 6, wa w 5 1`] = `
+{
+  "_cmd": "de v 6, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa w 6 1`] = `
+{
+  "_cmd": "de v 6, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa w 7 1`] = `
+{
+  "_cmd": "de v 6, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa w 8 1`] = `
+{
+  "_cmd": "de v 6, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa w 9 1`] = `
+{
+  "_cmd": "de v 6, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa w 10 1`] = `
+{
+  "_cmd": "de v 6, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa w v 1 1`] = `
+{
+  "_cmd": "de v 6, wa w v 1",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`de v 6, wa w v 2 1`] = `
+{
+  "_cmd": "de v 6, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 6, wa w v 3 1`] = `
+{
+  "_cmd": "de v 6, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 6, wa w v 4 1`] = `
+{
+  "_cmd": "de v 6, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 6, wa w v 5 1`] = `
+{
+  "_cmd": "de v 6, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 6, wa w v 6 1`] = `
+{
+  "_cmd": "de v 6, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 6, wa w v 7 1`] = `
+{
+  "_cmd": "de v 6, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 6, wa w v 8 1`] = `
+{
+  "_cmd": "de v 6, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 6, wa w v 9 1`] = `
+{
+  "_cmd": "de v 6, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 6, wa w v 10 1`] = `
+{
+  "_cmd": "de v 6, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 6, wa w v 11 1`] = `
+{
+  "_cmd": "de v 6, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 6, wa w v 12 1`] = `
+{
+  "_cmd": "de v 6, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 6, wa w v 13 1`] = `
+{
+  "_cmd": "de v 6, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 6, wa w v 14 1`] = `
+{
+  "_cmd": "de v 6, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 6, wa w v 15 1`] = `
+{
+  "_cmd": "de v 6, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, wa d 1 1`] = `
+{
+  "_cmd": "de v 7, wa d 1",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, wa d 2 1`] = `
+{
+  "_cmd": "de v 7, wa d 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, wa d 3 1`] = `
+{
+  "_cmd": "de v 7, wa d 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa d 4 1`] = `
+{
+  "_cmd": "de v 7, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa d 5 1`] = `
+{
+  "_cmd": "de v 7, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, wa d 6 1`] = `
+{
+  "_cmd": "de v 7, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa d 7 1`] = `
+{
+  "_cmd": "de v 7, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa d 8 1`] = `
+{
+  "_cmd": "de v 7, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa d 9 1`] = `
+{
+  "_cmd": "de v 7, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa d 10 1`] = `
+{
+  "_cmd": "de v 7, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa d v 1 1`] = `
+{
+  "_cmd": "de v 7, wa d v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, wa d v 2 1`] = `
+{
+  "_cmd": "de v 7, wa d v 2",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, wa d v 3 1`] = `
+{
+  "_cmd": "de v 7, wa d v 3",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, wa d v 4 1`] = `
+{
+  "_cmd": "de v 7, wa d v 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa d v 5 1`] = `
+{
+  "_cmd": "de v 7, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, wa d v 6 1`] = `
+{
+  "_cmd": "de v 7, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa d v 7 1`] = `
+{
+  "_cmd": "de v 7, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa d v 8 1`] = `
+{
+  "_cmd": "de v 7, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa d v 9 1`] = `
+{
+  "_cmd": "de v 7, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa d v 10 1`] = `
+{
+  "_cmd": "de v 7, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa d v 11 1`] = `
+{
+  "_cmd": "de v 7, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa d v 12 1`] = `
+{
+  "_cmd": "de v 7, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, wa d v 13 1`] = `
+{
+  "_cmd": "de v 7, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, wa d v 14 1`] = `
+{
+  "_cmd": "de v 7, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, wa d v 15 1`] = `
+{
+  "_cmd": "de v 7, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 7, wa p 1 1`] = `
+{
+  "_cmd": "de v 7, wa p 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, wa p 2 1`] = `
+{
+  "_cmd": "de v 7, wa p 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, wa p 3 1`] = `
+{
+  "_cmd": "de v 7, wa p 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, wa p 4 1`] = `
+{
+  "_cmd": "de v 7, wa p 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa p 5 1`] = `
+{
+  "_cmd": "de v 7, wa p 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa p 6 1`] = `
+{
+  "_cmd": "de v 7, wa p 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa p 7 1`] = `
+{
+  "_cmd": "de v 7, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa p 8 1`] = `
+{
+  "_cmd": "de v 7, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa p 9 1`] = `
+{
+  "_cmd": "de v 7, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa p 10 1`] = `
+{
+  "_cmd": "de v 7, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa p v 1 1`] = `
+{
+  "_cmd": "de v 7, wa p v 1",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`de v 7, wa p v 2 1`] = `
+{
+  "_cmd": "de v 7, wa p v 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, wa p v 3 1`] = `
+{
+  "_cmd": "de v 7, wa p v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, wa p v 4 1`] = `
+{
+  "_cmd": "de v 7, wa p v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa p v 5 1`] = `
+{
+  "_cmd": "de v 7, wa p v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa p v 6 1`] = `
+{
+  "_cmd": "de v 7, wa p v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, wa p v 7 1`] = `
+{
+  "_cmd": "de v 7, wa p v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa p v 8 1`] = `
+{
+  "_cmd": "de v 7, wa p v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa p v 9 1`] = `
+{
+  "_cmd": "de v 7, wa p v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa p v 10 1`] = `
+{
+  "_cmd": "de v 7, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa p v 11 1`] = `
+{
+  "_cmd": "de v 7, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa p v 12 1`] = `
+{
+  "_cmd": "de v 7, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, wa p v 13 1`] = `
+{
+  "_cmd": "de v 7, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, wa p v 14 1`] = `
+{
+  "_cmd": "de v 7, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, wa p v 15 1`] = `
+{
+  "_cmd": "de v 7, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, wa v 1 1`] = `
+{
+  "_cmd": "de v 7, wa v 1",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`de v 7, wa v 2 1`] = `
+{
+  "_cmd": "de v 7, wa v 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, wa v 3 1`] = `
+{
+  "_cmd": "de v 7, wa v 3",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, wa v 4 1`] = `
+{
+  "_cmd": "de v 7, wa v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa v 5 1`] = `
+{
+  "_cmd": "de v 7, wa v 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa v 6 1`] = `
+{
+  "_cmd": "de v 7, wa v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa v 7 1`] = `
+{
+  "_cmd": "de v 7, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa v 8 1`] = `
+{
+  "_cmd": "de v 7, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa v 9 1`] = `
+{
+  "_cmd": "de v 7, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa v 10 1`] = `
+{
+  "_cmd": "de v 7, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa v 11 1`] = `
+{
+  "_cmd": "de v 7, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa v 12 1`] = `
+{
+  "_cmd": "de v 7, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, wa v 13 1`] = `
+{
+  "_cmd": "de v 7, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, wa v 14 1`] = `
+{
+  "_cmd": "de v 7, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, wa v 15 1`] = `
+{
+  "_cmd": "de v 7, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, wa w 1 1`] = `
+{
+  "_cmd": "de v 7, wa w 1",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`de v 7, wa w 2 1`] = `
+{
+  "_cmd": "de v 7, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, wa w 3 1`] = `
+{
+  "_cmd": "de v 7, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa w 4 1`] = `
+{
+  "_cmd": "de v 7, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, wa w 5 1`] = `
+{
+  "_cmd": "de v 7, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 7, wa w 6 1`] = `
+{
+  "_cmd": "de v 7, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa w 7 1`] = `
+{
+  "_cmd": "de v 7, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa w 8 1`] = `
+{
+  "_cmd": "de v 7, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa w 9 1`] = `
+{
+  "_cmd": "de v 7, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa w 10 1`] = `
+{
+  "_cmd": "de v 7, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa w v 1 1`] = `
+{
+  "_cmd": "de v 7, wa w v 1",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`de v 7, wa w v 2 1`] = `
+{
+  "_cmd": "de v 7, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`de v 7, wa w v 3 1`] = `
+{
+  "_cmd": "de v 7, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 7, wa w v 4 1`] = `
+{
+  "_cmd": "de v 7, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 7, wa w v 5 1`] = `
+{
+  "_cmd": "de v 7, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 7, wa w v 6 1`] = `
+{
+  "_cmd": "de v 7, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 7, wa w v 7 1`] = `
+{
+  "_cmd": "de v 7, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 7, wa w v 8 1`] = `
+{
+  "_cmd": "de v 7, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 7, wa w v 9 1`] = `
+{
+  "_cmd": "de v 7, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 7, wa w v 10 1`] = `
+{
+  "_cmd": "de v 7, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 7, wa w v 11 1`] = `
+{
+  "_cmd": "de v 7, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 7, wa w v 12 1`] = `
+{
+  "_cmd": "de v 7, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 7, wa w v 13 1`] = `
+{
+  "_cmd": "de v 7, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 7, wa w v 14 1`] = `
+{
+  "_cmd": "de v 7, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 7, wa w v 15 1`] = `
+{
+  "_cmd": "de v 7, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 8, wa d 1 1`] = `
+{
+  "_cmd": "de v 8, wa d 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, wa d 2 1`] = `
+{
+  "_cmd": "de v 8, wa d 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, wa d 3 1`] = `
+{
+  "_cmd": "de v 8, wa d 3",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa d 4 1`] = `
+{
+  "_cmd": "de v 8, wa d 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa d 5 1`] = `
+{
+  "_cmd": "de v 8, wa d 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, wa d 6 1`] = `
+{
+  "_cmd": "de v 8, wa d 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa d 7 1`] = `
+{
+  "_cmd": "de v 8, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa d 8 1`] = `
+{
+  "_cmd": "de v 8, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa d 9 1`] = `
+{
+  "_cmd": "de v 8, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa d 10 1`] = `
+{
+  "_cmd": "de v 8, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa d v 1 1`] = `
+{
+  "_cmd": "de v 8, wa d v 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, wa d v 2 1`] = `
+{
+  "_cmd": "de v 8, wa d v 2",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, wa d v 3 1`] = `
+{
+  "_cmd": "de v 8, wa d v 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, wa d v 4 1`] = `
+{
+  "_cmd": "de v 8, wa d v 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa d v 5 1`] = `
+{
+  "_cmd": "de v 8, wa d v 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, wa d v 6 1`] = `
+{
+  "_cmd": "de v 8, wa d v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa d v 7 1`] = `
+{
+  "_cmd": "de v 8, wa d v 7",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa d v 8 1`] = `
+{
+  "_cmd": "de v 8, wa d v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa d v 9 1`] = `
+{
+  "_cmd": "de v 8, wa d v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa d v 10 1`] = `
+{
+  "_cmd": "de v 8, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa d v 11 1`] = `
+{
+  "_cmd": "de v 8, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, wa d v 12 1`] = `
+{
+  "_cmd": "de v 8, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, wa d v 13 1`] = `
+{
+  "_cmd": "de v 8, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, wa d v 14 1`] = `
+{
+  "_cmd": "de v 8, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, wa d v 15 1`] = `
+{
+  "_cmd": "de v 8, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, wa p 1 1`] = `
+{
+  "_cmd": "de v 8, wa p 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, wa p 2 1`] = `
+{
+  "_cmd": "de v 8, wa p 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, wa p 3 1`] = `
+{
+  "_cmd": "de v 8, wa p 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, wa p 4 1`] = `
+{
+  "_cmd": "de v 8, wa p 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa p 5 1`] = `
+{
+  "_cmd": "de v 8, wa p 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa p 6 1`] = `
+{
+  "_cmd": "de v 8, wa p 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa p 7 1`] = `
+{
+  "_cmd": "de v 8, wa p 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa p 8 1`] = `
+{
+  "_cmd": "de v 8, wa p 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa p 9 1`] = `
+{
+  "_cmd": "de v 8, wa p 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa p 10 1`] = `
+{
+  "_cmd": "de v 8, wa p 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa p v 1 1`] = `
+{
+  "_cmd": "de v 8, wa p v 1",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`de v 8, wa p v 2 1`] = `
+{
+  "_cmd": "de v 8, wa p v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, wa p v 3 1`] = `
+{
+  "_cmd": "de v 8, wa p v 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`de v 8, wa p v 4 1`] = `
+{
+  "_cmd": "de v 8, wa p v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa p v 5 1`] = `
+{
+  "_cmd": "de v 8, wa p v 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa p v 6 1`] = `
+{
+  "_cmd": "de v 8, wa p v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, wa p v 7 1`] = `
+{
+  "_cmd": "de v 8, wa p v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa p v 8 1`] = `
+{
+  "_cmd": "de v 8, wa p v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa p v 9 1`] = `
+{
+  "_cmd": "de v 8, wa p v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa p v 10 1`] = `
+{
+  "_cmd": "de v 8, wa p v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa p v 11 1`] = `
+{
+  "_cmd": "de v 8, wa p v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, wa p v 12 1`] = `
+{
+  "_cmd": "de v 8, wa p v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, wa p v 13 1`] = `
+{
+  "_cmd": "de v 8, wa p v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, wa p v 14 1`] = `
+{
+  "_cmd": "de v 8, wa p v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, wa p v 15 1`] = `
+{
+  "_cmd": "de v 8, wa p v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, wa v 1 1`] = `
+{
+  "_cmd": "de v 8, wa v 1",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`de v 8, wa v 2 1`] = `
+{
+  "_cmd": "de v 8, wa v 2",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, wa v 3 1`] = `
+{
+  "_cmd": "de v 8, wa v 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, wa v 4 1`] = `
+{
+  "_cmd": "de v 8, wa v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa v 5 1`] = `
+{
+  "_cmd": "de v 8, wa v 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa v 6 1`] = `
+{
+  "_cmd": "de v 8, wa v 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, wa v 7 1`] = `
+{
+  "_cmd": "de v 8, wa v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa v 8 1`] = `
+{
+  "_cmd": "de v 8, wa v 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa v 9 1`] = `
+{
+  "_cmd": "de v 8, wa v 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa v 10 1`] = `
+{
+  "_cmd": "de v 8, wa v 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa v 11 1`] = `
+{
+  "_cmd": "de v 8, wa v 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, wa v 12 1`] = `
+{
+  "_cmd": "de v 8, wa v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, wa v 13 1`] = `
+{
+  "_cmd": "de v 8, wa v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, wa v 14 1`] = `
+{
+  "_cmd": "de v 8, wa v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, wa v 15 1`] = `
+{
+  "_cmd": "de v 8, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, wa w 1 1`] = `
+{
+  "_cmd": "de v 8, wa w 1",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, wa w 2 1`] = `
+{
+  "_cmd": "de v 8, wa w 2",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, wa w 3 1`] = `
+{
+  "_cmd": "de v 8, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa w 4 1`] = `
+{
+  "_cmd": "de v 8, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa w 5 1`] = `
+{
+  "_cmd": "de v 8, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa w 6 1`] = `
+{
+  "_cmd": "de v 8, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`de v 8, wa w 7 1`] = `
+{
+  "_cmd": "de v 8, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa w 8 1`] = `
+{
+  "_cmd": "de v 8, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa w 9 1`] = `
+{
+  "_cmd": "de v 8, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa w 10 1`] = `
+{
+  "_cmd": "de v 8, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, wa w v 1 1`] = `
+{
+  "_cmd": "de v 8, wa w v 1",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`de v 8, wa w v 2 1`] = `
+{
+  "_cmd": "de v 8, wa w v 2",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`de v 8, wa w v 3 1`] = `
+{
+  "_cmd": "de v 8, wa w v 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 8, wa w v 4 1`] = `
+{
+  "_cmd": "de v 8, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`de v 8, wa w v 5 1`] = `
+{
+  "_cmd": "de v 8, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`de v 8, wa w v 6 1`] = `
+{
+  "_cmd": "de v 8, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`de v 8, wa w v 7 1`] = `
+{
+  "_cmd": "de v 8, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`de v 8, wa w v 8 1`] = `
+{
+  "_cmd": "de v 8, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`de v 8, wa w v 9 1`] = `
+{
+  "_cmd": "de v 8, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`de v 8, wa w v 10 1`] = `
+{
+  "_cmd": "de v 8, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 8, wa w v 11 1`] = `
+{
+  "_cmd": "de v 8, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`de v 8, wa w v 12 1`] = `
+{
+  "_cmd": "de v 8, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`de v 8, wa w v 13 1`] = `
+{
+  "_cmd": "de v 8, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`de v 8, wa w v 14 1`] = `
+{
+  "_cmd": "de v 8, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`de v 8, wa w v 15 1`] = `
+{
+  "_cmd": "de v 8, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 9, wa d 1 1`] = `
+{
+  "_cmd": "de v 9, wa d 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, wa d 2 1`] = `
+{
+  "_cmd": "de v 9, wa d 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, wa d 3 1`] = `
+{
+  "_cmd": "de v 9, wa d 3",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa d 4 1`] = `
+{
+  "_cmd": "de v 9, wa d 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa d 5 1`] = `
+{
+  "_cmd": "de v 9, wa d 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa d 6 1`] = `
+{
+  "_cmd": "de v 9, wa d 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, wa d 7 1`] = `
+{
+  "_cmd": "de v 9, wa d 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa d 8 1`] = `
+{
+  "_cmd": "de v 9, wa d 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa d 9 1`] = `
+{
+  "_cmd": "de v 9, wa d 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa d 10 1`] = `
+{
+  "_cmd": "de v 9, wa d 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa d v 1 1`] = `
+{
+  "_cmd": "de v 9, wa d v 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, wa d v 2 1`] = `
+{
+  "_cmd": "de v 9, wa d v 2",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, wa d v 3 1`] = `
+{
+  "_cmd": "de v 9, wa d v 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa d v 4 1`] = `
+{
+  "_cmd": "de v 9, wa d v 4",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa d v 5 1`] = `
+{
+  "_cmd": "de v 9, wa d v 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa d v 6 1`] = `
+{
+  "_cmd": "de v 9, wa d v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, wa d v 7 1`] = `
+{
+  "_cmd": "de v 9, wa d v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa d v 8 1`] = `
+{
+  "_cmd": "de v 9, wa d v 8",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa d v 9 1`] = `
+{
+  "_cmd": "de v 9, wa d v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa d v 10 1`] = `
+{
+  "_cmd": "de v 9, wa d v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa d v 11 1`] = `
+{
+  "_cmd": "de v 9, wa d v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, wa d v 12 1`] = `
+{
+  "_cmd": "de v 9, wa d v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, wa d v 13 1`] = `
+{
+  "_cmd": "de v 9, wa d v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, wa d v 14 1`] = `
+{
+  "_cmd": "de v 9, wa d v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, wa d v 15 1`] = `
+{
+  "_cmd": "de v 9, wa d v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, wa p 1 1`] = `
+{
+  "_cmd": "de v 9, wa p 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, wa p 2 1`] = `
+{
+  "_cmd": "de v 9, wa p 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, wa p 3 1`] = `
+{
+  "_cmd": "de v 9, wa p 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa p 4 1`] = `
+{
+  "_cmd": "de v 9, wa p 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa p 5 1`] = `
+{
+  "_cmd": "de v 9, wa p 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa p 6 1`] = `
+{
+  "_cmd": "de v 9, wa p 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa p 7 1`] = `
+{
+  "_cmd": "de v 9, wa p 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa p 8 1`] = `
+{
+  "_cmd": "de v 9, wa p 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa p 9 1`] = `
+{
+  "_cmd": "de v 9, wa p 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa p 10 1`] = `
+{
+  "_cmd": "de v 9, wa p 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa p v 1 1`] = `
+{
+  "_cmd": "de v 9, wa p v 1",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`de v 9, wa p v 2 1`] = `
+{
+  "_cmd": "de v 9, wa p v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, wa p v 3 1`] = `
+{
+  "_cmd": "de v 9, wa p v 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`de v 9, wa p v 4 1`] = `
+{
+  "_cmd": "de v 9, wa p v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa p v 5 1`] = `
+{
+  "_cmd": "de v 9, wa p v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa p v 6 1`] = `
+{
+  "_cmd": "de v 9, wa p v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa p v 7 1`] = `
+{
+  "_cmd": "de v 9, wa p v 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, wa p v 8 1`] = `
+{
+  "_cmd": "de v 9, wa p v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa p v 9 1`] = `
+{
+  "_cmd": "de v 9, wa p v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa p v 10 1`] = `
+{
+  "_cmd": "de v 9, wa p v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa p v 11 1`] = `
+{
+  "_cmd": "de v 9, wa p v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, wa p v 12 1`] = `
+{
+  "_cmd": "de v 9, wa p v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, wa p v 13 1`] = `
+{
+  "_cmd": "de v 9, wa p v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, wa p v 14 1`] = `
+{
+  "_cmd": "de v 9, wa p v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, wa p v 15 1`] = `
+{
+  "_cmd": "de v 9, wa p v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, wa v 1 1`] = `
+{
+  "_cmd": "de v 9, wa v 1",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`de v 9, wa v 2 1`] = `
+{
+  "_cmd": "de v 9, wa v 2",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, wa v 3 1`] = `
+{
+  "_cmd": "de v 9, wa v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa v 4 1`] = `
+{
+  "_cmd": "de v 9, wa v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa v 5 1`] = `
+{
+  "_cmd": "de v 9, wa v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa v 6 1`] = `
+{
+  "_cmd": "de v 9, wa v 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa v 7 1`] = `
+{
+  "_cmd": "de v 9, wa v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa v 8 1`] = `
+{
+  "_cmd": "de v 9, wa v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa v 9 1`] = `
+{
+  "_cmd": "de v 9, wa v 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa v 10 1`] = `
+{
+  "_cmd": "de v 9, wa v 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa v 11 1`] = `
+{
+  "_cmd": "de v 9, wa v 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, wa v 12 1`] = `
+{
+  "_cmd": "de v 9, wa v 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, wa v 13 1`] = `
+{
+  "_cmd": "de v 9, wa v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, wa v 14 1`] = `
+{
+  "_cmd": "de v 9, wa v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, wa v 15 1`] = `
+{
+  "_cmd": "de v 9, wa v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, wa w 1 1`] = `
+{
+  "_cmd": "de v 9, wa w 1",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, wa w 2 1`] = `
+{
+  "_cmd": "de v 9, wa w 2",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa w 3 1`] = `
+{
+  "_cmd": "de v 9, wa w 3",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa w 4 1`] = `
+{
+  "_cmd": "de v 9, wa w 4",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa w 5 1`] = `
+{
+  "_cmd": "de v 9, wa w 5",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, wa w 6 1`] = `
+{
+  "_cmd": "de v 9, wa w 6",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`de v 9, wa w 7 1`] = `
+{
+  "_cmd": "de v 9, wa w 7",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa w 8 1`] = `
+{
+  "_cmd": "de v 9, wa w 8",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa w 9 1`] = `
+{
+  "_cmd": "de v 9, wa w 9",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa w 10 1`] = `
+{
+  "_cmd": "de v 9, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, wa w v 1 1`] = `
+{
+  "_cmd": "de v 9, wa w v 1",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`de v 9, wa w v 2 1`] = `
+{
+  "_cmd": "de v 9, wa w v 2",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 9, wa w v 3 1`] = `
+{
+  "_cmd": "de v 9, wa w v 3",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`de v 9, wa w v 4 1`] = `
+{
+  "_cmd": "de v 9, wa w v 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 9, wa w v 5 1`] = `
+{
+  "_cmd": "de v 9, wa w v 5",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`de v 9, wa w v 6 1`] = `
+{
+  "_cmd": "de v 9, wa w v 6",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`de v 9, wa w v 7 1`] = `
+{
+  "_cmd": "de v 9, wa w v 7",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`de v 9, wa w v 8 1`] = `
+{
+  "_cmd": "de v 9, wa w v 8",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`de v 9, wa w v 9 1`] = `
+{
+  "_cmd": "de v 9, wa w v 9",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`de v 9, wa w v 10 1`] = `
+{
+  "_cmd": "de v 9, wa w v 10",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`de v 9, wa w v 11 1`] = `
+{
+  "_cmd": "de v 9, wa w v 11",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`de v 9, wa w v 12 1`] = `
+{
+  "_cmd": "de v 9, wa w v 12",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`de v 9, wa w v 13 1`] = `
+{
+  "_cmd": "de v 9, wa w v 13",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`de v 9, wa w v 14 1`] = `
+{
+  "_cmd": "de v 9, wa w v 14",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`de v 9, wa w v 15 1`] = `
+{
+  "_cmd": "de v 9, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`de v 10, wa d 1 1`] = `
+{
+  "_cmd": "de v 10, wa d 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de v 10, wa d 2 1`] = `
+{
+  "_cmd": "de v 10, wa d 2",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, wa d 3 1`] = `
+{
+  "_cmd": "de v 10, wa d 3",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa d 4 1`] = `
+{
+  "_cmd": "de v 10, wa d 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa d 5 1`] = `
+{
+  "_cmd": "de v 10, wa d 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa d 6 1`] = `
+{
+  "_cmd": "de v 10, wa d 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa d 7 1`] = `
+{
+  "_cmd": "de v 10, wa d 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, wa d 8 1`] = `
+{
+  "_cmd": "de v 10, wa d 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa d 9 1`] = `
+{
+  "_cmd": "de v 10, wa d 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa d 10 1`] = `
+{
+  "_cmd": "de v 10, wa d 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa d v 1 1`] = `
+{
+  "_cmd": "de v 10, wa d v 1",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`de v 10, wa d v 2 1`] = `
+{
+  "_cmd": "de v 10, wa d v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa d v 3 1`] = `
+{
+  "_cmd": "de v 10, wa d v 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa d v 4 1`] = `
+{
+  "_cmd": "de v 10, wa d v 4",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, wa d v 5 1`] = `
+{
+  "_cmd": "de v 10, wa d v 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa d v 6 1`] = `
+{
+  "_cmd": "de v 10, wa d v 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa d v 7 1`] = `
+{
+  "_cmd": "de v 10, wa d v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, wa d v 8 1`] = `
+{
+  "_cmd": "de v 10, wa d v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa d v 9 1`] = `
+{
+  "_cmd": "de v 10, wa d v 9",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa d v 10 1`] = `
+{
+  "_cmd": "de v 10, wa d v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa d v 11 1`] = `
+{
+  "_cmd": "de v 10, wa d v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, wa d v 12 1`] = `
+{
+  "_cmd": "de v 10, wa d v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, wa d v 13 1`] = `
+{
+  "_cmd": "de v 10, wa d v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, wa d v 14 1`] = `
+{
+  "_cmd": "de v 10, wa d v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, wa d v 15 1`] = `
+{
+  "_cmd": "de v 10, wa d v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, wa p 1 1`] = `
+{
+  "_cmd": "de v 10, wa p 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de v 10, wa p 2 1`] = `
+{
+  "_cmd": "de v 10, wa p 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa p 3 1`] = `
+{
+  "_cmd": "de v 10, wa p 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa p 4 1`] = `
+{
+  "_cmd": "de v 10, wa p 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, wa p 5 1`] = `
+{
+  "_cmd": "de v 10, wa p 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa p 6 1`] = `
+{
+  "_cmd": "de v 10, wa p 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa p 7 1`] = `
+{
+  "_cmd": "de v 10, wa p 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa p 8 1`] = `
+{
+  "_cmd": "de v 10, wa p 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa p 9 1`] = `
+{
+  "_cmd": "de v 10, wa p 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa p 10 1`] = `
+{
+  "_cmd": "de v 10, wa p 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa p v 1 1`] = `
+{
+  "_cmd": "de v 10, wa p v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de v 10, wa p v 2 1`] = `
+{
+  "_cmd": "de v 10, wa p v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa p v 3 1`] = `
+{
+  "_cmd": "de v 10, wa p v 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, wa p v 4 1`] = `
+{
+  "_cmd": "de v 10, wa p v 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa p v 5 1`] = `
+{
+  "_cmd": "de v 10, wa p v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa p v 6 1`] = `
+{
+  "_cmd": "de v 10, wa p v 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa p v 7 1`] = `
+{
+  "_cmd": "de v 10, wa p v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa p v 8 1`] = `
+{
+  "_cmd": "de v 10, wa p v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, wa p v 9 1`] = `
+{
+  "_cmd": "de v 10, wa p v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa p v 10 1`] = `
+{
+  "_cmd": "de v 10, wa p v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa p v 11 1`] = `
+{
+  "_cmd": "de v 10, wa p v 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, wa p v 12 1`] = `
+{
+  "_cmd": "de v 10, wa p v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, wa p v 13 1`] = `
+{
+  "_cmd": "de v 10, wa p v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, wa p v 14 1`] = `
+{
+  "_cmd": "de v 10, wa p v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, wa p v 15 1`] = `
+{
+  "_cmd": "de v 10, wa p v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, wa v 1 1`] = `
+{
+  "_cmd": "de v 10, wa v 1",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`de v 10, wa v 2 1`] = `
+{
+  "_cmd": "de v 10, wa v 2",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa v 3 1`] = `
+{
+  "_cmd": "de v 10, wa v 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`de v 10, wa v 4 1`] = `
+{
+  "_cmd": "de v 10, wa v 4",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, wa v 5 1`] = `
+{
+  "_cmd": "de v 10, wa v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa v 6 1`] = `
+{
+  "_cmd": "de v 10, wa v 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa v 7 1`] = `
+{
+  "_cmd": "de v 10, wa v 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa v 8 1`] = `
+{
+  "_cmd": "de v 10, wa v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa v 9 1`] = `
+{
+  "_cmd": "de v 10, wa v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa v 10 1`] = `
+{
+  "_cmd": "de v 10, wa v 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa v 11 1`] = `
+{
+  "_cmd": "de v 10, wa v 11",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, wa v 12 1`] = `
+{
+  "_cmd": "de v 10, wa v 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, wa v 13 1`] = `
+{
+  "_cmd": "de v 10, wa v 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, wa v 14 1`] = `
+{
+  "_cmd": "de v 10, wa v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, wa v 15 1`] = `
+{
+  "_cmd": "de v 10, wa v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, wa w 1 1`] = `
+{
+  "_cmd": "de v 10, wa w 1",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa w 2 1`] = `
+{
+  "_cmd": "de v 10, wa w 2",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa w 3 1`] = `
+{
+  "_cmd": "de v 10, wa w 3",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, wa w 4 1`] = `
+{
+  "_cmd": "de v 10, wa w 4",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa w 5 1`] = `
+{
+  "_cmd": "de v 10, wa w 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa w 6 1`] = `
+{
+  "_cmd": "de v 10, wa w 6",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, wa w 7 1`] = `
+{
+  "_cmd": "de v 10, wa w 7",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`de v 10, wa w 8 1`] = `
+{
+  "_cmd": "de v 10, wa w 8",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa w 9 1`] = `
+{
+  "_cmd": "de v 10, wa w 9",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa w 10 1`] = `
+{
+  "_cmd": "de v 10, wa w 10",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, wa w v 1 1`] = `
+{
+  "_cmd": "de v 10, wa w v 1",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`de v 10, wa w v 2 1`] = `
+{
+  "_cmd": "de v 10, wa w v 2",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 10, wa w v 3 1`] = `
+{
+  "_cmd": "de v 10, wa w v 3",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`de v 10, wa w v 4 1`] = `
+{
+  "_cmd": "de v 10, wa w v 4",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 10, wa w v 5 1`] = `
+{
+  "_cmd": "de v 10, wa w v 5",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`de v 10, wa w v 6 1`] = `
+{
+  "_cmd": "de v 10, wa w v 6",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`de v 10, wa w v 7 1`] = `
+{
+  "_cmd": "de v 10, wa w v 7",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`de v 10, wa w v 8 1`] = `
+{
+  "_cmd": "de v 10, wa w v 8",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`de v 10, wa w v 9 1`] = `
+{
+  "_cmd": "de v 10, wa w v 9",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`de v 10, wa w v 10 1`] = `
+{
+  "_cmd": "de v 10, wa w v 10",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`de v 10, wa w v 11 1`] = `
+{
+  "_cmd": "de v 10, wa w v 11",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`de v 10, wa w v 12 1`] = `
+{
+  "_cmd": "de v 10, wa w v 12",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`de v 10, wa w v 13 1`] = `
+{
+  "_cmd": "de v 10, wa w v 13",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`de v 10, wa w v 14 1`] = `
+{
+  "_cmd": "de v 10, wa w v 14",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`de v 10, wa w v 15 1`] = `
+{
+  "_cmd": "de v 10, wa w v 15",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`de v 11, wa d 1 1`] = `
+{
+  "_cmd": "de v 11, wa d 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de v 11, wa d 2 1`] = `
+{
+  "_cmd": "de v 11, wa d 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, wa d 3 1`] = `
+{
+  "_cmd": "de v 11, wa d 3",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, wa d 4 1`] = `
+{
+  "_cmd": "de v 11, wa d 4",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa d 5 1`] = `
+{
+  "_cmd": "de v 11, wa d 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa d 6 1`] = `
+{
+  "_cmd": "de v 11, wa d 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa d 7 1`] = `
+{
+  "_cmd": "de v 11, wa d 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa d 8 1`] = `
+{
+  "_cmd": "de v 11, wa d 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa d 9 1`] = `
+{
+  "_cmd": "de v 11, wa d 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa d 10 1`] = `
+{
+  "_cmd": "de v 11, wa d 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa d v 1 1`] = `
+{
+  "_cmd": "de v 11, wa d v 1",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`de v 11, wa d v 2 1`] = `
+{
+  "_cmd": "de v 11, wa d v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa d v 3 1`] = `
+{
+  "_cmd": "de v 11, wa d v 3",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, wa d v 4 1`] = `
+{
+  "_cmd": "de v 11, wa d v 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, wa d v 5 1`] = `
+{
+  "_cmd": "de v 11, wa d v 5",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa d v 6 1`] = `
+{
+  "_cmd": "de v 11, wa d v 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa d v 7 1`] = `
+{
+  "_cmd": "de v 11, wa d v 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa d v 8 1`] = `
+{
+  "_cmd": "de v 11, wa d v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa d v 9 1`] = `
+{
+  "_cmd": "de v 11, wa d v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa d v 10 1`] = `
+{
+  "_cmd": "de v 11, wa d v 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa d v 11 1`] = `
+{
+  "_cmd": "de v 11, wa d v 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, wa d v 12 1`] = `
+{
+  "_cmd": "de v 11, wa d v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, wa d v 13 1`] = `
+{
+  "_cmd": "de v 11, wa d v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, wa d v 14 1`] = `
+{
+  "_cmd": "de v 11, wa d v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, wa d v 15 1`] = `
+{
+  "_cmd": "de v 11, wa d v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, wa p 1 1`] = `
+{
+  "_cmd": "de v 11, wa p 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, wa p 2 1`] = `
+{
+  "_cmd": "de v 11, wa p 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa p 3 1`] = `
+{
+  "_cmd": "de v 11, wa p 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, wa p 4 1`] = `
+{
+  "_cmd": "de v 11, wa p 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, wa p 5 1`] = `
+{
+  "_cmd": "de v 11, wa p 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa p 6 1`] = `
+{
+  "_cmd": "de v 11, wa p 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa p 7 1`] = `
+{
+  "_cmd": "de v 11, wa p 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa p 8 1`] = `
+{
+  "_cmd": "de v 11, wa p 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa p 9 1`] = `
+{
+  "_cmd": "de v 11, wa p 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa p 10 1`] = `
+{
+  "_cmd": "de v 11, wa p 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa p v 1 1`] = `
+{
+  "_cmd": "de v 11, wa p v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, wa p v 2 1`] = `
+{
+  "_cmd": "de v 11, wa p v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa p v 3 1`] = `
+{
+  "_cmd": "de v 11, wa p v 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, wa p v 4 1`] = `
+{
+  "_cmd": "de v 11, wa p v 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, wa p v 5 1`] = `
+{
+  "_cmd": "de v 11, wa p v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa p v 6 1`] = `
+{
+  "_cmd": "de v 11, wa p v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa p v 7 1`] = `
+{
+  "_cmd": "de v 11, wa p v 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa p v 8 1`] = `
+{
+  "_cmd": "de v 11, wa p v 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa p v 9 1`] = `
+{
+  "_cmd": "de v 11, wa p v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa p v 10 1`] = `
+{
+  "_cmd": "de v 11, wa p v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa p v 11 1`] = `
+{
+  "_cmd": "de v 11, wa p v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa p v 12 1`] = `
+{
+  "_cmd": "de v 11, wa p v 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, wa p v 13 1`] = `
+{
+  "_cmd": "de v 11, wa p v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, wa p v 14 1`] = `
+{
+  "_cmd": "de v 11, wa p v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, wa p v 15 1`] = `
+{
+  "_cmd": "de v 11, wa p v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, wa v 1 1`] = `
+{
+  "_cmd": "de v 11, wa v 1",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`de v 11, wa v 2 1`] = `
+{
+  "_cmd": "de v 11, wa v 2",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa v 3 1`] = `
+{
+  "_cmd": "de v 11, wa v 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, wa v 4 1`] = `
+{
+  "_cmd": "de v 11, wa v 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, wa v 5 1`] = `
+{
+  "_cmd": "de v 11, wa v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa v 6 1`] = `
+{
+  "_cmd": "de v 11, wa v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa v 7 1`] = `
+{
+  "_cmd": "de v 11, wa v 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa v 8 1`] = `
+{
+  "_cmd": "de v 11, wa v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa v 9 1`] = `
+{
+  "_cmd": "de v 11, wa v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa v 10 1`] = `
+{
+  "_cmd": "de v 11, wa v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa v 11 1`] = `
+{
+  "_cmd": "de v 11, wa v 11",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, wa v 12 1`] = `
+{
+  "_cmd": "de v 11, wa v 12",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, wa v 13 1`] = `
+{
+  "_cmd": "de v 11, wa v 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, wa v 14 1`] = `
+{
+  "_cmd": "de v 11, wa v 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, wa v 15 1`] = `
+{
+  "_cmd": "de v 11, wa v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, wa w 1 1`] = `
+{
+  "_cmd": "de v 11, wa w 1",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa w 2 1`] = `
+{
+  "_cmd": "de v 11, wa w 2",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`de v 11, wa w 3 1`] = `
+{
+  "_cmd": "de v 11, wa w 3",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, wa w 4 1`] = `
+{
+  "_cmd": "de v 11, wa w 4",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa w 5 1`] = `
+{
+  "_cmd": "de v 11, wa w 5",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa w 6 1`] = `
+{
+  "_cmd": "de v 11, wa w 6",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa w 7 1`] = `
+{
+  "_cmd": "de v 11, wa w 7",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa w 8 1`] = `
+{
+  "_cmd": "de v 11, wa w 8",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`de v 11, wa w 9 1`] = `
+{
+  "_cmd": "de v 11, wa w 9",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa w 10 1`] = `
+{
+  "_cmd": "de v 11, wa w 10",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, wa w v 1 1`] = `
+{
+  "_cmd": "de v 11, wa w v 1",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`de v 11, wa w v 2 1`] = `
+{
+  "_cmd": "de v 11, wa w v 2",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`de v 11, wa w v 3 1`] = `
+{
+  "_cmd": "de v 11, wa w v 3",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`de v 11, wa w v 4 1`] = `
+{
+  "_cmd": "de v 11, wa w v 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 11, wa w v 5 1`] = `
+{
+  "_cmd": "de v 11, wa w v 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 11, wa w v 6 1`] = `
+{
+  "_cmd": "de v 11, wa w v 6",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`de v 11, wa w v 7 1`] = `
+{
+  "_cmd": "de v 11, wa w v 7",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`de v 11, wa w v 8 1`] = `
+{
+  "_cmd": "de v 11, wa w v 8",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`de v 11, wa w v 9 1`] = `
+{
+  "_cmd": "de v 11, wa w v 9",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`de v 11, wa w v 10 1`] = `
+{
+  "_cmd": "de v 11, wa w v 10",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`de v 11, wa w v 11 1`] = `
+{
+  "_cmd": "de v 11, wa w v 11",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`de v 11, wa w v 12 1`] = `
+{
+  "_cmd": "de v 11, wa w v 12",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`de v 11, wa w v 13 1`] = `
+{
+  "_cmd": "de v 11, wa w v 13",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`de v 11, wa w v 14 1`] = `
+{
+  "_cmd": "de v 11, wa w v 14",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`de v 11, wa w v 15 1`] = `
+{
+  "_cmd": "de v 11, wa w v 15",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`de v 12, wa d 1 1`] = `
+{
+  "_cmd": "de v 12, wa d 1",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de v 12, wa d 2 1`] = `
+{
+  "_cmd": "de v 12, wa d 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, wa d 3 1`] = `
+{
+  "_cmd": "de v 12, wa d 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, wa d 4 1`] = `
+{
+  "_cmd": "de v 12, wa d 4",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa d 5 1`] = `
+{
+  "_cmd": "de v 12, wa d 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa d 6 1`] = `
+{
+  "_cmd": "de v 12, wa d 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa d 7 1`] = `
+{
+  "_cmd": "de v 12, wa d 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa d 8 1`] = `
+{
+  "_cmd": "de v 12, wa d 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa d 9 1`] = `
+{
+  "_cmd": "de v 12, wa d 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa d 10 1`] = `
+{
+  "_cmd": "de v 12, wa d 10",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa d v 1 1`] = `
+{
+  "_cmd": "de v 12, wa d v 1",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`de v 12, wa d v 2 1`] = `
+{
+  "_cmd": "de v 12, wa d v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa d v 3 1`] = `
+{
+  "_cmd": "de v 12, wa d v 3",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, wa d v 4 1`] = `
+{
+  "_cmd": "de v 12, wa d v 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa d v 5 1`] = `
+{
+  "_cmd": "de v 12, wa d v 5",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, wa d v 6 1`] = `
+{
+  "_cmd": "de v 12, wa d v 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa d v 7 1`] = `
+{
+  "_cmd": "de v 12, wa d v 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa d v 8 1`] = `
+{
+  "_cmd": "de v 12, wa d v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa d v 9 1`] = `
+{
+  "_cmd": "de v 12, wa d v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa d v 10 1`] = `
+{
+  "_cmd": "de v 12, wa d v 10",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa d v 11 1`] = `
+{
+  "_cmd": "de v 12, wa d v 11",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, wa d v 12 1`] = `
+{
+  "_cmd": "de v 12, wa d v 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, wa d v 13 1`] = `
+{
+  "_cmd": "de v 12, wa d v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, wa d v 14 1`] = `
+{
+  "_cmd": "de v 12, wa d v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, wa d v 15 1`] = `
+{
+  "_cmd": "de v 12, wa d v 15",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, wa p 1 1`] = `
+{
+  "_cmd": "de v 12, wa p 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, wa p 2 1`] = `
+{
+  "_cmd": "de v 12, wa p 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa p 3 1`] = `
+{
+  "_cmd": "de v 12, wa p 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, wa p 4 1`] = `
+{
+  "_cmd": "de v 12, wa p 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa p 5 1`] = `
+{
+  "_cmd": "de v 12, wa p 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, wa p 6 1`] = `
+{
+  "_cmd": "de v 12, wa p 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa p 7 1`] = `
+{
+  "_cmd": "de v 12, wa p 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa p 8 1`] = `
+{
+  "_cmd": "de v 12, wa p 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa p 9 1`] = `
+{
+  "_cmd": "de v 12, wa p 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa p 10 1`] = `
+{
+  "_cmd": "de v 12, wa p 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa p v 1 1`] = `
+{
+  "_cmd": "de v 12, wa p v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, wa p v 2 1`] = `
+{
+  "_cmd": "de v 12, wa p v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa p v 3 1`] = `
+{
+  "_cmd": "de v 12, wa p v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, wa p v 4 1`] = `
+{
+  "_cmd": "de v 12, wa p v 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, wa p v 5 1`] = `
+{
+  "_cmd": "de v 12, wa p v 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa p v 6 1`] = `
+{
+  "_cmd": "de v 12, wa p v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa p v 7 1`] = `
+{
+  "_cmd": "de v 12, wa p v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa p v 8 1`] = `
+{
+  "_cmd": "de v 12, wa p v 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa p v 9 1`] = `
+{
+  "_cmd": "de v 12, wa p v 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa p v 10 1`] = `
+{
+  "_cmd": "de v 12, wa p v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa p v 11 1`] = `
+{
+  "_cmd": "de v 12, wa p v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa p v 12 1`] = `
+{
+  "_cmd": "de v 12, wa p v 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, wa p v 13 1`] = `
+{
+  "_cmd": "de v 12, wa p v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, wa p v 14 1`] = `
+{
+  "_cmd": "de v 12, wa p v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, wa p v 15 1`] = `
+{
+  "_cmd": "de v 12, wa p v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, wa v 1 1`] = `
+{
+  "_cmd": "de v 12, wa v 1",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`de v 12, wa v 2 1`] = `
+{
+  "_cmd": "de v 12, wa v 2",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa v 3 1`] = `
+{
+  "_cmd": "de v 12, wa v 3",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, wa v 4 1`] = `
+{
+  "_cmd": "de v 12, wa v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa v 5 1`] = `
+{
+  "_cmd": "de v 12, wa v 5",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, wa v 6 1`] = `
+{
+  "_cmd": "de v 12, wa v 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa v 7 1`] = `
+{
+  "_cmd": "de v 12, wa v 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa v 8 1`] = `
+{
+  "_cmd": "de v 12, wa v 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa v 9 1`] = `
+{
+  "_cmd": "de v 12, wa v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa v 10 1`] = `
+{
+  "_cmd": "de v 12, wa v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa v 11 1`] = `
+{
+  "_cmd": "de v 12, wa v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, wa v 12 1`] = `
+{
+  "_cmd": "de v 12, wa v 12",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, wa v 13 1`] = `
+{
+  "_cmd": "de v 12, wa v 13",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, wa v 14 1`] = `
+{
+  "_cmd": "de v 12, wa v 14",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, wa v 15 1`] = `
+{
+  "_cmd": "de v 12, wa v 15",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, wa w 1 1`] = `
+{
+  "_cmd": "de v 12, wa w 1",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa w 2 1`] = `
+{
+  "_cmd": "de v 12, wa w 2",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`de v 12, wa w 3 1`] = `
+{
+  "_cmd": "de v 12, wa w 3",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa w 4 1`] = `
+{
+  "_cmd": "de v 12, wa w 4",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, wa w 5 1`] = `
+{
+  "_cmd": "de v 12, wa w 5",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa w 6 1`] = `
+{
+  "_cmd": "de v 12, wa w 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa w 7 1`] = `
+{
+  "_cmd": "de v 12, wa w 7",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa w 8 1`] = `
+{
+  "_cmd": "de v 12, wa w 8",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa w 9 1`] = `
+{
+  "_cmd": "de v 12, wa w 9",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`de v 12, wa w 10 1`] = `
+{
+  "_cmd": "de v 12, wa w 10",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, wa w v 1 1`] = `
+{
+  "_cmd": "de v 12, wa w v 1",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`de v 12, wa w v 2 1`] = `
+{
+  "_cmd": "de v 12, wa w v 2",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`de v 12, wa w v 3 1`] = `
+{
+  "_cmd": "de v 12, wa w v 3",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`de v 12, wa w v 4 1`] = `
+{
+  "_cmd": "de v 12, wa w v 4",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`de v 12, wa w v 5 1`] = `
+{
+  "_cmd": "de v 12, wa w v 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 12, wa w v 6 1`] = `
+{
+  "_cmd": "de v 12, wa w v 6",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`de v 12, wa w v 7 1`] = `
+{
+  "_cmd": "de v 12, wa w v 7",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`de v 12, wa w v 8 1`] = `
+{
+  "_cmd": "de v 12, wa w v 8",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`de v 12, wa w v 9 1`] = `
+{
+  "_cmd": "de v 12, wa w v 9",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`de v 12, wa w v 10 1`] = `
+{
+  "_cmd": "de v 12, wa w v 10",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`de v 12, wa w v 11 1`] = `
+{
+  "_cmd": "de v 12, wa w v 11",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`de v 12, wa w v 12 1`] = `
+{
+  "_cmd": "de v 12, wa w v 12",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`de v 12, wa w v 13 1`] = `
+{
+  "_cmd": "de v 12, wa w v 13",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`de v 12, wa w v 14 1`] = `
+{
+  "_cmd": "de v 12, wa w v 14",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`de v 12, wa w v 15 1`] = `
+{
+  "_cmd": "de v 12, wa w v 15",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`de v 13, wa d 1 1`] = `
+{
+  "_cmd": "de v 13, wa d 1",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de v 13, wa d 2 1`] = `
+{
+  "_cmd": "de v 13, wa d 2",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, wa d 3 1`] = `
+{
+  "_cmd": "de v 13, wa d 3",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, wa d 4 1`] = `
+{
+  "_cmd": "de v 13, wa d 4",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa d 5 1`] = `
+{
+  "_cmd": "de v 13, wa d 5",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa d 6 1`] = `
+{
+  "_cmd": "de v 13, wa d 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa d 7 1`] = `
+{
+  "_cmd": "de v 13, wa d 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa d 8 1`] = `
+{
+  "_cmd": "de v 13, wa d 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa d 9 1`] = `
+{
+  "_cmd": "de v 13, wa d 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, wa d 10 1`] = `
+{
+  "_cmd": "de v 13, wa d 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa d v 1 1`] = `
+{
+  "_cmd": "de v 13, wa d v 1",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`de v 13, wa d v 2 1`] = `
+{
+  "_cmd": "de v 13, wa d v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa d v 3 1`] = `
+{
+  "_cmd": "de v 13, wa d v 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, wa d v 4 1`] = `
+{
+  "_cmd": "de v 13, wa d v 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa d v 5 1`] = `
+{
+  "_cmd": "de v 13, wa d v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, wa d v 6 1`] = `
+{
+  "_cmd": "de v 13, wa d v 6",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa d v 7 1`] = `
+{
+  "_cmd": "de v 13, wa d v 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa d v 8 1`] = `
+{
+  "_cmd": "de v 13, wa d v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa d v 9 1`] = `
+{
+  "_cmd": "de v 13, wa d v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, wa d v 10 1`] = `
+{
+  "_cmd": "de v 13, wa d v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa d v 11 1`] = `
+{
+  "_cmd": "de v 13, wa d v 11",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, wa d v 12 1`] = `
+{
+  "_cmd": "de v 13, wa d v 12",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, wa d v 13 1`] = `
+{
+  "_cmd": "de v 13, wa d v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, wa d v 14 1`] = `
+{
+  "_cmd": "de v 13, wa d v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, wa d v 15 1`] = `
+{
+  "_cmd": "de v 13, wa d v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, wa p 1 1`] = `
+{
+  "_cmd": "de v 13, wa p 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, wa p 2 1`] = `
+{
+  "_cmd": "de v 13, wa p 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa p 3 1`] = `
+{
+  "_cmd": "de v 13, wa p 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, wa p 4 1`] = `
+{
+  "_cmd": "de v 13, wa p 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa p 5 1`] = `
+{
+  "_cmd": "de v 13, wa p 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, wa p 6 1`] = `
+{
+  "_cmd": "de v 13, wa p 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa p 7 1`] = `
+{
+  "_cmd": "de v 13, wa p 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa p 8 1`] = `
+{
+  "_cmd": "de v 13, wa p 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa p 9 1`] = `
+{
+  "_cmd": "de v 13, wa p 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa p 10 1`] = `
+{
+  "_cmd": "de v 13, wa p 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa p v 1 1`] = `
+{
+  "_cmd": "de v 13, wa p v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, wa p v 2 1`] = `
+{
+  "_cmd": "de v 13, wa p v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa p v 3 1`] = `
+{
+  "_cmd": "de v 13, wa p v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, wa p v 4 1`] = `
+{
+  "_cmd": "de v 13, wa p v 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, wa p v 5 1`] = `
+{
+  "_cmd": "de v 13, wa p v 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa p v 6 1`] = `
+{
+  "_cmd": "de v 13, wa p v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa p v 7 1`] = `
+{
+  "_cmd": "de v 13, wa p v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa p v 8 1`] = `
+{
+  "_cmd": "de v 13, wa p v 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa p v 9 1`] = `
+{
+  "_cmd": "de v 13, wa p v 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa p v 10 1`] = `
+{
+  "_cmd": "de v 13, wa p v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, wa p v 11 1`] = `
+{
+  "_cmd": "de v 13, wa p v 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa p v 12 1`] = `
+{
+  "_cmd": "de v 13, wa p v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, wa p v 13 1`] = `
+{
+  "_cmd": "de v 13, wa p v 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, wa p v 14 1`] = `
+{
+  "_cmd": "de v 13, wa p v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, wa p v 15 1`] = `
+{
+  "_cmd": "de v 13, wa p v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, wa v 1 1`] = `
+{
+  "_cmd": "de v 13, wa v 1",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`de v 13, wa v 2 1`] = `
+{
+  "_cmd": "de v 13, wa v 2",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa v 3 1`] = `
+{
+  "_cmd": "de v 13, wa v 3",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, wa v 4 1`] = `
+{
+  "_cmd": "de v 13, wa v 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa v 5 1`] = `
+{
+  "_cmd": "de v 13, wa v 5",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, wa v 6 1`] = `
+{
+  "_cmd": "de v 13, wa v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa v 7 1`] = `
+{
+  "_cmd": "de v 13, wa v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa v 8 1`] = `
+{
+  "_cmd": "de v 13, wa v 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa v 9 1`] = `
+{
+  "_cmd": "de v 13, wa v 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa v 10 1`] = `
+{
+  "_cmd": "de v 13, wa v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa v 11 1`] = `
+{
+  "_cmd": "de v 13, wa v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, wa v 12 1`] = `
+{
+  "_cmd": "de v 13, wa v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, wa v 13 1`] = `
+{
+  "_cmd": "de v 13, wa v 13",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, wa v 14 1`] = `
+{
+  "_cmd": "de v 13, wa v 14",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, wa v 15 1`] = `
+{
+  "_cmd": "de v 13, wa v 15",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, wa w 1 1`] = `
+{
+  "_cmd": "de v 13, wa w 1",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa w 2 1`] = `
+{
+  "_cmd": "de v 13, wa w 2",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`de v 13, wa w 3 1`] = `
+{
+  "_cmd": "de v 13, wa w 3",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa w 4 1`] = `
+{
+  "_cmd": "de v 13, wa w 4",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, wa w 5 1`] = `
+{
+  "_cmd": "de v 13, wa w 5",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa w 6 1`] = `
+{
+  "_cmd": "de v 13, wa w 6",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa w 7 1`] = `
+{
+  "_cmd": "de v 13, wa w 7",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa w 8 1`] = `
+{
+  "_cmd": "de v 13, wa w 8",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, wa w 9 1`] = `
+{
+  "_cmd": "de v 13, wa w 9",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`de v 13, wa w 10 1`] = `
+{
+  "_cmd": "de v 13, wa w 10",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, wa w v 1 1`] = `
+{
+  "_cmd": "de v 13, wa w v 1",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`de v 13, wa w v 2 1`] = `
+{
+  "_cmd": "de v 13, wa w v 2",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`de v 13, wa w v 3 1`] = `
+{
+  "_cmd": "de v 13, wa w v 3",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 13, wa w v 4 1`] = `
+{
+  "_cmd": "de v 13, wa w v 4",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`de v 13, wa w v 5 1`] = `
+{
+  "_cmd": "de v 13, wa w v 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 13, wa w v 6 1`] = `
+{
+  "_cmd": "de v 13, wa w v 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 13, wa w v 7 1`] = `
+{
+  "_cmd": "de v 13, wa w v 7",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`de v 13, wa w v 8 1`] = `
+{
+  "_cmd": "de v 13, wa w v 8",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`de v 13, wa w v 9 1`] = `
+{
+  "_cmd": "de v 13, wa w v 9",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`de v 13, wa w v 10 1`] = `
+{
+  "_cmd": "de v 13, wa w v 10",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`de v 13, wa w v 11 1`] = `
+{
+  "_cmd": "de v 13, wa w v 11",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`de v 13, wa w v 12 1`] = `
+{
+  "_cmd": "de v 13, wa w v 12",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`de v 13, wa w v 13 1`] = `
+{
+  "_cmd": "de v 13, wa w v 13",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`de v 13, wa w v 14 1`] = `
+{
+  "_cmd": "de v 13, wa w v 14",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`de v 13, wa w v 15 1`] = `
+{
+  "_cmd": "de v 13, wa w v 15",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`de v 14, wa d 1 1`] = `
+{
+  "_cmd": "de v 14, wa d 1",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de v 14, wa d 2 1`] = `
+{
+  "_cmd": "de v 14, wa d 2",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, wa d 3 1`] = `
+{
+  "_cmd": "de v 14, wa d 3",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa d 4 1`] = `
+{
+  "_cmd": "de v 14, wa d 4",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, wa d 5 1`] = `
+{
+  "_cmd": "de v 14, wa d 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa d 6 1`] = `
+{
+  "_cmd": "de v 14, wa d 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa d 7 1`] = `
+{
+  "_cmd": "de v 14, wa d 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa d 8 1`] = `
+{
+  "_cmd": "de v 14, wa d 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa d 9 1`] = `
+{
+  "_cmd": "de v 14, wa d 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa d 10 1`] = `
+{
+  "_cmd": "de v 14, wa d 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, wa d v 1 1`] = `
+{
+  "_cmd": "de v 14, wa d v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, wa d v 2 1`] = `
+{
+  "_cmd": "de v 14, wa d v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, wa d v 3 1`] = `
+{
+  "_cmd": "de v 14, wa d v 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa d v 4 1`] = `
+{
+  "_cmd": "de v 14, wa d v 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, wa d v 5 1`] = `
+{
+  "_cmd": "de v 14, wa d v 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa d v 6 1`] = `
+{
+  "_cmd": "de v 14, wa d v 6",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa d v 7 1`] = `
+{
+  "_cmd": "de v 14, wa d v 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa d v 8 1`] = `
+{
+  "_cmd": "de v 14, wa d v 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa d v 9 1`] = `
+{
+  "_cmd": "de v 14, wa d v 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa d v 10 1`] = `
+{
+  "_cmd": "de v 14, wa d v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, wa d v 11 1`] = `
+{
+  "_cmd": "de v 14, wa d v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, wa d v 12 1`] = `
+{
+  "_cmd": "de v 14, wa d v 12",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, wa d v 13 1`] = `
+{
+  "_cmd": "de v 14, wa d v 13",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, wa d v 14 1`] = `
+{
+  "_cmd": "de v 14, wa d v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, wa d v 15 1`] = `
+{
+  "_cmd": "de v 14, wa d v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, wa p 1 1`] = `
+{
+  "_cmd": "de v 14, wa p 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, wa p 2 1`] = `
+{
+  "_cmd": "de v 14, wa p 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, wa p 3 1`] = `
+{
+  "_cmd": "de v 14, wa p 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, wa p 4 1`] = `
+{
+  "_cmd": "de v 14, wa p 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa p 5 1`] = `
+{
+  "_cmd": "de v 14, wa p 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa p 6 1`] = `
+{
+  "_cmd": "de v 14, wa p 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa p 7 1`] = `
+{
+  "_cmd": "de v 14, wa p 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa p 8 1`] = `
+{
+  "_cmd": "de v 14, wa p 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa p 9 1`] = `
+{
+  "_cmd": "de v 14, wa p 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa p 10 1`] = `
+{
+  "_cmd": "de v 14, wa p 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa p v 1 1`] = `
+{
+  "_cmd": "de v 14, wa p v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, wa p v 2 1`] = `
+{
+  "_cmd": "de v 14, wa p v 2",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de v 14, wa p v 3 1`] = `
+{
+  "_cmd": "de v 14, wa p v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, wa p v 4 1`] = `
+{
+  "_cmd": "de v 14, wa p v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa p v 5 1`] = `
+{
+  "_cmd": "de v 14, wa p v 5",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, wa p v 6 1`] = `
+{
+  "_cmd": "de v 14, wa p v 6",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa p v 7 1`] = `
+{
+  "_cmd": "de v 14, wa p v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa p v 8 1`] = `
+{
+  "_cmd": "de v 14, wa p v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa p v 9 1`] = `
+{
+  "_cmd": "de v 14, wa p v 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa p v 10 1`] = `
+{
+  "_cmd": "de v 14, wa p v 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa p v 11 1`] = `
+{
+  "_cmd": "de v 14, wa p v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, wa p v 12 1`] = `
+{
+  "_cmd": "de v 14, wa p v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, wa p v 13 1`] = `
+{
+  "_cmd": "de v 14, wa p v 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, wa p v 14 1`] = `
+{
+  "_cmd": "de v 14, wa p v 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, wa p v 15 1`] = `
+{
+  "_cmd": "de v 14, wa p v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, wa v 1 1`] = `
+{
+  "_cmd": "de v 14, wa v 1",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`de v 14, wa v 2 1`] = `
+{
+  "_cmd": "de v 14, wa v 2",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, wa v 3 1`] = `
+{
+  "_cmd": "de v 14, wa v 3",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, wa v 4 1`] = `
+{
+  "_cmd": "de v 14, wa v 4",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa v 5 1`] = `
+{
+  "_cmd": "de v 14, wa v 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa v 6 1`] = `
+{
+  "_cmd": "de v 14, wa v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa v 7 1`] = `
+{
+  "_cmd": "de v 14, wa v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa v 8 1`] = `
+{
+  "_cmd": "de v 14, wa v 8",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa v 9 1`] = `
+{
+  "_cmd": "de v 14, wa v 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa v 10 1`] = `
+{
+  "_cmd": "de v 14, wa v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa v 11 1`] = `
+{
+  "_cmd": "de v 14, wa v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, wa v 12 1`] = `
+{
+  "_cmd": "de v 14, wa v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, wa v 13 1`] = `
+{
+  "_cmd": "de v 14, wa v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, wa v 14 1`] = `
+{
+  "_cmd": "de v 14, wa v 14",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, wa v 15 1`] = `
+{
+  "_cmd": "de v 14, wa v 15",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, wa w 1 1`] = `
+{
+  "_cmd": "de v 14, wa w 1",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`de v 14, wa w 2 1`] = `
+{
+  "_cmd": "de v 14, wa w 2",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`de v 14, wa w 3 1`] = `
+{
+  "_cmd": "de v 14, wa w 3",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, wa w 4 1`] = `
+{
+  "_cmd": "de v 14, wa w 4",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa w 5 1`] = `
+{
+  "_cmd": "de v 14, wa w 5",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa w 6 1`] = `
+{
+  "_cmd": "de v 14, wa w 6",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa w 7 1`] = `
+{
+  "_cmd": "de v 14, wa w 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa w 8 1`] = `
+{
+  "_cmd": "de v 14, wa w 8",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa w 9 1`] = `
+{
+  "_cmd": "de v 14, wa w 9",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, wa w 10 1`] = `
+{
+  "_cmd": "de v 14, wa w 10",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`de v 14, wa w v 1 1`] = `
+{
+  "_cmd": "de v 14, wa w v 1",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`de v 14, wa w v 2 1`] = `
+{
+  "_cmd": "de v 14, wa w v 2",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`de v 14, wa w v 3 1`] = `
+{
+  "_cmd": "de v 14, wa w v 3",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 14, wa w v 4 1`] = `
+{
+  "_cmd": "de v 14, wa w v 4",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`de v 14, wa w v 5 1`] = `
+{
+  "_cmd": "de v 14, wa w v 5",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 14, wa w v 6 1`] = `
+{
+  "_cmd": "de v 14, wa w v 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 14, wa w v 7 1`] = `
+{
+  "_cmd": "de v 14, wa w v 7",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`de v 14, wa w v 8 1`] = `
+{
+  "_cmd": "de v 14, wa w v 8",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`de v 14, wa w v 9 1`] = `
+{
+  "_cmd": "de v 14, wa w v 9",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`de v 14, wa w v 10 1`] = `
+{
+  "_cmd": "de v 14, wa w v 10",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`de v 14, wa w v 11 1`] = `
+{
+  "_cmd": "de v 14, wa w v 11",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`de v 14, wa w v 12 1`] = `
+{
+  "_cmd": "de v 14, wa w v 12",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`de v 14, wa w v 13 1`] = `
+{
+  "_cmd": "de v 14, wa w v 13",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`de v 14, wa w v 14 1`] = `
+{
+  "_cmd": "de v 14, wa w v 14",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`de v 14, wa w v 15 1`] = `
+{
+  "_cmd": "de v 14, wa w v 15",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`de v 15, wa d 1 1`] = `
+{
+  "_cmd": "de v 15, wa d 1",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, wa d 2 1`] = `
+{
+  "_cmd": "de v 15, wa d 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, wa d 3 1`] = `
+{
+  "_cmd": "de v 15, wa d 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, wa d 4 1`] = `
+{
+  "_cmd": "de v 15, wa d 4",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, wa d 5 1`] = `
+{
+  "_cmd": "de v 15, wa d 5",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa d 6 1`] = `
+{
+  "_cmd": "de v 15, wa d 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa d 7 1`] = `
+{
+  "_cmd": "de v 15, wa d 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa d 8 1`] = `
+{
+  "_cmd": "de v 15, wa d 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa d 9 1`] = `
+{
+  "_cmd": "de v 15, wa d 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa d 10 1`] = `
+{
+  "_cmd": "de v 15, wa d 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa d v 1 1`] = `
+{
+  "_cmd": "de v 15, wa d v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, wa d v 2 1`] = `
+{
+  "_cmd": "de v 15, wa d v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, wa d v 3 1`] = `
+{
+  "_cmd": "de v 15, wa d v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, wa d v 4 1`] = `
+{
+  "_cmd": "de v 15, wa d v 4",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, wa d v 5 1`] = `
+{
+  "_cmd": "de v 15, wa d v 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa d v 6 1`] = `
+{
+  "_cmd": "de v 15, wa d v 6",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, wa d v 7 1`] = `
+{
+  "_cmd": "de v 15, wa d v 7",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa d v 8 1`] = `
+{
+  "_cmd": "de v 15, wa d v 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa d v 9 1`] = `
+{
+  "_cmd": "de v 15, wa d v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa d v 10 1`] = `
+{
+  "_cmd": "de v 15, wa d v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa d v 11 1`] = `
+{
+  "_cmd": "de v 15, wa d v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, wa d v 12 1`] = `
+{
+  "_cmd": "de v 15, wa d v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, wa d v 13 1`] = `
+{
+  "_cmd": "de v 15, wa d v 13",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, wa d v 14 1`] = `
+{
+  "_cmd": "de v 15, wa d v 14",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, wa d v 15 1`] = `
+{
+  "_cmd": "de v 15, wa d v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, wa p 1 1`] = `
+{
+  "_cmd": "de v 15, wa p 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, wa p 2 1`] = `
+{
+  "_cmd": "de v 15, wa p 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, wa p 3 1`] = `
+{
+  "_cmd": "de v 15, wa p 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, wa p 4 1`] = `
+{
+  "_cmd": "de v 15, wa p 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, wa p 5 1`] = `
+{
+  "_cmd": "de v 15, wa p 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa p 6 1`] = `
+{
+  "_cmd": "de v 15, wa p 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, wa p 7 1`] = `
+{
+  "_cmd": "de v 15, wa p 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa p 8 1`] = `
+{
+  "_cmd": "de v 15, wa p 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa p 9 1`] = `
+{
+  "_cmd": "de v 15, wa p 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa p 10 1`] = `
+{
+  "_cmd": "de v 15, wa p 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa p v 1 1`] = `
+{
+  "_cmd": "de v 15, wa p v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, wa p v 2 1`] = `
+{
+  "_cmd": "de v 15, wa p v 2",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, wa p v 3 1`] = `
+{
+  "_cmd": "de v 15, wa p v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, wa p v 4 1`] = `
+{
+  "_cmd": "de v 15, wa p v 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, wa p v 5 1`] = `
+{
+  "_cmd": "de v 15, wa p v 5",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, wa p v 6 1`] = `
+{
+  "_cmd": "de v 15, wa p v 6",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa p v 7 1`] = `
+{
+  "_cmd": "de v 15, wa p v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa p v 8 1`] = `
+{
+  "_cmd": "de v 15, wa p v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa p v 9 1`] = `
+{
+  "_cmd": "de v 15, wa p v 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa p v 10 1`] = `
+{
+  "_cmd": "de v 15, wa p v 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa p v 11 1`] = `
+{
+  "_cmd": "de v 15, wa p v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa p v 12 1`] = `
+{
+  "_cmd": "de v 15, wa p v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, wa p v 13 1`] = `
+{
+  "_cmd": "de v 15, wa p v 13",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, wa p v 14 1`] = `
+{
+  "_cmd": "de v 15, wa p v 14",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, wa p v 15 1`] = `
+{
+  "_cmd": "de v 15, wa p v 15",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, wa v 1 1`] = `
+{
+  "_cmd": "de v 15, wa v 1",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`de v 15, wa v 2 1`] = `
+{
+  "_cmd": "de v 15, wa v 2",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, wa v 3 1`] = `
+{
+  "_cmd": "de v 15, wa v 3",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, wa v 4 1`] = `
+{
+  "_cmd": "de v 15, wa v 4",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, wa v 5 1`] = `
+{
+  "_cmd": "de v 15, wa v 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa v 6 1`] = `
+{
+  "_cmd": "de v 15, wa v 6",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, wa v 7 1`] = `
+{
+  "_cmd": "de v 15, wa v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa v 8 1`] = `
+{
+  "_cmd": "de v 15, wa v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa v 9 1`] = `
+{
+  "_cmd": "de v 15, wa v 9",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa v 10 1`] = `
+{
+  "_cmd": "de v 15, wa v 10",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa v 11 1`] = `
+{
+  "_cmd": "de v 15, wa v 11",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa v 12 1`] = `
+{
+  "_cmd": "de v 15, wa v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 15, wa v 13 1`] = `
+{
+  "_cmd": "de v 15, wa v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, wa v 14 1`] = `
+{
+  "_cmd": "de v 15, wa v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, wa v 15 1`] = `
+{
+  "_cmd": "de v 15, wa v 15",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, wa w 1 1`] = `
+{
+  "_cmd": "de v 15, wa w 1",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`de v 15, wa w 2 1`] = `
+{
+  "_cmd": "de v 15, wa w 2",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`de v 15, wa w 3 1`] = `
+{
+  "_cmd": "de v 15, wa w 3",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, wa w 4 1`] = `
+{
+  "_cmd": "de v 15, wa w 4",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa w 5 1`] = `
+{
+  "_cmd": "de v 15, wa w 5",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, wa w 6 1`] = `
+{
+  "_cmd": "de v 15, wa w 6",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa w 7 1`] = `
+{
+  "_cmd": "de v 15, wa w 7",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa w 8 1`] = `
+{
+  "_cmd": "de v 15, wa w 8",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa w 9 1`] = `
+{
+  "_cmd": "de v 15, wa w 9",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa w 10 1`] = `
+{
+  "_cmd": "de v 15, wa w 10",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, wa w v 1 1`] = `
+{
+  "_cmd": "de v 15, wa w v 1",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`de v 15, wa w v 2 1`] = `
+{
+  "_cmd": "de v 15, wa w v 2",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`de v 15, wa w v 3 1`] = `
+{
+  "_cmd": "de v 15, wa w v 3",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 15, wa w v 4 1`] = `
+{
+  "_cmd": "de v 15, wa w v 4",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`de v 15, wa w v 5 1`] = `
+{
+  "_cmd": "de v 15, wa w v 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 15, wa w v 6 1`] = `
+{
+  "_cmd": "de v 15, wa w v 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 15, wa w v 7 1`] = `
+{
+  "_cmd": "de v 15, wa w v 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 15, wa w v 8 1`] = `
+{
+  "_cmd": "de v 15, wa w v 8",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`de v 15, wa w v 9 1`] = `
+{
+  "_cmd": "de v 15, wa w v 9",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`de v 15, wa w v 10 1`] = `
+{
+  "_cmd": "de v 15, wa w v 10",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`de v 15, wa w v 11 1`] = `
+{
+  "_cmd": "de v 15, wa w v 11",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`de v 15, wa w v 12 1`] = `
+{
+  "_cmd": "de v 15, wa w v 12",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`de v 15, wa w v 13 1`] = `
+{
+  "_cmd": "de v 15, wa w v 13",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`de v 15, wa w v 14 1`] = `
+{
+  "_cmd": "de v 15, wa w v 14",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`de v 15, wa w v 15 1`] = `
+{
+  "_cmd": "de v 15, wa w v 15",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`de v 16, wa d 1 1`] = `
+{
+  "_cmd": "de v 16, wa d 1",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, wa d 2 1`] = `
+{
+  "_cmd": "de v 16, wa d 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, wa d 3 1`] = `
+{
+  "_cmd": "de v 16, wa d 3",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, wa d 4 1`] = `
+{
+  "_cmd": "de v 16, wa d 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, wa d 5 1`] = `
+{
+  "_cmd": "de v 16, wa d 5",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa d 6 1`] = `
+{
+  "_cmd": "de v 16, wa d 6",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa d 7 1`] = `
+{
+  "_cmd": "de v 16, wa d 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa d 8 1`] = `
+{
+  "_cmd": "de v 16, wa d 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa d 9 1`] = `
+{
+  "_cmd": "de v 16, wa d 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa d 10 1`] = `
+{
+  "_cmd": "de v 16, wa d 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa d v 1 1`] = `
+{
+  "_cmd": "de v 16, wa d v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, wa d v 2 1`] = `
+{
+  "_cmd": "de v 16, wa d v 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, wa d v 3 1`] = `
+{
+  "_cmd": "de v 16, wa d v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa d v 4 1`] = `
+{
+  "_cmd": "de v 16, wa d v 4",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, wa d v 5 1`] = `
+{
+  "_cmd": "de v 16, wa d v 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa d v 6 1`] = `
+{
+  "_cmd": "de v 16, wa d v 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, wa d v 7 1`] = `
+{
+  "_cmd": "de v 16, wa d v 7",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa d v 8 1`] = `
+{
+  "_cmd": "de v 16, wa d v 8",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa d v 9 1`] = `
+{
+  "_cmd": "de v 16, wa d v 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa d v 10 1`] = `
+{
+  "_cmd": "de v 16, wa d v 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa d v 11 1`] = `
+{
+  "_cmd": "de v 16, wa d v 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, wa d v 12 1`] = `
+{
+  "_cmd": "de v 16, wa d v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, wa d v 13 1`] = `
+{
+  "_cmd": "de v 16, wa d v 13",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, wa d v 14 1`] = `
+{
+  "_cmd": "de v 16, wa d v 14",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, wa d v 15 1`] = `
+{
+  "_cmd": "de v 16, wa d v 15",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, wa p 1 1`] = `
+{
+  "_cmd": "de v 16, wa p 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, wa p 2 1`] = `
+{
+  "_cmd": "de v 16, wa p 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, wa p 3 1`] = `
+{
+  "_cmd": "de v 16, wa p 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa p 4 1`] = `
+{
+  "_cmd": "de v 16, wa p 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, wa p 5 1`] = `
+{
+  "_cmd": "de v 16, wa p 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa p 6 1`] = `
+{
+  "_cmd": "de v 16, wa p 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, wa p 7 1`] = `
+{
+  "_cmd": "de v 16, wa p 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa p 8 1`] = `
+{
+  "_cmd": "de v 16, wa p 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa p 9 1`] = `
+{
+  "_cmd": "de v 16, wa p 9",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa p 10 1`] = `
+{
+  "_cmd": "de v 16, wa p 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa p v 1 1`] = `
+{
+  "_cmd": "de v 16, wa p v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, wa p v 2 1`] = `
+{
+  "_cmd": "de v 16, wa p v 2",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, wa p v 3 1`] = `
+{
+  "_cmd": "de v 16, wa p v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa p v 4 1`] = `
+{
+  "_cmd": "de v 16, wa p v 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, wa p v 5 1`] = `
+{
+  "_cmd": "de v 16, wa p v 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, wa p v 6 1`] = `
+{
+  "_cmd": "de v 16, wa p v 6",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa p v 7 1`] = `
+{
+  "_cmd": "de v 16, wa p v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa p v 8 1`] = `
+{
+  "_cmd": "de v 16, wa p v 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa p v 9 1`] = `
+{
+  "_cmd": "de v 16, wa p v 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa p v 10 1`] = `
+{
+  "_cmd": "de v 16, wa p v 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa p v 11 1`] = `
+{
+  "_cmd": "de v 16, wa p v 11",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa p v 12 1`] = `
+{
+  "_cmd": "de v 16, wa p v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, wa p v 13 1`] = `
+{
+  "_cmd": "de v 16, wa p v 13",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, wa p v 14 1`] = `
+{
+  "_cmd": "de v 16, wa p v 14",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, wa p v 15 1`] = `
+{
+  "_cmd": "de v 16, wa p v 15",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, wa v 1 1`] = `
+{
+  "_cmd": "de v 16, wa v 1",
+  "attacker": 16,
+  "defender": -3,
+}
+`;
+
+exports[`de v 16, wa v 2 1`] = `
+{
+  "_cmd": "de v 16, wa v 2",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, wa v 3 1`] = `
+{
+  "_cmd": "de v 16, wa v 3",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa v 4 1`] = `
+{
+  "_cmd": "de v 16, wa v 4",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, wa v 5 1`] = `
+{
+  "_cmd": "de v 16, wa v 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa v 6 1`] = `
+{
+  "_cmd": "de v 16, wa v 6",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, wa v 7 1`] = `
+{
+  "_cmd": "de v 16, wa v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa v 8 1`] = `
+{
+  "_cmd": "de v 16, wa v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa v 9 1`] = `
+{
+  "_cmd": "de v 16, wa v 9",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa v 10 1`] = `
+{
+  "_cmd": "de v 16, wa v 10",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa v 11 1`] = `
+{
+  "_cmd": "de v 16, wa v 11",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa v 12 1`] = `
+{
+  "_cmd": "de v 16, wa v 12",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, wa v 13 1`] = `
+{
+  "_cmd": "de v 16, wa v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 16, wa v 14 1`] = `
+{
+  "_cmd": "de v 16, wa v 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, wa v 15 1`] = `
+{
+  "_cmd": "de v 16, wa v 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, wa w 1 1`] = `
+{
+  "_cmd": "de v 16, wa w 1",
+  "attacker": 16,
+  "defender": -1,
+}
+`;
+
+exports[`de v 16, wa w 2 1`] = `
+{
+  "_cmd": "de v 16, wa w 2",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa w 3 1`] = `
+{
+  "_cmd": "de v 16, wa w 3",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`de v 16, wa w 4 1`] = `
+{
+  "_cmd": "de v 16, wa w 4",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa w 5 1`] = `
+{
+  "_cmd": "de v 16, wa w 5",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, wa w 6 1`] = `
+{
+  "_cmd": "de v 16, wa w 6",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa w 7 1`] = `
+{
+  "_cmd": "de v 16, wa w 7",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa w 8 1`] = `
+{
+  "_cmd": "de v 16, wa w 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa w 9 1`] = `
+{
+  "_cmd": "de v 16, wa w 9",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa w 10 1`] = `
+{
+  "_cmd": "de v 16, wa w 10",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, wa w v 1 1`] = `
+{
+  "_cmd": "de v 16, wa w v 1",
+  "attacker": 16,
+  "defender": -2,
+}
+`;
+
+exports[`de v 16, wa w v 2 1`] = `
+{
+  "_cmd": "de v 16, wa w v 2",
+  "attacker": 16,
+  "defender": 0,
+}
+`;
+
+exports[`de v 16, wa w v 3 1`] = `
+{
+  "_cmd": "de v 16, wa w v 3",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`de v 16, wa w v 4 1`] = `
+{
+  "_cmd": "de v 16, wa w v 4",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`de v 16, wa w v 5 1`] = `
+{
+  "_cmd": "de v 16, wa w v 5",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`de v 16, wa w v 6 1`] = `
+{
+  "_cmd": "de v 16, wa w v 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 16, wa w v 7 1`] = `
+{
+  "_cmd": "de v 16, wa w v 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 16, wa w v 8 1`] = `
+{
+  "_cmd": "de v 16, wa w v 8",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`de v 16, wa w v 9 1`] = `
+{
+  "_cmd": "de v 16, wa w v 9",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`de v 16, wa w v 10 1`] = `
+{
+  "_cmd": "de v 16, wa w v 10",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`de v 16, wa w v 11 1`] = `
+{
+  "_cmd": "de v 16, wa w v 11",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`de v 16, wa w v 12 1`] = `
+{
+  "_cmd": "de v 16, wa w v 12",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`de v 16, wa w v 13 1`] = `
+{
+  "_cmd": "de v 16, wa w v 13",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`de v 16, wa w v 14 1`] = `
+{
+  "_cmd": "de v 16, wa w v 14",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`de v 16, wa w v 15 1`] = `
+{
+  "_cmd": "de v 16, wa w v 15",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`de v 17, wa d 1 1`] = `
+{
+  "_cmd": "de v 17, wa d 1",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, wa d 2 1`] = `
+{
+  "_cmd": "de v 17, wa d 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, wa d 3 1`] = `
+{
+  "_cmd": "de v 17, wa d 3",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, wa d 4 1`] = `
+{
+  "_cmd": "de v 17, wa d 4",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, wa d 5 1`] = `
+{
+  "_cmd": "de v 17, wa d 5",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa d 6 1`] = `
+{
+  "_cmd": "de v 17, wa d 6",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa d 7 1`] = `
+{
+  "_cmd": "de v 17, wa d 7",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa d 8 1`] = `
+{
+  "_cmd": "de v 17, wa d 8",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa d 9 1`] = `
+{
+  "_cmd": "de v 17, wa d 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa d 10 1`] = `
+{
+  "_cmd": "de v 17, wa d 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa d v 1 1`] = `
+{
+  "_cmd": "de v 17, wa d v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, wa d v 2 1`] = `
+{
+  "_cmd": "de v 17, wa d v 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, wa d v 3 1`] = `
+{
+  "_cmd": "de v 17, wa d v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa d v 4 1`] = `
+{
+  "_cmd": "de v 17, wa d v 4",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, wa d v 5 1`] = `
+{
+  "_cmd": "de v 17, wa d v 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa d v 6 1`] = `
+{
+  "_cmd": "de v 17, wa d v 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa d v 7 1`] = `
+{
+  "_cmd": "de v 17, wa d v 7",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa d v 8 1`] = `
+{
+  "_cmd": "de v 17, wa d v 8",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa d v 9 1`] = `
+{
+  "_cmd": "de v 17, wa d v 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa d v 10 1`] = `
+{
+  "_cmd": "de v 17, wa d v 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa d v 11 1`] = `
+{
+  "_cmd": "de v 17, wa d v 11",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, wa d v 12 1`] = `
+{
+  "_cmd": "de v 17, wa d v 12",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, wa d v 13 1`] = `
+{
+  "_cmd": "de v 17, wa d v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, wa d v 14 1`] = `
+{
+  "_cmd": "de v 17, wa d v 14",
+  "attacker": 10,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, wa d v 15 1`] = `
+{
+  "_cmd": "de v 17, wa d v 15",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, wa p 1 1`] = `
+{
+  "_cmd": "de v 17, wa p 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, wa p 2 1`] = `
+{
+  "_cmd": "de v 17, wa p 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, wa p 3 1`] = `
+{
+  "_cmd": "de v 17, wa p 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa p 4 1`] = `
+{
+  "_cmd": "de v 17, wa p 4",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, wa p 5 1`] = `
+{
+  "_cmd": "de v 17, wa p 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa p 6 1`] = `
+{
+  "_cmd": "de v 17, wa p 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa p 7 1`] = `
+{
+  "_cmd": "de v 17, wa p 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa p 8 1`] = `
+{
+  "_cmd": "de v 17, wa p 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa p 9 1`] = `
+{
+  "_cmd": "de v 17, wa p 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa p 10 1`] = `
+{
+  "_cmd": "de v 17, wa p 10",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa p v 1 1`] = `
+{
+  "_cmd": "de v 17, wa p v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, wa p v 2 1`] = `
+{
+  "_cmd": "de v 17, wa p v 2",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, wa p v 3 1`] = `
+{
+  "_cmd": "de v 17, wa p v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa p v 4 1`] = `
+{
+  "_cmd": "de v 17, wa p v 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, wa p v 5 1`] = `
+{
+  "_cmd": "de v 17, wa p v 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, wa p v 6 1`] = `
+{
+  "_cmd": "de v 17, wa p v 6",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa p v 7 1`] = `
+{
+  "_cmd": "de v 17, wa p v 7",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa p v 8 1`] = `
+{
+  "_cmd": "de v 17, wa p v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa p v 9 1`] = `
+{
+  "_cmd": "de v 17, wa p v 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa p v 10 1`] = `
+{
+  "_cmd": "de v 17, wa p v 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa p v 11 1`] = `
+{
+  "_cmd": "de v 17, wa p v 11",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa p v 12 1`] = `
+{
+  "_cmd": "de v 17, wa p v 12",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, wa p v 13 1`] = `
+{
+  "_cmd": "de v 17, wa p v 13",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, wa p v 14 1`] = `
+{
+  "_cmd": "de v 17, wa p v 14",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, wa p v 15 1`] = `
+{
+  "_cmd": "de v 17, wa p v 15",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, wa v 1 1`] = `
+{
+  "_cmd": "de v 17, wa v 1",
+  "attacker": 17,
+  "defender": -3,
+}
+`;
+
+exports[`de v 17, wa v 2 1`] = `
+{
+  "_cmd": "de v 17, wa v 2",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, wa v 3 1`] = `
+{
+  "_cmd": "de v 17, wa v 3",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa v 4 1`] = `
+{
+  "_cmd": "de v 17, wa v 4",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, wa v 5 1`] = `
+{
+  "_cmd": "de v 17, wa v 5",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, wa v 6 1`] = `
+{
+  "_cmd": "de v 17, wa v 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa v 7 1`] = `
+{
+  "_cmd": "de v 17, wa v 7",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa v 8 1`] = `
+{
+  "_cmd": "de v 17, wa v 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa v 9 1`] = `
+{
+  "_cmd": "de v 17, wa v 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa v 10 1`] = `
+{
+  "_cmd": "de v 17, wa v 10",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa v 11 1`] = `
+{
+  "_cmd": "de v 17, wa v 11",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa v 12 1`] = `
+{
+  "_cmd": "de v 17, wa v 12",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, wa v 13 1`] = `
+{
+  "_cmd": "de v 17, wa v 13",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de v 17, wa v 14 1`] = `
+{
+  "_cmd": "de v 17, wa v 14",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, wa v 15 1`] = `
+{
+  "_cmd": "de v 17, wa v 15",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, wa w 1 1`] = `
+{
+  "_cmd": "de v 17, wa w 1",
+  "attacker": 17,
+  "defender": -1,
+}
+`;
+
+exports[`de v 17, wa w 2 1`] = `
+{
+  "_cmd": "de v 17, wa w 2",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa w 3 1`] = `
+{
+  "_cmd": "de v 17, wa w 3",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`de v 17, wa w 4 1`] = `
+{
+  "_cmd": "de v 17, wa w 4",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa w 5 1`] = `
+{
+  "_cmd": "de v 17, wa w 5",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa w 6 1`] = `
+{
+  "_cmd": "de v 17, wa w 6",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa w 7 1`] = `
+{
+  "_cmd": "de v 17, wa w 7",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa w 8 1`] = `
+{
+  "_cmd": "de v 17, wa w 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa w 9 1`] = `
+{
+  "_cmd": "de v 17, wa w 9",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa w 10 1`] = `
+{
+  "_cmd": "de v 17, wa w 10",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, wa w v 1 1`] = `
+{
+  "_cmd": "de v 17, wa w v 1",
+  "attacker": 17,
+  "defender": -2,
+}
+`;
+
+exports[`de v 17, wa w v 2 1`] = `
+{
+  "_cmd": "de v 17, wa w v 2",
+  "attacker": 17,
+  "defender": 0,
+}
+`;
+
+exports[`de v 17, wa w v 3 1`] = `
+{
+  "_cmd": "de v 17, wa w v 3",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`de v 17, wa w v 4 1`] = `
+{
+  "_cmd": "de v 17, wa w v 4",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 17, wa w v 5 1`] = `
+{
+  "_cmd": "de v 17, wa w v 5",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`de v 17, wa w v 6 1`] = `
+{
+  "_cmd": "de v 17, wa w v 6",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 17, wa w v 7 1`] = `
+{
+  "_cmd": "de v 17, wa w v 7",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 17, wa w v 8 1`] = `
+{
+  "_cmd": "de v 17, wa w v 8",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`de v 17, wa w v 9 1`] = `
+{
+  "_cmd": "de v 17, wa w v 9",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`de v 17, wa w v 10 1`] = `
+{
+  "_cmd": "de v 17, wa w v 10",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`de v 17, wa w v 11 1`] = `
+{
+  "_cmd": "de v 17, wa w v 11",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`de v 17, wa w v 12 1`] = `
+{
+  "_cmd": "de v 17, wa w v 12",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`de v 17, wa w v 13 1`] = `
+{
+  "_cmd": "de v 17, wa w v 13",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`de v 17, wa w v 14 1`] = `
+{
+  "_cmd": "de v 17, wa w v 14",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`de v 17, wa w v 15 1`] = `
+{
+  "_cmd": "de v 17, wa w v 15",
+  "attacker": 9,
+  "defender": 15,
+}
+`;
+
+exports[`de v 18, wa d 1 1`] = `
+{
+  "_cmd": "de v 18, wa d 1",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, wa d 2 1`] = `
+{
+  "_cmd": "de v 18, wa d 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, wa d 3 1`] = `
+{
+  "_cmd": "de v 18, wa d 3",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, wa d 4 1`] = `
+{
+  "_cmd": "de v 18, wa d 4",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa d 5 1`] = `
+{
+  "_cmd": "de v 18, wa d 5",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, wa d 6 1`] = `
+{
+  "_cmd": "de v 18, wa d 6",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa d 7 1`] = `
+{
+  "_cmd": "de v 18, wa d 7",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa d 8 1`] = `
+{
+  "_cmd": "de v 18, wa d 8",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa d 9 1`] = `
+{
+  "_cmd": "de v 18, wa d 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa d 10 1`] = `
+{
+  "_cmd": "de v 18, wa d 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, wa d v 1 1`] = `
+{
+  "_cmd": "de v 18, wa d v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, wa d v 2 1`] = `
+{
+  "_cmd": "de v 18, wa d v 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, wa d v 3 1`] = `
+{
+  "_cmd": "de v 18, wa d v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa d v 4 1`] = `
+{
+  "_cmd": "de v 18, wa d v 4",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa d v 5 1`] = `
+{
+  "_cmd": "de v 18, wa d v 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, wa d v 6 1`] = `
+{
+  "_cmd": "de v 18, wa d v 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa d v 7 1`] = `
+{
+  "_cmd": "de v 18, wa d v 7",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, wa d v 8 1`] = `
+{
+  "_cmd": "de v 18, wa d v 8",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa d v 9 1`] = `
+{
+  "_cmd": "de v 18, wa d v 9",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa d v 10 1`] = `
+{
+  "_cmd": "de v 18, wa d v 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, wa d v 11 1`] = `
+{
+  "_cmd": "de v 18, wa d v 11",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, wa d v 12 1`] = `
+{
+  "_cmd": "de v 18, wa d v 12",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, wa d v 13 1`] = `
+{
+  "_cmd": "de v 18, wa d v 13",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, wa d v 14 1`] = `
+{
+  "_cmd": "de v 18, wa d v 14",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, wa d v 15 1`] = `
+{
+  "_cmd": "de v 18, wa d v 15",
+  "attacker": 11,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, wa p 1 1`] = `
+{
+  "_cmd": "de v 18, wa p 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, wa p 2 1`] = `
+{
+  "_cmd": "de v 18, wa p 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, wa p 3 1`] = `
+{
+  "_cmd": "de v 18, wa p 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa p 4 1`] = `
+{
+  "_cmd": "de v 18, wa p 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, wa p 5 1`] = `
+{
+  "_cmd": "de v 18, wa p 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa p 6 1`] = `
+{
+  "_cmd": "de v 18, wa p 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa p 7 1`] = `
+{
+  "_cmd": "de v 18, wa p 7",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, wa p 8 1`] = `
+{
+  "_cmd": "de v 18, wa p 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa p 9 1`] = `
+{
+  "_cmd": "de v 18, wa p 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa p 10 1`] = `
+{
+  "_cmd": "de v 18, wa p 10",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa p v 1 1`] = `
+{
+  "_cmd": "de v 18, wa p v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, wa p v 2 1`] = `
+{
+  "_cmd": "de v 18, wa p v 2",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, wa p v 3 1`] = `
+{
+  "_cmd": "de v 18, wa p v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa p v 4 1`] = `
+{
+  "_cmd": "de v 18, wa p v 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, wa p v 5 1`] = `
+{
+  "_cmd": "de v 18, wa p v 5",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa p v 6 1`] = `
+{
+  "_cmd": "de v 18, wa p v 6",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, wa p v 7 1`] = `
+{
+  "_cmd": "de v 18, wa p v 7",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa p v 8 1`] = `
+{
+  "_cmd": "de v 18, wa p v 8",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa p v 9 1`] = `
+{
+  "_cmd": "de v 18, wa p v 9",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa p v 10 1`] = `
+{
+  "_cmd": "de v 18, wa p v 10",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa p v 11 1`] = `
+{
+  "_cmd": "de v 18, wa p v 11",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, wa p v 12 1`] = `
+{
+  "_cmd": "de v 18, wa p v 12",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, wa p v 13 1`] = `
+{
+  "_cmd": "de v 18, wa p v 13",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, wa p v 14 1`] = `
+{
+  "_cmd": "de v 18, wa p v 14",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, wa p v 15 1`] = `
+{
+  "_cmd": "de v 18, wa p v 15",
+  "attacker": 13,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, wa v 1 1`] = `
+{
+  "_cmd": "de v 18, wa v 1",
+  "attacker": 18,
+  "defender": -3,
+}
+`;
+
+exports[`de v 18, wa v 2 1`] = `
+{
+  "_cmd": "de v 18, wa v 2",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, wa v 3 1`] = `
+{
+  "_cmd": "de v 18, wa v 3",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa v 4 1`] = `
+{
+  "_cmd": "de v 18, wa v 4",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, wa v 5 1`] = `
+{
+  "_cmd": "de v 18, wa v 5",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa v 6 1`] = `
+{
+  "_cmd": "de v 18, wa v 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa v 7 1`] = `
+{
+  "_cmd": "de v 18, wa v 7",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, wa v 8 1`] = `
+{
+  "_cmd": "de v 18, wa v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa v 9 1`] = `
+{
+  "_cmd": "de v 18, wa v 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa v 10 1`] = `
+{
+  "_cmd": "de v 18, wa v 10",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa v 11 1`] = `
+{
+  "_cmd": "de v 18, wa v 11",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, wa v 12 1`] = `
+{
+  "_cmd": "de v 18, wa v 12",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, wa v 13 1`] = `
+{
+  "_cmd": "de v 18, wa v 13",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, wa v 14 1`] = `
+{
+  "_cmd": "de v 18, wa v 14",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de v 18, wa v 15 1`] = `
+{
+  "_cmd": "de v 18, wa v 15",
+  "attacker": 12,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, wa w 1 1`] = `
+{
+  "_cmd": "de v 18, wa w 1",
+  "attacker": 18,
+  "defender": -1,
+}
+`;
+
+exports[`de v 18, wa w 2 1`] = `
+{
+  "_cmd": "de v 18, wa w 2",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa w 3 1`] = `
+{
+  "_cmd": "de v 18, wa w 3",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`de v 18, wa w 4 1`] = `
+{
+  "_cmd": "de v 18, wa w 4",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, wa w 5 1`] = `
+{
+  "_cmd": "de v 18, wa w 5",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa w 6 1`] = `
+{
+  "_cmd": "de v 18, wa w 6",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, wa w 7 1`] = `
+{
+  "_cmd": "de v 18, wa w 7",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa w 8 1`] = `
+{
+  "_cmd": "de v 18, wa w 8",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa w 9 1`] = `
+{
+  "_cmd": "de v 18, wa w 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa w 10 1`] = `
+{
+  "_cmd": "de v 18, wa w 10",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, wa w v 1 1`] = `
+{
+  "_cmd": "de v 18, wa w v 1",
+  "attacker": 18,
+  "defender": -2,
+}
+`;
+
+exports[`de v 18, wa w v 2 1`] = `
+{
+  "_cmd": "de v 18, wa w v 2",
+  "attacker": 18,
+  "defender": 0,
+}
+`;
+
+exports[`de v 18, wa w v 3 1`] = `
+{
+  "_cmd": "de v 18, wa w v 3",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`de v 18, wa w v 4 1`] = `
+{
+  "_cmd": "de v 18, wa w v 4",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 18, wa w v 5 1`] = `
+{
+  "_cmd": "de v 18, wa w v 5",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`de v 18, wa w v 6 1`] = `
+{
+  "_cmd": "de v 18, wa w v 6",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 18, wa w v 7 1`] = `
+{
+  "_cmd": "de v 18, wa w v 7",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 18, wa w v 8 1`] = `
+{
+  "_cmd": "de v 18, wa w v 8",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 18, wa w v 9 1`] = `
+{
+  "_cmd": "de v 18, wa w v 9",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`de v 18, wa w v 10 1`] = `
+{
+  "_cmd": "de v 18, wa w v 10",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`de v 18, wa w v 11 1`] = `
+{
+  "_cmd": "de v 18, wa w v 11",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`de v 18, wa w v 12 1`] = `
+{
+  "_cmd": "de v 18, wa w v 12",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`de v 18, wa w v 13 1`] = `
+{
+  "_cmd": "de v 18, wa w v 13",
+  "attacker": 10,
+  "defender": 12,
+}
+`;
+
+exports[`de v 18, wa w v 14 1`] = `
+{
+  "_cmd": "de v 18, wa w v 14",
+  "attacker": 10,
+  "defender": 14,
+}
+`;
+
+exports[`de v 18, wa w v 15 1`] = `
+{
+  "_cmd": "de v 18, wa w v 15",
+  "attacker": 10,
+  "defender": 15,
+}
+`;
+
+exports[`de v 19, wa d 1 1`] = `
+{
+  "_cmd": "de v 19, wa d 1",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, wa d 2 1`] = `
+{
+  "_cmd": "de v 19, wa d 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, wa d 3 1`] = `
+{
+  "_cmd": "de v 19, wa d 3",
+  "attacker": 15,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, wa d 4 1`] = `
+{
+  "_cmd": "de v 19, wa d 4",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa d 5 1`] = `
+{
+  "_cmd": "de v 19, wa d 5",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, wa d 6 1`] = `
+{
+  "_cmd": "de v 19, wa d 6",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa d 7 1`] = `
+{
+  "_cmd": "de v 19, wa d 7",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa d 8 1`] = `
+{
+  "_cmd": "de v 19, wa d 8",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa d 9 1`] = `
+{
+  "_cmd": "de v 19, wa d 9",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa d 10 1`] = `
+{
+  "_cmd": "de v 19, wa d 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, wa d v 1 1`] = `
+{
+  "_cmd": "de v 19, wa d v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, wa d v 2 1`] = `
+{
+  "_cmd": "de v 19, wa d v 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, wa d v 3 1`] = `
+{
+  "_cmd": "de v 19, wa d v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa d v 4 1`] = `
+{
+  "_cmd": "de v 19, wa d v 4",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa d v 5 1`] = `
+{
+  "_cmd": "de v 19, wa d v 5",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, wa d v 6 1`] = `
+{
+  "_cmd": "de v 19, wa d v 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa d v 7 1`] = `
+{
+  "_cmd": "de v 19, wa d v 7",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa d v 8 1`] = `
+{
+  "_cmd": "de v 19, wa d v 8",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa d v 9 1`] = `
+{
+  "_cmd": "de v 19, wa d v 9",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa d v 10 1`] = `
+{
+  "_cmd": "de v 19, wa d v 10",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, wa d v 11 1`] = `
+{
+  "_cmd": "de v 19, wa d v 11",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, wa d v 12 1`] = `
+{
+  "_cmd": "de v 19, wa d v 12",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, wa d v 13 1`] = `
+{
+  "_cmd": "de v 19, wa d v 13",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, wa d v 14 1`] = `
+{
+  "_cmd": "de v 19, wa d v 14",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, wa d v 15 1`] = `
+{
+  "_cmd": "de v 19, wa d v 15",
+  "attacker": 12,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, wa p 1 1`] = `
+{
+  "_cmd": "de v 19, wa p 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, wa p 2 1`] = `
+{
+  "_cmd": "de v 19, wa p 2",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, wa p 3 1`] = `
+{
+  "_cmd": "de v 19, wa p 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa p 4 1`] = `
+{
+  "_cmd": "de v 19, wa p 4",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, wa p 5 1`] = `
+{
+  "_cmd": "de v 19, wa p 5",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa p 6 1`] = `
+{
+  "_cmd": "de v 19, wa p 6",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa p 7 1`] = `
+{
+  "_cmd": "de v 19, wa p 7",
+  "attacker": 14,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa p 8 1`] = `
+{
+  "_cmd": "de v 19, wa p 8",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa p 9 1`] = `
+{
+  "_cmd": "de v 19, wa p 9",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa p 10 1`] = `
+{
+  "_cmd": "de v 19, wa p 10",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa p v 1 1`] = `
+{
+  "_cmd": "de v 19, wa p v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, wa p v 2 1`] = `
+{
+  "_cmd": "de v 19, wa p v 2",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, wa p v 3 1`] = `
+{
+  "_cmd": "de v 19, wa p v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa p v 4 1`] = `
+{
+  "_cmd": "de v 19, wa p v 4",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, wa p v 5 1`] = `
+{
+  "_cmd": "de v 19, wa p v 5",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa p v 6 1`] = `
+{
+  "_cmd": "de v 19, wa p v 6",
+  "attacker": 16,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, wa p v 7 1`] = `
+{
+  "_cmd": "de v 19, wa p v 7",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa p v 8 1`] = `
+{
+  "_cmd": "de v 19, wa p v 8",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa p v 9 1`] = `
+{
+  "_cmd": "de v 19, wa p v 9",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa p v 10 1`] = `
+{
+  "_cmd": "de v 19, wa p v 10",
+  "attacker": 15,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa p v 11 1`] = `
+{
+  "_cmd": "de v 19, wa p v 11",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, wa p v 12 1`] = `
+{
+  "_cmd": "de v 19, wa p v 12",
+  "attacker": 14,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, wa p v 13 1`] = `
+{
+  "_cmd": "de v 19, wa p v 13",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, wa p v 14 1`] = `
+{
+  "_cmd": "de v 19, wa p v 14",
+  "attacker": 14,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, wa p v 15 1`] = `
+{
+  "_cmd": "de v 19, wa p v 15",
+  "attacker": 14,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, wa v 1 1`] = `
+{
+  "_cmd": "de v 19, wa v 1",
+  "attacker": 19,
+  "defender": -3,
+}
+`;
+
+exports[`de v 19, wa v 2 1`] = `
+{
+  "_cmd": "de v 19, wa v 2",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, wa v 3 1`] = `
+{
+  "_cmd": "de v 19, wa v 3",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa v 4 1`] = `
+{
+  "_cmd": "de v 19, wa v 4",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, wa v 5 1`] = `
+{
+  "_cmd": "de v 19, wa v 5",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa v 6 1`] = `
+{
+  "_cmd": "de v 19, wa v 6",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa v 7 1`] = `
+{
+  "_cmd": "de v 19, wa v 7",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa v 8 1`] = `
+{
+  "_cmd": "de v 19, wa v 8",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa v 9 1`] = `
+{
+  "_cmd": "de v 19, wa v 9",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa v 10 1`] = `
+{
+  "_cmd": "de v 19, wa v 10",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa v 11 1`] = `
+{
+  "_cmd": "de v 19, wa v 11",
+  "attacker": 14,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, wa v 12 1`] = `
+{
+  "_cmd": "de v 19, wa v 12",
+  "attacker": 13,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, wa v 13 1`] = `
+{
+  "_cmd": "de v 19, wa v 13",
+  "attacker": 13,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, wa v 14 1`] = `
+{
+  "_cmd": "de v 19, wa v 14",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, wa v 15 1`] = `
+{
+  "_cmd": "de v 19, wa v 15",
+  "attacker": 13,
+  "defender": 14,
+}
+`;
+
+exports[`de v 19, wa w 1 1`] = `
+{
+  "_cmd": "de v 19, wa w 1",
+  "attacker": 19,
+  "defender": -1,
+}
+`;
+
+exports[`de v 19, wa w 2 1`] = `
+{
+  "_cmd": "de v 19, wa w 2",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa w 3 1`] = `
+{
+  "_cmd": "de v 19, wa w 3",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`de v 19, wa w 4 1`] = `
+{
+  "_cmd": "de v 19, wa w 4",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, wa w 5 1`] = `
+{
+  "_cmd": "de v 19, wa w 5",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa w 6 1`] = `
+{
+  "_cmd": "de v 19, wa w 6",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa w 7 1`] = `
+{
+  "_cmd": "de v 19, wa w 7",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa w 8 1`] = `
+{
+  "_cmd": "de v 19, wa w 8",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa w 9 1`] = `
+{
+  "_cmd": "de v 19, wa w 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa w 10 1`] = `
+{
+  "_cmd": "de v 19, wa w 10",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, wa w v 1 1`] = `
+{
+  "_cmd": "de v 19, wa w v 1",
+  "attacker": 19,
+  "defender": -2,
+}
+`;
+
+exports[`de v 19, wa w v 2 1`] = `
+{
+  "_cmd": "de v 19, wa w v 2",
+  "attacker": 19,
+  "defender": 0,
+}
+`;
+
+exports[`de v 19, wa w v 3 1`] = `
+{
+  "_cmd": "de v 19, wa w v 3",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`de v 19, wa w v 4 1`] = `
+{
+  "_cmd": "de v 19, wa w v 4",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 19, wa w v 5 1`] = `
+{
+  "_cmd": "de v 19, wa w v 5",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`de v 19, wa w v 6 1`] = `
+{
+  "_cmd": "de v 19, wa w v 6",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`de v 19, wa w v 7 1`] = `
+{
+  "_cmd": "de v 19, wa w v 7",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 19, wa w v 8 1`] = `
+{
+  "_cmd": "de v 19, wa w v 8",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 19, wa w v 9 1`] = `
+{
+  "_cmd": "de v 19, wa w v 9",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`de v 19, wa w v 10 1`] = `
+{
+  "_cmd": "de v 19, wa w v 10",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`de v 19, wa w v 11 1`] = `
+{
+  "_cmd": "de v 19, wa w v 11",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`de v 19, wa w v 12 1`] = `
+{
+  "_cmd": "de v 19, wa w v 12",
+  "attacker": 11,
+  "defender": 11,
+}
+`;
+
+exports[`de v 19, wa w v 13 1`] = `
+{
+  "_cmd": "de v 19, wa w v 13",
+  "attacker": 11,
+  "defender": 12,
+}
+`;
+
+exports[`de v 19, wa w v 14 1`] = `
+{
+  "_cmd": "de v 19, wa w v 14",
+  "attacker": 11,
+  "defender": 13,
+}
+`;
+
+exports[`de v 19, wa w v 15 1`] = `
+{
+  "_cmd": "de v 19, wa w v 15",
+  "attacker": 11,
+  "defender": 15,
+}
+`;
+
+exports[`de v 20, wa d 1 1`] = `
+{
+  "_cmd": "de v 20, wa d 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa d 2 1`] = `
+{
+  "_cmd": "de v 20, wa d 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, wa d 3 1`] = `
+{
+  "_cmd": "de v 20, wa d 3",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa d 4 1`] = `
+{
+  "_cmd": "de v 20, wa d 4",
+  "attacker": 15,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, wa d 5 1`] = `
+{
+  "_cmd": "de v 20, wa d 5",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa d 6 1`] = `
+{
+  "_cmd": "de v 20, wa d 6",
+  "attacker": 14,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa d 7 1`] = `
+{
+  "_cmd": "de v 20, wa d 7",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa d 8 1`] = `
+{
+  "_cmd": "de v 20, wa d 8",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa d 9 1`] = `
+{
+  "_cmd": "de v 20, wa d 9",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa d 10 1`] = `
+{
+  "_cmd": "de v 20, wa d 10",
+  "attacker": 13,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, wa d v 1 1`] = `
+{
+  "_cmd": "de v 20, wa d v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, wa d v 2 1`] = `
+{
+  "_cmd": "de v 20, wa d v 2",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, wa d v 3 1`] = `
+{
+  "_cmd": "de v 20, wa d v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, wa d v 4 1`] = `
+{
+  "_cmd": "de v 20, wa d v 4",
+  "attacker": 16,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa d v 5 1`] = `
+{
+  "_cmd": "de v 20, wa d v 5",
+  "attacker": 15,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa d v 6 1`] = `
+{
+  "_cmd": "de v 20, wa d v 6",
+  "attacker": 15,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa d v 7 1`] = `
+{
+  "_cmd": "de v 20, wa d v 7",
+  "attacker": 15,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa d v 8 1`] = `
+{
+  "_cmd": "de v 20, wa d v 8",
+  "attacker": 14,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa d v 9 1`] = `
+{
+  "_cmd": "de v 20, wa d v 9",
+  "attacker": 14,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa d v 10 1`] = `
+{
+  "_cmd": "de v 20, wa d v 10",
+  "attacker": 14,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa d v 11 1`] = `
+{
+  "_cmd": "de v 20, wa d v 11",
+  "attacker": 14,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, wa d v 12 1`] = `
+{
+  "_cmd": "de v 20, wa d v 12",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, wa d v 13 1`] = `
+{
+  "_cmd": "de v 20, wa d v 13",
+  "attacker": 13,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, wa d v 14 1`] = `
+{
+  "_cmd": "de v 20, wa d v 14",
+  "attacker": 13,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, wa d v 15 1`] = `
+{
+  "_cmd": "de v 20, wa d v 15",
+  "attacker": 13,
+  "defender": 14,
+}
+`;
+
+exports[`de v 20, wa p 1 1`] = `
+{
+  "_cmd": "de v 20, wa p 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, wa p 2 1`] = `
+{
+  "_cmd": "de v 20, wa p 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa p 3 1`] = `
+{
+  "_cmd": "de v 20, wa p 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, wa p 4 1`] = `
+{
+  "_cmd": "de v 20, wa p 4",
+  "attacker": 17,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa p 5 1`] = `
+{
+  "_cmd": "de v 20, wa p 5",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, wa p 6 1`] = `
+{
+  "_cmd": "de v 20, wa p 6",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa p 7 1`] = `
+{
+  "_cmd": "de v 20, wa p 7",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa p 8 1`] = `
+{
+  "_cmd": "de v 20, wa p 8",
+  "attacker": 15,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa p 9 1`] = `
+{
+  "_cmd": "de v 20, wa p 9",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa p 10 1`] = `
+{
+  "_cmd": "de v 20, wa p 10",
+  "attacker": 15,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa p v 1 1`] = `
+{
+  "_cmd": "de v 20, wa p v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, wa p v 2 1`] = `
+{
+  "_cmd": "de v 20, wa p v 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa p v 3 1`] = `
+{
+  "_cmd": "de v 20, wa p v 3",
+  "attacker": 20,
+  "defender": -1,
+}
+`;
+
+exports[`de v 20, wa p v 4 1`] = `
+{
+  "_cmd": "de v 20, wa p v 4",
+  "attacker": 18,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa p v 5 1`] = `
+{
+  "_cmd": "de v 20, wa p v 5",
+  "attacker": 17,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, wa p v 6 1`] = `
+{
+  "_cmd": "de v 20, wa p v 6",
+  "attacker": 17,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa p v 7 1`] = `
+{
+  "_cmd": "de v 20, wa p v 7",
+  "attacker": 16,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa p v 8 1`] = `
+{
+  "_cmd": "de v 20, wa p v 8",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa p v 9 1`] = `
+{
+  "_cmd": "de v 20, wa p v 9",
+  "attacker": 16,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa p v 10 1`] = `
+{
+  "_cmd": "de v 20, wa p v 10",
+  "attacker": 16,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa p v 11 1`] = `
+{
+  "_cmd": "de v 20, wa p v 11",
+  "attacker": 15,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, wa p v 12 1`] = `
+{
+  "_cmd": "de v 20, wa p v 12",
+  "attacker": 15,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, wa p v 13 1`] = `
+{
+  "_cmd": "de v 20, wa p v 13",
+  "attacker": 15,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, wa p v 14 1`] = `
+{
+  "_cmd": "de v 20, wa p v 14",
+  "attacker": 15,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, wa p v 15 1`] = `
+{
+  "_cmd": "de v 20, wa p v 15",
+  "attacker": 15,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, wa v 1 1`] = `
+{
+  "_cmd": "de v 20, wa v 1",
+  "attacker": 20,
+  "defender": -3,
+}
+`;
+
+exports[`de v 20, wa v 2 1`] = `
+{
+  "_cmd": "de v 20, wa v 2",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa v 3 1`] = `
+{
+  "_cmd": "de v 20, wa v 3",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, wa v 4 1`] = `
+{
+  "_cmd": "de v 20, wa v 4",
+  "attacker": 17,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa v 5 1`] = `
+{
+  "_cmd": "de v 20, wa v 5",
+  "attacker": 16,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, wa v 6 1`] = `
+{
+  "_cmd": "de v 20, wa v 6",
+  "attacker": 16,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa v 7 1`] = `
+{
+  "_cmd": "de v 20, wa v 7",
+  "attacker": 16,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa v 8 1`] = `
+{
+  "_cmd": "de v 20, wa v 8",
+  "attacker": 15,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa v 9 1`] = `
+{
+  "_cmd": "de v 20, wa v 9",
+  "attacker": 15,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa v 10 1`] = `
+{
+  "_cmd": "de v 20, wa v 10",
+  "attacker": 15,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa v 11 1`] = `
+{
+  "_cmd": "de v 20, wa v 11",
+  "attacker": 15,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, wa v 12 1`] = `
+{
+  "_cmd": "de v 20, wa v 12",
+  "attacker": 14,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, wa v 13 1`] = `
+{
+  "_cmd": "de v 20, wa v 13",
+  "attacker": 14,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, wa v 14 1`] = `
+{
+  "_cmd": "de v 20, wa v 14",
+  "attacker": 14,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, wa v 15 1`] = `
+{
+  "_cmd": "de v 20, wa v 15",
+  "attacker": 14,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, wa w 1 1`] = `
+{
+  "_cmd": "de v 20, wa w 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa w 2 1`] = `
+{
+  "_cmd": "de v 20, wa w 2",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, wa w 3 1`] = `
+{
+  "_cmd": "de v 20, wa w 3",
+  "attacker": 14,
+  "defender": 2,
+}
+`;
+
+exports[`de v 20, wa w 4 1`] = `
+{
+  "_cmd": "de v 20, wa w 4",
+  "attacker": 13,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa w 5 1`] = `
+{
+  "_cmd": "de v 20, wa w 5",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa w 6 1`] = `
+{
+  "_cmd": "de v 20, wa w 6",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa w 7 1`] = `
+{
+  "_cmd": "de v 20, wa w 7",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa w 8 1`] = `
+{
+  "_cmd": "de v 20, wa w 8",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa w 9 1`] = `
+{
+  "_cmd": "de v 20, wa w 9",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa w 10 1`] = `
+{
+  "_cmd": "de v 20, wa w 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, wa w v 1 1`] = `
+{
+  "_cmd": "de v 20, wa w v 1",
+  "attacker": 20,
+  "defender": -2,
+}
+`;
+
+exports[`de v 20, wa w v 2 1`] = `
+{
+  "_cmd": "de v 20, wa w v 2",
+  "attacker": 20,
+  "defender": 0,
+}
+`;
+
+exports[`de v 20, wa w v 3 1`] = `
+{
+  "_cmd": "de v 20, wa w v 3",
+  "attacker": 14,
+  "defender": 1,
+}
+`;
+
+exports[`de v 20, wa w v 4 1`] = `
+{
+  "_cmd": "de v 20, wa w v 4",
+  "attacker": 14,
+  "defender": 3,
+}
+`;
+
+exports[`de v 20, wa w v 5 1`] = `
+{
+  "_cmd": "de v 20, wa w v 5",
+  "attacker": 13,
+  "defender": 4,
+}
+`;
+
+exports[`de v 20, wa w v 6 1`] = `
+{
+  "_cmd": "de v 20, wa w v 6",
+  "attacker": 13,
+  "defender": 5,
+}
+`;
+
+exports[`de v 20, wa w v 7 1`] = `
+{
+  "_cmd": "de v 20, wa w v 7",
+  "attacker": 13,
+  "defender": 6,
+}
+`;
+
+exports[`de v 20, wa w v 8 1`] = `
+{
+  "_cmd": "de v 20, wa w v 8",
+  "attacker": 13,
+  "defender": 7,
+}
+`;
+
+exports[`de v 20, wa w v 9 1`] = `
+{
+  "_cmd": "de v 20, wa w v 9",
+  "attacker": 13,
+  "defender": 8,
+}
+`;
+
+exports[`de v 20, wa w v 10 1`] = `
+{
+  "_cmd": "de v 20, wa w v 10",
+  "attacker": 12,
+  "defender": 9,
+}
+`;
+
+exports[`de v 20, wa w v 11 1`] = `
+{
+  "_cmd": "de v 20, wa w v 11",
+  "attacker": 12,
+  "defender": 10,
+}
+`;
+
+exports[`de v 20, wa w v 12 1`] = `
+{
+  "_cmd": "de v 20, wa w v 12",
+  "attacker": 12,
+  "defender": 11,
+}
+`;
+
+exports[`de v 20, wa w v 13 1`] = `
+{
+  "_cmd": "de v 20, wa w v 13",
+  "attacker": 12,
+  "defender": 12,
+}
+`;
+
+exports[`de v 20, wa w v 14 1`] = `
+{
+  "_cmd": "de v 20, wa w v 14",
+  "attacker": 12,
+  "defender": 13,
+}
+`;
+
+exports[`de v 20, wa w v 15 1`] = `
+{
+  "_cmd": "de v 20, wa w v 15",
+  "attacker": 12,
+  "defender": 14,
+}
+`;

--- a/bot/tests/simpleCalc/__snapshots__/wa-vs-de.test.js.snap
+++ b/bot/tests/simpleCalc/__snapshots__/wa-vs-de.test.js.snap
@@ -1,0 +1,40001 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`wa b 1, de d 1 1`] = `
+{
+  "_cmd": "wa b 1, de d 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 1, de d 2 1`] = `
+{
+  "_cmd": "wa b 1, de d 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, de d 3 1`] = `
+{
+  "_cmd": "wa b 1, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, de d 4 1`] = `
+{
+  "_cmd": "wa b 1, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de d 5 1`] = `
+{
+  "_cmd": "wa b 1, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de d 6 1`] = `
+{
+  "_cmd": "wa b 1, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de d 7 1`] = `
+{
+  "_cmd": "wa b 1, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, de d 8 1`] = `
+{
+  "_cmd": "wa b 1, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de d 9 1`] = `
+{
+  "_cmd": "wa b 1, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de d 10 1`] = `
+{
+  "_cmd": "wa b 1, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de d 11 1`] = `
+{
+  "_cmd": "wa b 1, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de d 12 1`] = `
+{
+  "_cmd": "wa b 1, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de d 13 1`] = `
+{
+  "_cmd": "wa b 1, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de d 14 1`] = `
+{
+  "_cmd": "wa b 1, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de d 15 1`] = `
+{
+  "_cmd": "wa b 1, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de d v 1 1`] = `
+{
+  "_cmd": "wa b 1, de d v 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 1, de d v 2 1`] = `
+{
+  "_cmd": "wa b 1, de d v 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, de d v 3 1`] = `
+{
+  "_cmd": "wa b 1, de d v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, de d v 4 1`] = `
+{
+  "_cmd": "wa b 1, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de d v 5 1`] = `
+{
+  "_cmd": "wa b 1, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de d v 6 1`] = `
+{
+  "_cmd": "wa b 1, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, de d v 7 1`] = `
+{
+  "_cmd": "wa b 1, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de d v 8 1`] = `
+{
+  "_cmd": "wa b 1, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de d v 9 1`] = `
+{
+  "_cmd": "wa b 1, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de d v 10 1`] = `
+{
+  "_cmd": "wa b 1, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de d v 11 1`] = `
+{
+  "_cmd": "wa b 1, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de d v 12 1`] = `
+{
+  "_cmd": "wa b 1, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de d v 13 1`] = `
+{
+  "_cmd": "wa b 1, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de d v 14 1`] = `
+{
+  "_cmd": "wa b 1, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de d v 15 1`] = `
+{
+  "_cmd": "wa b 1, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de d v 16 1`] = `
+{
+  "_cmd": "wa b 1, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 1, de d v 17 1`] = `
+{
+  "_cmd": "wa b 1, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 1, de d v 18 1`] = `
+{
+  "_cmd": "wa b 1, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 1, de d v 19 1`] = `
+{
+  "_cmd": "wa b 1, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 1, de d v 20 1`] = `
+{
+  "_cmd": "wa b 1, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 1, de p 1 1`] = `
+{
+  "_cmd": "wa b 1, de p 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 1, de p 2 1`] = `
+{
+  "_cmd": "wa b 1, de p 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 1, de p 3 1`] = `
+{
+  "_cmd": "wa b 1, de p 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, de p 4 1`] = `
+{
+  "_cmd": "wa b 1, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, de p 5 1`] = `
+{
+  "_cmd": "wa b 1, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de p 6 1`] = `
+{
+  "_cmd": "wa b 1, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de p 7 1`] = `
+{
+  "_cmd": "wa b 1, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de p 8 1`] = `
+{
+  "_cmd": "wa b 1, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, de p 9 1`] = `
+{
+  "_cmd": "wa b 1, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de p 10 1`] = `
+{
+  "_cmd": "wa b 1, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de p 11 1`] = `
+{
+  "_cmd": "wa b 1, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de p 12 1`] = `
+{
+  "_cmd": "wa b 1, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de p 13 1`] = `
+{
+  "_cmd": "wa b 1, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de p 14 1`] = `
+{
+  "_cmd": "wa b 1, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de p 15 1`] = `
+{
+  "_cmd": "wa b 1, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de p v 1 1`] = `
+{
+  "_cmd": "wa b 1, de p v 1",
+  "attacker": 1,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 1, de p v 2 1`] = `
+{
+  "_cmd": "wa b 1, de p v 2",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 1, de p v 3 1`] = `
+{
+  "_cmd": "wa b 1, de p v 3",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, de p v 4 1`] = `
+{
+  "_cmd": "wa b 1, de p v 4",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, de p v 5 1`] = `
+{
+  "_cmd": "wa b 1, de p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, de p v 6 1`] = `
+{
+  "_cmd": "wa b 1, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de p v 7 1`] = `
+{
+  "_cmd": "wa b 1, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, de p v 8 1`] = `
+{
+  "_cmd": "wa b 1, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de p v 9 1`] = `
+{
+  "_cmd": "wa b 1, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de p v 10 1`] = `
+{
+  "_cmd": "wa b 1, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de p v 11 1`] = `
+{
+  "_cmd": "wa b 1, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de p v 12 1`] = `
+{
+  "_cmd": "wa b 1, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de p v 13 1`] = `
+{
+  "_cmd": "wa b 1, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de p v 14 1`] = `
+{
+  "_cmd": "wa b 1, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de p v 15 1`] = `
+{
+  "_cmd": "wa b 1, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de p v 16 1`] = `
+{
+  "_cmd": "wa b 1, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 1, de p v 17 1`] = `
+{
+  "_cmd": "wa b 1, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 1, de p v 18 1`] = `
+{
+  "_cmd": "wa b 1, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 1, de p v 19 1`] = `
+{
+  "_cmd": "wa b 1, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 1, de p v 20 1`] = `
+{
+  "_cmd": "wa b 1, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 1, de v 1 1`] = `
+{
+  "_cmd": "wa b 1, de v 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 1, de v 2 1`] = `
+{
+  "_cmd": "wa b 1, de v 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 1, de v 3 1`] = `
+{
+  "_cmd": "wa b 1, de v 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, de v 4 1`] = `
+{
+  "_cmd": "wa b 1, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, de v 5 1`] = `
+{
+  "_cmd": "wa b 1, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de v 6 1`] = `
+{
+  "_cmd": "wa b 1, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, de v 7 1`] = `
+{
+  "_cmd": "wa b 1, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de v 8 1`] = `
+{
+  "_cmd": "wa b 1, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, de v 9 1`] = `
+{
+  "_cmd": "wa b 1, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de v 10 1`] = `
+{
+  "_cmd": "wa b 1, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de v 11 1`] = `
+{
+  "_cmd": "wa b 1, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de v 12 1`] = `
+{
+  "_cmd": "wa b 1, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de v 13 1`] = `
+{
+  "_cmd": "wa b 1, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de v 14 1`] = `
+{
+  "_cmd": "wa b 1, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de v 15 1`] = `
+{
+  "_cmd": "wa b 1, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de v 16 1`] = `
+{
+  "_cmd": "wa b 1, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 1, de v 17 1`] = `
+{
+  "_cmd": "wa b 1, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 1, de v 18 1`] = `
+{
+  "_cmd": "wa b 1, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 1, de v 19 1`] = `
+{
+  "_cmd": "wa b 1, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 1, de v 20 1`] = `
+{
+  "_cmd": "wa b 1, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 1, de w 1 1`] = `
+{
+  "_cmd": "wa b 1, de w 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, de w 2 1`] = `
+{
+  "_cmd": "wa b 1, de w 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, de w 3 1`] = `
+{
+  "_cmd": "wa b 1, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de w 4 1`] = `
+{
+  "_cmd": "wa b 1, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de w 5 1`] = `
+{
+  "_cmd": "wa b 1, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, de w 6 1`] = `
+{
+  "_cmd": "wa b 1, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de w 7 1`] = `
+{
+  "_cmd": "wa b 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de w 8 1`] = `
+{
+  "_cmd": "wa b 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, de w 9 1`] = `
+{
+  "_cmd": "wa b 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de w 10 1`] = `
+{
+  "_cmd": "wa b 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de w 11 1`] = `
+{
+  "_cmd": "wa b 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de w 12 1`] = `
+{
+  "_cmd": "wa b 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de w 13 1`] = `
+{
+  "_cmd": "wa b 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de w 14 1`] = `
+{
+  "_cmd": "wa b 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de w 15 1`] = `
+{
+  "_cmd": "wa b 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 1, de w v 1 1`] = `
+{
+  "_cmd": "wa b 1, de w v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, de w v 2 1`] = `
+{
+  "_cmd": "wa b 1, de w v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, de w v 3 1`] = `
+{
+  "_cmd": "wa b 1, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, de w v 4 1`] = `
+{
+  "_cmd": "wa b 1, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, de w v 5 1`] = `
+{
+  "_cmd": "wa b 1, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, de w v 6 1`] = `
+{
+  "_cmd": "wa b 1, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, de w v 7 1`] = `
+{
+  "_cmd": "wa b 1, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, de w v 8 1`] = `
+{
+  "_cmd": "wa b 1, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, de w v 9 1`] = `
+{
+  "_cmd": "wa b 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, de w v 10 1`] = `
+{
+  "_cmd": "wa b 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, de w v 11 1`] = `
+{
+  "_cmd": "wa b 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, de w v 12 1`] = `
+{
+  "_cmd": "wa b 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, de w v 13 1`] = `
+{
+  "_cmd": "wa b 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, de w v 14 1`] = `
+{
+  "_cmd": "wa b 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, de w v 15 1`] = `
+{
+  "_cmd": "wa b 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 1, de w v 16 1`] = `
+{
+  "_cmd": "wa b 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 1, de w v 17 1`] = `
+{
+  "_cmd": "wa b 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 1, de w v 18 1`] = `
+{
+  "_cmd": "wa b 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 1, de w v 19 1`] = `
+{
+  "_cmd": "wa b 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 1, de w v 20 1`] = `
+{
+  "_cmd": "wa b 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b 2, de d 1 1`] = `
+{
+  "_cmd": "wa b 2, de d 1",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 2, de d 2 1`] = `
+{
+  "_cmd": "wa b 2, de d 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, de d 3 1`] = `
+{
+  "_cmd": "wa b 2, de d 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, de d 4 1`] = `
+{
+  "_cmd": "wa b 2, de d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, de d 5 1`] = `
+{
+  "_cmd": "wa b 2, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de d 6 1`] = `
+{
+  "_cmd": "wa b 2, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, de d 7 1`] = `
+{
+  "_cmd": "wa b 2, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de d 8 1`] = `
+{
+  "_cmd": "wa b 2, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de d 9 1`] = `
+{
+  "_cmd": "wa b 2, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de d 10 1`] = `
+{
+  "_cmd": "wa b 2, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de d 11 1`] = `
+{
+  "_cmd": "wa b 2, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de d 12 1`] = `
+{
+  "_cmd": "wa b 2, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de d 13 1`] = `
+{
+  "_cmd": "wa b 2, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de d 14 1`] = `
+{
+  "_cmd": "wa b 2, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, de d 15 1`] = `
+{
+  "_cmd": "wa b 2, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 2, de d v 1 1`] = `
+{
+  "_cmd": "wa b 2, de d v 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 2, de d v 2 1`] = `
+{
+  "_cmd": "wa b 2, de d v 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, de d v 3 1`] = `
+{
+  "_cmd": "wa b 2, de d v 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 2, de d v 4 1`] = `
+{
+  "_cmd": "wa b 2, de d v 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, de d v 5 1`] = `
+{
+  "_cmd": "wa b 2, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de d v 6 1`] = `
+{
+  "_cmd": "wa b 2, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, de d v 7 1`] = `
+{
+  "_cmd": "wa b 2, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, de d v 8 1`] = `
+{
+  "_cmd": "wa b 2, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de d v 9 1`] = `
+{
+  "_cmd": "wa b 2, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de d v 10 1`] = `
+{
+  "_cmd": "wa b 2, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de d v 11 1`] = `
+{
+  "_cmd": "wa b 2, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, de d v 12 1`] = `
+{
+  "_cmd": "wa b 2, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de d v 13 1`] = `
+{
+  "_cmd": "wa b 2, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de d v 14 1`] = `
+{
+  "_cmd": "wa b 2, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de d v 15 1`] = `
+{
+  "_cmd": "wa b 2, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 2, de d v 16 1`] = `
+{
+  "_cmd": "wa b 2, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, de d v 17 1`] = `
+{
+  "_cmd": "wa b 2, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 2, de d v 18 1`] = `
+{
+  "_cmd": "wa b 2, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 2, de d v 19 1`] = `
+{
+  "_cmd": "wa b 2, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 2, de d v 20 1`] = `
+{
+  "_cmd": "wa b 2, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 2, de p 1 1`] = `
+{
+  "_cmd": "wa b 2, de p 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, de p 2 1`] = `
+{
+  "_cmd": "wa b 2, de p 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 2, de p 3 1`] = `
+{
+  "_cmd": "wa b 2, de p 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, de p 4 1`] = `
+{
+  "_cmd": "wa b 2, de p 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, de p 5 1`] = `
+{
+  "_cmd": "wa b 2, de p 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, de p 6 1`] = `
+{
+  "_cmd": "wa b 2, de p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de p 7 1`] = `
+{
+  "_cmd": "wa b 2, de p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, de p 8 1`] = `
+{
+  "_cmd": "wa b 2, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de p 9 1`] = `
+{
+  "_cmd": "wa b 2, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de p 10 1`] = `
+{
+  "_cmd": "wa b 2, de p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de p 11 1`] = `
+{
+  "_cmd": "wa b 2, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de p 12 1`] = `
+{
+  "_cmd": "wa b 2, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, de p 13 1`] = `
+{
+  "_cmd": "wa b 2, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de p 14 1`] = `
+{
+  "_cmd": "wa b 2, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de p 15 1`] = `
+{
+  "_cmd": "wa b 2, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, de p v 1 1`] = `
+{
+  "_cmd": "wa b 2, de p v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, de p v 2 1`] = `
+{
+  "_cmd": "wa b 2, de p v 2",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 2, de p v 3 1`] = `
+{
+  "_cmd": "wa b 2, de p v 3",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, de p v 4 1`] = `
+{
+  "_cmd": "wa b 2, de p v 4",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 2, de p v 5 1`] = `
+{
+  "_cmd": "wa b 2, de p v 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, de p v 6 1`] = `
+{
+  "_cmd": "wa b 2, de p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, de p v 7 1`] = `
+{
+  "_cmd": "wa b 2, de p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de p v 8 1`] = `
+{
+  "_cmd": "wa b 2, de p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, de p v 9 1`] = `
+{
+  "_cmd": "wa b 2, de p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de p v 10 1`] = `
+{
+  "_cmd": "wa b 2, de p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de p v 11 1`] = `
+{
+  "_cmd": "wa b 2, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de p v 12 1`] = `
+{
+  "_cmd": "wa b 2, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, de p v 13 1`] = `
+{
+  "_cmd": "wa b 2, de p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de p v 14 1`] = `
+{
+  "_cmd": "wa b 2, de p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de p v 15 1`] = `
+{
+  "_cmd": "wa b 2, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de p v 16 1`] = `
+{
+  "_cmd": "wa b 2, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, de p v 17 1`] = `
+{
+  "_cmd": "wa b 2, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, de p v 18 1`] = `
+{
+  "_cmd": "wa b 2, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 2, de p v 19 1`] = `
+{
+  "_cmd": "wa b 2, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 2, de p v 20 1`] = `
+{
+  "_cmd": "wa b 2, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 2, de v 1 1`] = `
+{
+  "_cmd": "wa b 2, de v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, de v 2 1`] = `
+{
+  "_cmd": "wa b 2, de v 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 2, de v 3 1`] = `
+{
+  "_cmd": "wa b 2, de v 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, de v 4 1`] = `
+{
+  "_cmd": "wa b 2, de v 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, de v 5 1`] = `
+{
+  "_cmd": "wa b 2, de v 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, de v 6 1`] = `
+{
+  "_cmd": "wa b 2, de v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de v 7 1`] = `
+{
+  "_cmd": "wa b 2, de v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, de v 8 1`] = `
+{
+  "_cmd": "wa b 2, de v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de v 9 1`] = `
+{
+  "_cmd": "wa b 2, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de v 10 1`] = `
+{
+  "_cmd": "wa b 2, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de v 11 1`] = `
+{
+  "_cmd": "wa b 2, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de v 12 1`] = `
+{
+  "_cmd": "wa b 2, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de v 13 1`] = `
+{
+  "_cmd": "wa b 2, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de v 14 1`] = `
+{
+  "_cmd": "wa b 2, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de v 15 1`] = `
+{
+  "_cmd": "wa b 2, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, de v 16 1`] = `
+{
+  "_cmd": "wa b 2, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 2, de v 17 1`] = `
+{
+  "_cmd": "wa b 2, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, de v 18 1`] = `
+{
+  "_cmd": "wa b 2, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 2, de v 19 1`] = `
+{
+  "_cmd": "wa b 2, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 2, de v 20 1`] = `
+{
+  "_cmd": "wa b 2, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 2, de w 1 1`] = `
+{
+  "_cmd": "wa b 2, de w 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, de w 2 1`] = `
+{
+  "_cmd": "wa b 2, de w 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, de w 3 1`] = `
+{
+  "_cmd": "wa b 2, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, de w 4 1`] = `
+{
+  "_cmd": "wa b 2, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de w 5 1`] = `
+{
+  "_cmd": "wa b 2, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, de w 6 1`] = `
+{
+  "_cmd": "wa b 2, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de w 7 1`] = `
+{
+  "_cmd": "wa b 2, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de w 8 1`] = `
+{
+  "_cmd": "wa b 2, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de w 9 1`] = `
+{
+  "_cmd": "wa b 2, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de w 10 1`] = `
+{
+  "_cmd": "wa b 2, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, de w 11 1`] = `
+{
+  "_cmd": "wa b 2, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de w 12 1`] = `
+{
+  "_cmd": "wa b 2, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de w 13 1`] = `
+{
+  "_cmd": "wa b 2, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de w 14 1`] = `
+{
+  "_cmd": "wa b 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 2, de w 15 1`] = `
+{
+  "_cmd": "wa b 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, de w v 1 1`] = `
+{
+  "_cmd": "wa b 2, de w v 1",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, de w v 2 1`] = `
+{
+  "_cmd": "wa b 2, de w v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, de w v 3 1`] = `
+{
+  "_cmd": "wa b 2, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, de w v 4 1`] = `
+{
+  "_cmd": "wa b 2, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, de w v 5 1`] = `
+{
+  "_cmd": "wa b 2, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, de w v 6 1`] = `
+{
+  "_cmd": "wa b 2, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, de w v 7 1`] = `
+{
+  "_cmd": "wa b 2, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, de w v 8 1`] = `
+{
+  "_cmd": "wa b 2, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, de w v 9 1`] = `
+{
+  "_cmd": "wa b 2, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, de w v 10 1`] = `
+{
+  "_cmd": "wa b 2, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, de w v 11 1`] = `
+{
+  "_cmd": "wa b 2, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, de w v 12 1`] = `
+{
+  "_cmd": "wa b 2, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, de w v 13 1`] = `
+{
+  "_cmd": "wa b 2, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, de w v 14 1`] = `
+{
+  "_cmd": "wa b 2, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, de w v 15 1`] = `
+{
+  "_cmd": "wa b 2, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 2, de w v 16 1`] = `
+{
+  "_cmd": "wa b 2, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, de w v 17 1`] = `
+{
+  "_cmd": "wa b 2, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 2, de w v 18 1`] = `
+{
+  "_cmd": "wa b 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 2, de w v 19 1`] = `
+{
+  "_cmd": "wa b 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 2, de w v 20 1`] = `
+{
+  "_cmd": "wa b 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b 3, de d 1 1`] = `
+{
+  "_cmd": "wa b 3, de d 1",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 3, de d 2 1`] = `
+{
+  "_cmd": "wa b 3, de d 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, de d 3 1`] = `
+{
+  "_cmd": "wa b 3, de d 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de d 4 1`] = `
+{
+  "_cmd": "wa b 3, de d 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, de d 5 1`] = `
+{
+  "_cmd": "wa b 3, de d 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, de d 6 1`] = `
+{
+  "_cmd": "wa b 3, de d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de d 7 1`] = `
+{
+  "_cmd": "wa b 3, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, de d 8 1`] = `
+{
+  "_cmd": "wa b 3, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de d 9 1`] = `
+{
+  "_cmd": "wa b 3, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de d 10 1`] = `
+{
+  "_cmd": "wa b 3, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, de d 11 1`] = `
+{
+  "_cmd": "wa b 3, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de d 12 1`] = `
+{
+  "_cmd": "wa b 3, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de d 13 1`] = `
+{
+  "_cmd": "wa b 3, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de d 14 1`] = `
+{
+  "_cmd": "wa b 3, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de d 15 1`] = `
+{
+  "_cmd": "wa b 3, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de d v 1 1`] = `
+{
+  "_cmd": "wa b 3, de d v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 3, de d v 2 1`] = `
+{
+  "_cmd": "wa b 3, de d v 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 3, de d v 3 1`] = `
+{
+  "_cmd": "wa b 3, de d v 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 3, de d v 4 1`] = `
+{
+  "_cmd": "wa b 3, de d v 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, de d v 5 1`] = `
+{
+  "_cmd": "wa b 3, de d v 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, de d v 6 1`] = `
+{
+  "_cmd": "wa b 3, de d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, de d v 7 1`] = `
+{
+  "_cmd": "wa b 3, de d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de d v 8 1`] = `
+{
+  "_cmd": "wa b 3, de d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de d v 9 1`] = `
+{
+  "_cmd": "wa b 3, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, de d v 10 1`] = `
+{
+  "_cmd": "wa b 3, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de d v 11 1`] = `
+{
+  "_cmd": "wa b 3, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, de d v 12 1`] = `
+{
+  "_cmd": "wa b 3, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de d v 13 1`] = `
+{
+  "_cmd": "wa b 3, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de d v 14 1`] = `
+{
+  "_cmd": "wa b 3, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de d v 15 1`] = `
+{
+  "_cmd": "wa b 3, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de d v 16 1`] = `
+{
+  "_cmd": "wa b 3, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, de d v 17 1`] = `
+{
+  "_cmd": "wa b 3, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 3, de d v 18 1`] = `
+{
+  "_cmd": "wa b 3, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 3, de d v 19 1`] = `
+{
+  "_cmd": "wa b 3, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 3, de d v 20 1`] = `
+{
+  "_cmd": "wa b 3, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 3, de p 1 1`] = `
+{
+  "_cmd": "wa b 3, de p 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 3, de p 2 1`] = `
+{
+  "_cmd": "wa b 3, de p 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 3, de p 3 1`] = `
+{
+  "_cmd": "wa b 3, de p 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, de p 4 1`] = `
+{
+  "_cmd": "wa b 3, de p 4",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de p 5 1`] = `
+{
+  "_cmd": "wa b 3, de p 5",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, de p 6 1`] = `
+{
+  "_cmd": "wa b 3, de p 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, de p 7 1`] = `
+{
+  "_cmd": "wa b 3, de p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, de p 8 1`] = `
+{
+  "_cmd": "wa b 3, de p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de p 9 1`] = `
+{
+  "_cmd": "wa b 3, de p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de p 10 1`] = `
+{
+  "_cmd": "wa b 3, de p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, de p 11 1`] = `
+{
+  "_cmd": "wa b 3, de p 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de p 12 1`] = `
+{
+  "_cmd": "wa b 3, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de p 13 1`] = `
+{
+  "_cmd": "wa b 3, de p 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de p 14 1`] = `
+{
+  "_cmd": "wa b 3, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de p 15 1`] = `
+{
+  "_cmd": "wa b 3, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de p v 1 1`] = `
+{
+  "_cmd": "wa b 3, de p v 1",
+  "attacker": 3,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 3, de p v 2 1`] = `
+{
+  "_cmd": "wa b 3, de p v 2",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 3, de p v 3 1`] = `
+{
+  "_cmd": "wa b 3, de p v 3",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 3, de p v 4 1`] = `
+{
+  "_cmd": "wa b 3, de p v 4",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 3, de p v 5 1`] = `
+{
+  "_cmd": "wa b 3, de p v 5",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de p v 6 1`] = `
+{
+  "_cmd": "wa b 3, de p v 6",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, de p v 7 1`] = `
+{
+  "_cmd": "wa b 3, de p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, de p v 8 1`] = `
+{
+  "_cmd": "wa b 3, de p v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de p v 9 1`] = `
+{
+  "_cmd": "wa b 3, de p v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, de p v 10 1`] = `
+{
+  "_cmd": "wa b 3, de p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de p v 11 1`] = `
+{
+  "_cmd": "wa b 3, de p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de p v 12 1`] = `
+{
+  "_cmd": "wa b 3, de p v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, de p v 13 1`] = `
+{
+  "_cmd": "wa b 3, de p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de p v 14 1`] = `
+{
+  "_cmd": "wa b 3, de p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de p v 15 1`] = `
+{
+  "_cmd": "wa b 3, de p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de p v 16 1`] = `
+{
+  "_cmd": "wa b 3, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de p v 17 1`] = `
+{
+  "_cmd": "wa b 3, de p v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, de p v 18 1`] = `
+{
+  "_cmd": "wa b 3, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 3, de p v 19 1`] = `
+{
+  "_cmd": "wa b 3, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 3, de p v 20 1`] = `
+{
+  "_cmd": "wa b 3, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 3, de v 1 1`] = `
+{
+  "_cmd": "wa b 3, de v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 3, de v 2 1`] = `
+{
+  "_cmd": "wa b 3, de v 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 3, de v 3 1`] = `
+{
+  "_cmd": "wa b 3, de v 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, de v 4 1`] = `
+{
+  "_cmd": "wa b 3, de v 4",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de v 5 1`] = `
+{
+  "_cmd": "wa b 3, de v 5",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, de v 6 1`] = `
+{
+  "_cmd": "wa b 3, de v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, de v 7 1`] = `
+{
+  "_cmd": "wa b 3, de v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, de v 8 1`] = `
+{
+  "_cmd": "wa b 3, de v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, de v 9 1`] = `
+{
+  "_cmd": "wa b 3, de v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de v 10 1`] = `
+{
+  "_cmd": "wa b 3, de v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, de v 11 1`] = `
+{
+  "_cmd": "wa b 3, de v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de v 12 1`] = `
+{
+  "_cmd": "wa b 3, de v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de v 13 1`] = `
+{
+  "_cmd": "wa b 3, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de v 14 1`] = `
+{
+  "_cmd": "wa b 3, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de v 15 1`] = `
+{
+  "_cmd": "wa b 3, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de v 16 1`] = `
+{
+  "_cmd": "wa b 3, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de v 17 1`] = `
+{
+  "_cmd": "wa b 3, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, de v 18 1`] = `
+{
+  "_cmd": "wa b 3, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 3, de v 19 1`] = `
+{
+  "_cmd": "wa b 3, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 3, de v 20 1`] = `
+{
+  "_cmd": "wa b 3, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 3, de w 1 1`] = `
+{
+  "_cmd": "wa b 3, de w 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, de w 2 1`] = `
+{
+  "_cmd": "wa b 3, de w 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de w 3 1`] = `
+{
+  "_cmd": "wa b 3, de w 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, de w 4 1`] = `
+{
+  "_cmd": "wa b 3, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, de w 5 1`] = `
+{
+  "_cmd": "wa b 3, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de w 6 1`] = `
+{
+  "_cmd": "wa b 3, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, de w 7 1`] = `
+{
+  "_cmd": "wa b 3, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, de w 8 1`] = `
+{
+  "_cmd": "wa b 3, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, de w 9 1`] = `
+{
+  "_cmd": "wa b 3, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, de w 10 1`] = `
+{
+  "_cmd": "wa b 3, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de w 11 1`] = `
+{
+  "_cmd": "wa b 3, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de w 12 1`] = `
+{
+  "_cmd": "wa b 3, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de w 13 1`] = `
+{
+  "_cmd": "wa b 3, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de w 14 1`] = `
+{
+  "_cmd": "wa b 3, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de w 15 1`] = `
+{
+  "_cmd": "wa b 3, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, de w v 1 1`] = `
+{
+  "_cmd": "wa b 3, de w v 1",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 3, de w v 2 1`] = `
+{
+  "_cmd": "wa b 3, de w v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, de w v 3 1`] = `
+{
+  "_cmd": "wa b 3, de w v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, de w v 4 1`] = `
+{
+  "_cmd": "wa b 3, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, de w v 5 1`] = `
+{
+  "_cmd": "wa b 3, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, de w v 6 1`] = `
+{
+  "_cmd": "wa b 3, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, de w v 7 1`] = `
+{
+  "_cmd": "wa b 3, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, de w v 8 1`] = `
+{
+  "_cmd": "wa b 3, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, de w v 9 1`] = `
+{
+  "_cmd": "wa b 3, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, de w v 10 1`] = `
+{
+  "_cmd": "wa b 3, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, de w v 11 1`] = `
+{
+  "_cmd": "wa b 3, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, de w v 12 1`] = `
+{
+  "_cmd": "wa b 3, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, de w v 13 1`] = `
+{
+  "_cmd": "wa b 3, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, de w v 14 1`] = `
+{
+  "_cmd": "wa b 3, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, de w v 15 1`] = `
+{
+  "_cmd": "wa b 3, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, de w v 16 1`] = `
+{
+  "_cmd": "wa b 3, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 3, de w v 17 1`] = `
+{
+  "_cmd": "wa b 3, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 3, de w v 18 1`] = `
+{
+  "_cmd": "wa b 3, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 3, de w v 19 1`] = `
+{
+  "_cmd": "wa b 3, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 3, de w v 20 1`] = `
+{
+  "_cmd": "wa b 3, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 4, de d 1 1`] = `
+{
+  "_cmd": "wa b 4, de d 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 4, de d 2 1`] = `
+{
+  "_cmd": "wa b 4, de d 2",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, de d 3 1`] = `
+{
+  "_cmd": "wa b 4, de d 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, de d 4 1`] = `
+{
+  "_cmd": "wa b 4, de d 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, de d 5 1`] = `
+{
+  "_cmd": "wa b 4, de d 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, de d 6 1`] = `
+{
+  "_cmd": "wa b 4, de d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, de d 7 1`] = `
+{
+  "_cmd": "wa b 4, de d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de d 8 1`] = `
+{
+  "_cmd": "wa b 4, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de d 9 1`] = `
+{
+  "_cmd": "wa b 4, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, de d 10 1`] = `
+{
+  "_cmd": "wa b 4, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de d 11 1`] = `
+{
+  "_cmd": "wa b 4, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de d 12 1`] = `
+{
+  "_cmd": "wa b 4, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de d 13 1`] = `
+{
+  "_cmd": "wa b 4, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de d 14 1`] = `
+{
+  "_cmd": "wa b 4, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de d 15 1`] = `
+{
+  "_cmd": "wa b 4, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, de d v 1 1`] = `
+{
+  "_cmd": "wa b 4, de d v 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 4, de d v 2 1`] = `
+{
+  "_cmd": "wa b 4, de d v 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, de d v 3 1`] = `
+{
+  "_cmd": "wa b 4, de d v 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 4, de d v 4 1`] = `
+{
+  "_cmd": "wa b 4, de d v 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, de d v 5 1`] = `
+{
+  "_cmd": "wa b 4, de d v 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, de d v 6 1`] = `
+{
+  "_cmd": "wa b 4, de d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, de d v 7 1`] = `
+{
+  "_cmd": "wa b 4, de d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de d v 8 1`] = `
+{
+  "_cmd": "wa b 4, de d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, de d v 9 1`] = `
+{
+  "_cmd": "wa b 4, de d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de d v 10 1`] = `
+{
+  "_cmd": "wa b 4, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de d v 11 1`] = `
+{
+  "_cmd": "wa b 4, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de d v 12 1`] = `
+{
+  "_cmd": "wa b 4, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, de d v 13 1`] = `
+{
+  "_cmd": "wa b 4, de d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de d v 14 1`] = `
+{
+  "_cmd": "wa b 4, de d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de d v 15 1`] = `
+{
+  "_cmd": "wa b 4, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de d v 16 1`] = `
+{
+  "_cmd": "wa b 4, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, de d v 17 1`] = `
+{
+  "_cmd": "wa b 4, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 4, de d v 18 1`] = `
+{
+  "_cmd": "wa b 4, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 4, de d v 19 1`] = `
+{
+  "_cmd": "wa b 4, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 4, de d v 20 1`] = `
+{
+  "_cmd": "wa b 4, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 4, de p 1 1`] = `
+{
+  "_cmd": "wa b 4, de p 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, de p 2 1`] = `
+{
+  "_cmd": "wa b 4, de p 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, de p 3 1`] = `
+{
+  "_cmd": "wa b 4, de p 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, de p 4 1`] = `
+{
+  "_cmd": "wa b 4, de p 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, de p 5 1`] = `
+{
+  "_cmd": "wa b 4, de p 5",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, de p 6 1`] = `
+{
+  "_cmd": "wa b 4, de p 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, de p 7 1`] = `
+{
+  "_cmd": "wa b 4, de p 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, de p 8 1`] = `
+{
+  "_cmd": "wa b 4, de p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de p 9 1`] = `
+{
+  "_cmd": "wa b 4, de p 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, de p 10 1`] = `
+{
+  "_cmd": "wa b 4, de p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de p 11 1`] = `
+{
+  "_cmd": "wa b 4, de p 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de p 12 1`] = `
+{
+  "_cmd": "wa b 4, de p 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de p 13 1`] = `
+{
+  "_cmd": "wa b 4, de p 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, de p 14 1`] = `
+{
+  "_cmd": "wa b 4, de p 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de p 15 1`] = `
+{
+  "_cmd": "wa b 4, de p 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de p v 1 1`] = `
+{
+  "_cmd": "wa b 4, de p v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, de p v 2 1`] = `
+{
+  "_cmd": "wa b 4, de p v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, de p v 3 1`] = `
+{
+  "_cmd": "wa b 4, de p v 3",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, de p v 4 1`] = `
+{
+  "_cmd": "wa b 4, de p v 4",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 4, de p v 5 1`] = `
+{
+  "_cmd": "wa b 4, de p v 5",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, de p v 6 1`] = `
+{
+  "_cmd": "wa b 4, de p v 6",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, de p v 7 1`] = `
+{
+  "_cmd": "wa b 4, de p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, de p v 8 1`] = `
+{
+  "_cmd": "wa b 4, de p v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, de p v 9 1`] = `
+{
+  "_cmd": "wa b 4, de p v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de p v 10 1`] = `
+{
+  "_cmd": "wa b 4, de p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de p v 11 1`] = `
+{
+  "_cmd": "wa b 4, de p v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, de p v 12 1`] = `
+{
+  "_cmd": "wa b 4, de p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de p v 13 1`] = `
+{
+  "_cmd": "wa b 4, de p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de p v 14 1`] = `
+{
+  "_cmd": "wa b 4, de p v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, de p v 15 1`] = `
+{
+  "_cmd": "wa b 4, de p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de p v 16 1`] = `
+{
+  "_cmd": "wa b 4, de p v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de p v 17 1`] = `
+{
+  "_cmd": "wa b 4, de p v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, de p v 18 1`] = `
+{
+  "_cmd": "wa b 4, de p v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, de p v 19 1`] = `
+{
+  "_cmd": "wa b 4, de p v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 4, de p v 20 1`] = `
+{
+  "_cmd": "wa b 4, de p v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 4, de v 1 1`] = `
+{
+  "_cmd": "wa b 4, de v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, de v 2 1`] = `
+{
+  "_cmd": "wa b 4, de v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, de v 3 1`] = `
+{
+  "_cmd": "wa b 4, de v 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, de v 4 1`] = `
+{
+  "_cmd": "wa b 4, de v 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, de v 5 1`] = `
+{
+  "_cmd": "wa b 4, de v 5",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, de v 6 1`] = `
+{
+  "_cmd": "wa b 4, de v 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, de v 7 1`] = `
+{
+  "_cmd": "wa b 4, de v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, de v 8 1`] = `
+{
+  "_cmd": "wa b 4, de v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de v 9 1`] = `
+{
+  "_cmd": "wa b 4, de v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, de v 10 1`] = `
+{
+  "_cmd": "wa b 4, de v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de v 11 1`] = `
+{
+  "_cmd": "wa b 4, de v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de v 12 1`] = `
+{
+  "_cmd": "wa b 4, de v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de v 13 1`] = `
+{
+  "_cmd": "wa b 4, de v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, de v 14 1`] = `
+{
+  "_cmd": "wa b 4, de v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de v 15 1`] = `
+{
+  "_cmd": "wa b 4, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de v 16 1`] = `
+{
+  "_cmd": "wa b 4, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, de v 17 1`] = `
+{
+  "_cmd": "wa b 4, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, de v 18 1`] = `
+{
+  "_cmd": "wa b 4, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 4, de v 19 1`] = `
+{
+  "_cmd": "wa b 4, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 4, de v 20 1`] = `
+{
+  "_cmd": "wa b 4, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 4, de w 1 1`] = `
+{
+  "_cmd": "wa b 4, de w 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, de w 2 1`] = `
+{
+  "_cmd": "wa b 4, de w 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, de w 3 1`] = `
+{
+  "_cmd": "wa b 4, de w 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, de w 4 1`] = `
+{
+  "_cmd": "wa b 4, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, de w 5 1`] = `
+{
+  "_cmd": "wa b 4, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, de w 6 1`] = `
+{
+  "_cmd": "wa b 4, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, de w 7 1`] = `
+{
+  "_cmd": "wa b 4, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de w 8 1`] = `
+{
+  "_cmd": "wa b 4, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, de w 9 1`] = `
+{
+  "_cmd": "wa b 4, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de w 10 1`] = `
+{
+  "_cmd": "wa b 4, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, de w 11 1`] = `
+{
+  "_cmd": "wa b 4, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de w 12 1`] = `
+{
+  "_cmd": "wa b 4, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de w 13 1`] = `
+{
+  "_cmd": "wa b 4, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de w 14 1`] = `
+{
+  "_cmd": "wa b 4, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, de w 15 1`] = `
+{
+  "_cmd": "wa b 4, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, de w v 1 1`] = `
+{
+  "_cmd": "wa b 4, de w v 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, de w v 2 1`] = `
+{
+  "_cmd": "wa b 4, de w v 2",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, de w v 3 1`] = `
+{
+  "_cmd": "wa b 4, de w v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, de w v 4 1`] = `
+{
+  "_cmd": "wa b 4, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, de w v 5 1`] = `
+{
+  "_cmd": "wa b 4, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, de w v 6 1`] = `
+{
+  "_cmd": "wa b 4, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, de w v 7 1`] = `
+{
+  "_cmd": "wa b 4, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, de w v 8 1`] = `
+{
+  "_cmd": "wa b 4, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, de w v 9 1`] = `
+{
+  "_cmd": "wa b 4, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, de w v 10 1`] = `
+{
+  "_cmd": "wa b 4, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, de w v 11 1`] = `
+{
+  "_cmd": "wa b 4, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, de w v 12 1`] = `
+{
+  "_cmd": "wa b 4, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, de w v 13 1`] = `
+{
+  "_cmd": "wa b 4, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, de w v 14 1`] = `
+{
+  "_cmd": "wa b 4, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, de w v 15 1`] = `
+{
+  "_cmd": "wa b 4, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, de w v 16 1`] = `
+{
+  "_cmd": "wa b 4, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 4, de w v 17 1`] = `
+{
+  "_cmd": "wa b 4, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 4, de w v 18 1`] = `
+{
+  "_cmd": "wa b 4, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 4, de w v 19 1`] = `
+{
+  "_cmd": "wa b 4, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 4, de w v 20 1`] = `
+{
+  "_cmd": "wa b 4, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 5, de d 1 1`] = `
+{
+  "_cmd": "wa b 5, de d 1",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 5, de d 2 1`] = `
+{
+  "_cmd": "wa b 5, de d 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, de d 3 1`] = `
+{
+  "_cmd": "wa b 5, de d 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de d 4 1`] = `
+{
+  "_cmd": "wa b 5, de d 4",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, de d 5 1`] = `
+{
+  "_cmd": "wa b 5, de d 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, de d 6 1`] = `
+{
+  "_cmd": "wa b 5, de d 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de d 7 1`] = `
+{
+  "_cmd": "wa b 5, de d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, de d 8 1`] = `
+{
+  "_cmd": "wa b 5, de d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, de d 9 1`] = `
+{
+  "_cmd": "wa b 5, de d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de d 10 1`] = `
+{
+  "_cmd": "wa b 5, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de d 11 1`] = `
+{
+  "_cmd": "wa b 5, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de d 12 1`] = `
+{
+  "_cmd": "wa b 5, de d 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, de d 13 1`] = `
+{
+  "_cmd": "wa b 5, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de d 14 1`] = `
+{
+  "_cmd": "wa b 5, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de d 15 1`] = `
+{
+  "_cmd": "wa b 5, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 5, de d v 1 1`] = `
+{
+  "_cmd": "wa b 5, de d v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, de d v 2 1`] = `
+{
+  "_cmd": "wa b 5, de d v 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, de d v 3 1`] = `
+{
+  "_cmd": "wa b 5, de d v 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de d v 4 1`] = `
+{
+  "_cmd": "wa b 5, de d v 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, de d v 5 1`] = `
+{
+  "_cmd": "wa b 5, de d v 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, de d v 6 1`] = `
+{
+  "_cmd": "wa b 5, de d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de d v 7 1`] = `
+{
+  "_cmd": "wa b 5, de d v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, de d v 8 1`] = `
+{
+  "_cmd": "wa b 5, de d v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, de d v 9 1`] = `
+{
+  "_cmd": "wa b 5, de d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de d v 10 1`] = `
+{
+  "_cmd": "wa b 5, de d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de d v 11 1`] = `
+{
+  "_cmd": "wa b 5, de d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de d v 12 1`] = `
+{
+  "_cmd": "wa b 5, de d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de d v 13 1`] = `
+{
+  "_cmd": "wa b 5, de d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de d v 14 1`] = `
+{
+  "_cmd": "wa b 5, de d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de d v 15 1`] = `
+{
+  "_cmd": "wa b 5, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, de d v 16 1`] = `
+{
+  "_cmd": "wa b 5, de d v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 5, de d v 17 1`] = `
+{
+  "_cmd": "wa b 5, de d v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, de d v 18 1`] = `
+{
+  "_cmd": "wa b 5, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 5, de d v 19 1`] = `
+{
+  "_cmd": "wa b 5, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 5, de d v 20 1`] = `
+{
+  "_cmd": "wa b 5, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 5, de p 1 1`] = `
+{
+  "_cmd": "wa b 5, de p 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, de p 2 1`] = `
+{
+  "_cmd": "wa b 5, de p 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, de p 3 1`] = `
+{
+  "_cmd": "wa b 5, de p 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 5, de p 4 1`] = `
+{
+  "_cmd": "wa b 5, de p 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de p 5 1`] = `
+{
+  "_cmd": "wa b 5, de p 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, de p 6 1`] = `
+{
+  "_cmd": "wa b 5, de p 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, de p 7 1`] = `
+{
+  "_cmd": "wa b 5, de p 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de p 8 1`] = `
+{
+  "_cmd": "wa b 5, de p 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, de p 9 1`] = `
+{
+  "_cmd": "wa b 5, de p 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, de p 10 1`] = `
+{
+  "_cmd": "wa b 5, de p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de p 11 1`] = `
+{
+  "_cmd": "wa b 5, de p 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de p 12 1`] = `
+{
+  "_cmd": "wa b 5, de p 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de p 13 1`] = `
+{
+  "_cmd": "wa b 5, de p 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de p 14 1`] = `
+{
+  "_cmd": "wa b 5, de p 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de p 15 1`] = `
+{
+  "_cmd": "wa b 5, de p 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de p v 1 1`] = `
+{
+  "_cmd": "wa b 5, de p v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, de p v 2 1`] = `
+{
+  "_cmd": "wa b 5, de p v 2",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 5, de p v 3 1`] = `
+{
+  "_cmd": "wa b 5, de p v 3",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, de p v 4 1`] = `
+{
+  "_cmd": "wa b 5, de p v 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de p v 5 1`] = `
+{
+  "_cmd": "wa b 5, de p v 5",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, de p v 6 1`] = `
+{
+  "_cmd": "wa b 5, de p v 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, de p v 7 1`] = `
+{
+  "_cmd": "wa b 5, de p v 7",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, de p v 8 1`] = `
+{
+  "_cmd": "wa b 5, de p v 8",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de p v 9 1`] = `
+{
+  "_cmd": "wa b 5, de p v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, de p v 10 1`] = `
+{
+  "_cmd": "wa b 5, de p v 10",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, de p v 11 1`] = `
+{
+  "_cmd": "wa b 5, de p v 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de p v 12 1`] = `
+{
+  "_cmd": "wa b 5, de p v 12",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de p v 13 1`] = `
+{
+  "_cmd": "wa b 5, de p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de p v 14 1`] = `
+{
+  "_cmd": "wa b 5, de p v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, de p v 15 1`] = `
+{
+  "_cmd": "wa b 5, de p v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de p v 16 1`] = `
+{
+  "_cmd": "wa b 5, de p v 16",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de p v 17 1`] = `
+{
+  "_cmd": "wa b 5, de p v 17",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, de p v 18 1`] = `
+{
+  "_cmd": "wa b 5, de p v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, de p v 19 1`] = `
+{
+  "_cmd": "wa b 5, de p v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 5, de p v 20 1`] = `
+{
+  "_cmd": "wa b 5, de p v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 5, de v 1 1`] = `
+{
+  "_cmd": "wa b 5, de v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, de v 2 1`] = `
+{
+  "_cmd": "wa b 5, de v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, de v 3 1`] = `
+{
+  "_cmd": "wa b 5, de v 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 5, de v 4 1`] = `
+{
+  "_cmd": "wa b 5, de v 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de v 5 1`] = `
+{
+  "_cmd": "wa b 5, de v 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, de v 6 1`] = `
+{
+  "_cmd": "wa b 5, de v 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, de v 7 1`] = `
+{
+  "_cmd": "wa b 5, de v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de v 8 1`] = `
+{
+  "_cmd": "wa b 5, de v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, de v 9 1`] = `
+{
+  "_cmd": "wa b 5, de v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, de v 10 1`] = `
+{
+  "_cmd": "wa b 5, de v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de v 11 1`] = `
+{
+  "_cmd": "wa b 5, de v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de v 12 1`] = `
+{
+  "_cmd": "wa b 5, de v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de v 13 1`] = `
+{
+  "_cmd": "wa b 5, de v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, de v 14 1`] = `
+{
+  "_cmd": "wa b 5, de v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de v 15 1`] = `
+{
+  "_cmd": "wa b 5, de v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de v 16 1`] = `
+{
+  "_cmd": "wa b 5, de v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, de v 17 1`] = `
+{
+  "_cmd": "wa b 5, de v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 5, de v 18 1`] = `
+{
+  "_cmd": "wa b 5, de v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, de v 19 1`] = `
+{
+  "_cmd": "wa b 5, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 5, de v 20 1`] = `
+{
+  "_cmd": "wa b 5, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 5, de w 1 1`] = `
+{
+  "_cmd": "wa b 5, de w 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, de w 2 1`] = `
+{
+  "_cmd": "wa b 5, de w 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, de w 3 1`] = `
+{
+  "_cmd": "wa b 5, de w 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, de w 4 1`] = `
+{
+  "_cmd": "wa b 5, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, de w 5 1`] = `
+{
+  "_cmd": "wa b 5, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, de w 6 1`] = `
+{
+  "_cmd": "wa b 5, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, de w 7 1`] = `
+{
+  "_cmd": "wa b 5, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, de w 8 1`] = `
+{
+  "_cmd": "wa b 5, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de w 9 1`] = `
+{
+  "_cmd": "wa b 5, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de w 10 1`] = `
+{
+  "_cmd": "wa b 5, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de w 11 1`] = `
+{
+  "_cmd": "wa b 5, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de w 12 1`] = `
+{
+  "_cmd": "wa b 5, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de w 13 1`] = `
+{
+  "_cmd": "wa b 5, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, de w 14 1`] = `
+{
+  "_cmd": "wa b 5, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 5, de w 15 1`] = `
+{
+  "_cmd": "wa b 5, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, de w v 1 1`] = `
+{
+  "_cmd": "wa b 5, de w v 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, de w v 2 1`] = `
+{
+  "_cmd": "wa b 5, de w v 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, de w v 3 1`] = `
+{
+  "_cmd": "wa b 5, de w v 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, de w v 4 1`] = `
+{
+  "_cmd": "wa b 5, de w v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, de w v 5 1`] = `
+{
+  "_cmd": "wa b 5, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, de w v 6 1`] = `
+{
+  "_cmd": "wa b 5, de w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, de w v 7 1`] = `
+{
+  "_cmd": "wa b 5, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, de w v 8 1`] = `
+{
+  "_cmd": "wa b 5, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, de w v 9 1`] = `
+{
+  "_cmd": "wa b 5, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, de w v 10 1`] = `
+{
+  "_cmd": "wa b 5, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, de w v 11 1`] = `
+{
+  "_cmd": "wa b 5, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, de w v 12 1`] = `
+{
+  "_cmd": "wa b 5, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, de w v 13 1`] = `
+{
+  "_cmd": "wa b 5, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, de w v 14 1`] = `
+{
+  "_cmd": "wa b 5, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 5, de w v 15 1`] = `
+{
+  "_cmd": "wa b 5, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, de w v 16 1`] = `
+{
+  "_cmd": "wa b 5, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 5, de w v 17 1`] = `
+{
+  "_cmd": "wa b 5, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 5, de w v 18 1`] = `
+{
+  "_cmd": "wa b 5, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 5, de w v 19 1`] = `
+{
+  "_cmd": "wa b 5, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 5, de w v 20 1`] = `
+{
+  "_cmd": "wa b 5, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 6, de d 1 1`] = `
+{
+  "_cmd": "wa b 6, de d 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 6, de d 2 1`] = `
+{
+  "_cmd": "wa b 6, de d 2",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, de d 3 1`] = `
+{
+  "_cmd": "wa b 6, de d 3",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, de d 4 1`] = `
+{
+  "_cmd": "wa b 6, de d 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, de d 5 1`] = `
+{
+  "_cmd": "wa b 6, de d 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de d 6 1`] = `
+{
+  "_cmd": "wa b 6, de d 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, de d 7 1`] = `
+{
+  "_cmd": "wa b 6, de d 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de d 8 1`] = `
+{
+  "_cmd": "wa b 6, de d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, de d 9 1`] = `
+{
+  "_cmd": "wa b 6, de d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de d 10 1`] = `
+{
+  "_cmd": "wa b 6, de d 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, de d 11 1`] = `
+{
+  "_cmd": "wa b 6, de d 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de d 12 1`] = `
+{
+  "_cmd": "wa b 6, de d 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de d 13 1`] = `
+{
+  "_cmd": "wa b 6, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de d 14 1`] = `
+{
+  "_cmd": "wa b 6, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 6, de d 15 1`] = `
+{
+  "_cmd": "wa b 6, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de d v 1 1`] = `
+{
+  "_cmd": "wa b 6, de d v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, de d v 2 1`] = `
+{
+  "_cmd": "wa b 6, de d v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, de d v 3 1`] = `
+{
+  "_cmd": "wa b 6, de d v 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 6, de d v 4 1`] = `
+{
+  "_cmd": "wa b 6, de d v 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, de d v 5 1`] = `
+{
+  "_cmd": "wa b 6, de d v 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de d v 6 1`] = `
+{
+  "_cmd": "wa b 6, de d v 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, de d v 7 1`] = `
+{
+  "_cmd": "wa b 6, de d v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de d v 8 1`] = `
+{
+  "_cmd": "wa b 6, de d v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de d v 9 1`] = `
+{
+  "_cmd": "wa b 6, de d v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, de d v 10 1`] = `
+{
+  "_cmd": "wa b 6, de d v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de d v 11 1`] = `
+{
+  "_cmd": "wa b 6, de d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de d v 12 1`] = `
+{
+  "_cmd": "wa b 6, de d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de d v 13 1`] = `
+{
+  "_cmd": "wa b 6, de d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de d v 14 1`] = `
+{
+  "_cmd": "wa b 6, de d v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de d v 15 1`] = `
+{
+  "_cmd": "wa b 6, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de d v 16 1`] = `
+{
+  "_cmd": "wa b 6, de d v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, de d v 17 1`] = `
+{
+  "_cmd": "wa b 6, de d v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 6, de d v 18 1`] = `
+{
+  "_cmd": "wa b 6, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 6, de d v 19 1`] = `
+{
+  "_cmd": "wa b 6, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 6, de d v 20 1`] = `
+{
+  "_cmd": "wa b 6, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 6, de p 1 1`] = `
+{
+  "_cmd": "wa b 6, de p 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, de p 2 1`] = `
+{
+  "_cmd": "wa b 6, de p 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, de p 3 1`] = `
+{
+  "_cmd": "wa b 6, de p 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, de p 4 1`] = `
+{
+  "_cmd": "wa b 6, de p 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, de p 5 1`] = `
+{
+  "_cmd": "wa b 6, de p 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, de p 6 1`] = `
+{
+  "_cmd": "wa b 6, de p 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de p 7 1`] = `
+{
+  "_cmd": "wa b 6, de p 7",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, de p 8 1`] = `
+{
+  "_cmd": "wa b 6, de p 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de p 9 1`] = `
+{
+  "_cmd": "wa b 6, de p 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de p 10 1`] = `
+{
+  "_cmd": "wa b 6, de p 10",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, de p 11 1`] = `
+{
+  "_cmd": "wa b 6, de p 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de p 12 1`] = `
+{
+  "_cmd": "wa b 6, de p 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de p 13 1`] = `
+{
+  "_cmd": "wa b 6, de p 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de p 14 1`] = `
+{
+  "_cmd": "wa b 6, de p 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de p 15 1`] = `
+{
+  "_cmd": "wa b 6, de p 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de p v 1 1`] = `
+{
+  "_cmd": "wa b 6, de p v 1",
+  "attacker": 6,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 6, de p v 2 1`] = `
+{
+  "_cmd": "wa b 6, de p v 2",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 6, de p v 3 1`] = `
+{
+  "_cmd": "wa b 6, de p v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, de p v 4 1`] = `
+{
+  "_cmd": "wa b 6, de p v 4",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 6, de p v 5 1`] = `
+{
+  "_cmd": "wa b 6, de p v 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, de p v 6 1`] = `
+{
+  "_cmd": "wa b 6, de p v 6",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, de p v 7 1`] = `
+{
+  "_cmd": "wa b 6, de p v 7",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de p v 8 1`] = `
+{
+  "_cmd": "wa b 6, de p v 8",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, de p v 9 1`] = `
+{
+  "_cmd": "wa b 6, de p v 9",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de p v 10 1`] = `
+{
+  "_cmd": "wa b 6, de p v 10",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de p v 11 1`] = `
+{
+  "_cmd": "wa b 6, de p v 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de p v 12 1`] = `
+{
+  "_cmd": "wa b 6, de p v 12",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, de p v 13 1`] = `
+{
+  "_cmd": "wa b 6, de p v 13",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de p v 14 1`] = `
+{
+  "_cmd": "wa b 6, de p v 14",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de p v 15 1`] = `
+{
+  "_cmd": "wa b 6, de p v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de p v 16 1`] = `
+{
+  "_cmd": "wa b 6, de p v 16",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 6, de p v 17 1`] = `
+{
+  "_cmd": "wa b 6, de p v 17",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de p v 18 1`] = `
+{
+  "_cmd": "wa b 6, de p v 18",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, de p v 19 1`] = `
+{
+  "_cmd": "wa b 6, de p v 19",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 6, de p v 20 1`] = `
+{
+  "_cmd": "wa b 6, de p v 20",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 6, de v 1 1`] = `
+{
+  "_cmd": "wa b 6, de v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, de v 2 1`] = `
+{
+  "_cmd": "wa b 6, de v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, de v 3 1`] = `
+{
+  "_cmd": "wa b 6, de v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, de v 4 1`] = `
+{
+  "_cmd": "wa b 6, de v 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, de v 5 1`] = `
+{
+  "_cmd": "wa b 6, de v 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, de v 6 1`] = `
+{
+  "_cmd": "wa b 6, de v 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de v 7 1`] = `
+{
+  "_cmd": "wa b 6, de v 7",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, de v 8 1`] = `
+{
+  "_cmd": "wa b 6, de v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de v 9 1`] = `
+{
+  "_cmd": "wa b 6, de v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de v 10 1`] = `
+{
+  "_cmd": "wa b 6, de v 10",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, de v 11 1`] = `
+{
+  "_cmd": "wa b 6, de v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, de v 12 1`] = `
+{
+  "_cmd": "wa b 6, de v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de v 13 1`] = `
+{
+  "_cmd": "wa b 6, de v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de v 14 1`] = `
+{
+  "_cmd": "wa b 6, de v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de v 15 1`] = `
+{
+  "_cmd": "wa b 6, de v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de v 16 1`] = `
+{
+  "_cmd": "wa b 6, de v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de v 17 1`] = `
+{
+  "_cmd": "wa b 6, de v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, de v 18 1`] = `
+{
+  "_cmd": "wa b 6, de v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 6, de v 19 1`] = `
+{
+  "_cmd": "wa b 6, de v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 6, de v 20 1`] = `
+{
+  "_cmd": "wa b 6, de v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 6, de w 1 1`] = `
+{
+  "_cmd": "wa b 6, de w 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, de w 2 1`] = `
+{
+  "_cmd": "wa b 6, de w 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, de w 3 1`] = `
+{
+  "_cmd": "wa b 6, de w 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, de w 4 1`] = `
+{
+  "_cmd": "wa b 6, de w 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, de w 5 1`] = `
+{
+  "_cmd": "wa b 6, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, de w 6 1`] = `
+{
+  "_cmd": "wa b 6, de w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de w 7 1`] = `
+{
+  "_cmd": "wa b 6, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de w 8 1`] = `
+{
+  "_cmd": "wa b 6, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, de w 9 1`] = `
+{
+  "_cmd": "wa b 6, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de w 10 1`] = `
+{
+  "_cmd": "wa b 6, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de w 11 1`] = `
+{
+  "_cmd": "wa b 6, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de w 12 1`] = `
+{
+  "_cmd": "wa b 6, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de w 13 1`] = `
+{
+  "_cmd": "wa b 6, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de w 14 1`] = `
+{
+  "_cmd": "wa b 6, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, de w 15 1`] = `
+{
+  "_cmd": "wa b 6, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 6, de w v 1 1`] = `
+{
+  "_cmd": "wa b 6, de w v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, de w v 2 1`] = `
+{
+  "_cmd": "wa b 6, de w v 2",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, de w v 3 1`] = `
+{
+  "_cmd": "wa b 6, de w v 3",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, de w v 4 1`] = `
+{
+  "_cmd": "wa b 6, de w v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, de w v 5 1`] = `
+{
+  "_cmd": "wa b 6, de w v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, de w v 6 1`] = `
+{
+  "_cmd": "wa b 6, de w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, de w v 7 1`] = `
+{
+  "_cmd": "wa b 6, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, de w v 8 1`] = `
+{
+  "_cmd": "wa b 6, de w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, de w v 9 1`] = `
+{
+  "_cmd": "wa b 6, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, de w v 10 1`] = `
+{
+  "_cmd": "wa b 6, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, de w v 11 1`] = `
+{
+  "_cmd": "wa b 6, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, de w v 12 1`] = `
+{
+  "_cmd": "wa b 6, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, de w v 13 1`] = `
+{
+  "_cmd": "wa b 6, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 6, de w v 14 1`] = `
+{
+  "_cmd": "wa b 6, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, de w v 15 1`] = `
+{
+  "_cmd": "wa b 6, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, de w v 16 1`] = `
+{
+  "_cmd": "wa b 6, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 6, de w v 17 1`] = `
+{
+  "_cmd": "wa b 6, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 6, de w v 18 1`] = `
+{
+  "_cmd": "wa b 6, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 6, de w v 19 1`] = `
+{
+  "_cmd": "wa b 6, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 6, de w v 20 1`] = `
+{
+  "_cmd": "wa b 6, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 7, de d 1 1`] = `
+{
+  "_cmd": "wa b 7, de d 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, de d 2 1`] = `
+{
+  "_cmd": "wa b 7, de d 2",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, de d 3 1`] = `
+{
+  "_cmd": "wa b 7, de d 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, de d 4 1`] = `
+{
+  "_cmd": "wa b 7, de d 4",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, de d 5 1`] = `
+{
+  "_cmd": "wa b 7, de d 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, de d 6 1`] = `
+{
+  "_cmd": "wa b 7, de d 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de d 7 1`] = `
+{
+  "_cmd": "wa b 7, de d 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de d 8 1`] = `
+{
+  "_cmd": "wa b 7, de d 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, de d 9 1`] = `
+{
+  "_cmd": "wa b 7, de d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de d 10 1`] = `
+{
+  "_cmd": "wa b 7, de d 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de d 11 1`] = `
+{
+  "_cmd": "wa b 7, de d 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, de d 12 1`] = `
+{
+  "_cmd": "wa b 7, de d 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, de d 13 1`] = `
+{
+  "_cmd": "wa b 7, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de d 14 1`] = `
+{
+  "_cmd": "wa b 7, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de d 15 1`] = `
+{
+  "_cmd": "wa b 7, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, de d v 1 1`] = `
+{
+  "_cmd": "wa b 7, de d v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, de d v 2 1`] = `
+{
+  "_cmd": "wa b 7, de d v 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, de d v 3 1`] = `
+{
+  "_cmd": "wa b 7, de d v 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, de d v 4 1`] = `
+{
+  "_cmd": "wa b 7, de d v 4",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, de d v 5 1`] = `
+{
+  "_cmd": "wa b 7, de d v 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, de d v 6 1`] = `
+{
+  "_cmd": "wa b 7, de d v 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de d v 7 1`] = `
+{
+  "_cmd": "wa b 7, de d v 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, de d v 8 1`] = `
+{
+  "_cmd": "wa b 7, de d v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de d v 9 1`] = `
+{
+  "_cmd": "wa b 7, de d v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de d v 10 1`] = `
+{
+  "_cmd": "wa b 7, de d v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de d v 11 1`] = `
+{
+  "_cmd": "wa b 7, de d v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de d v 12 1`] = `
+{
+  "_cmd": "wa b 7, de d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, de d v 13 1`] = `
+{
+  "_cmd": "wa b 7, de d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de d v 14 1`] = `
+{
+  "_cmd": "wa b 7, de d v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de d v 15 1`] = `
+{
+  "_cmd": "wa b 7, de d v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de d v 16 1`] = `
+{
+  "_cmd": "wa b 7, de d v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, de d v 17 1`] = `
+{
+  "_cmd": "wa b 7, de d v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 7, de d v 18 1`] = `
+{
+  "_cmd": "wa b 7, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 7, de d v 19 1`] = `
+{
+  "_cmd": "wa b 7, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 7, de d v 20 1`] = `
+{
+  "_cmd": "wa b 7, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 7, de p 1 1`] = `
+{
+  "_cmd": "wa b 7, de p 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, de p 2 1`] = `
+{
+  "_cmd": "wa b 7, de p 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, de p 3 1`] = `
+{
+  "_cmd": "wa b 7, de p 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, de p 4 1`] = `
+{
+  "_cmd": "wa b 7, de p 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, de p 5 1`] = `
+{
+  "_cmd": "wa b 7, de p 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, de p 6 1`] = `
+{
+  "_cmd": "wa b 7, de p 6",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, de p 7 1`] = `
+{
+  "_cmd": "wa b 7, de p 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de p 8 1`] = `
+{
+  "_cmd": "wa b 7, de p 8",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, de p 9 1`] = `
+{
+  "_cmd": "wa b 7, de p 9",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de p 10 1`] = `
+{
+  "_cmd": "wa b 7, de p 10",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de p 11 1`] = `
+{
+  "_cmd": "wa b 7, de p 11",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de p 12 1`] = `
+{
+  "_cmd": "wa b 7, de p 12",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de p 13 1`] = `
+{
+  "_cmd": "wa b 7, de p 13",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, de p 14 1`] = `
+{
+  "_cmd": "wa b 7, de p 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de p 15 1`] = `
+{
+  "_cmd": "wa b 7, de p 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de p v 1 1`] = `
+{
+  "_cmd": "wa b 7, de p v 1",
+  "attacker": 7,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 7, de p v 2 1`] = `
+{
+  "_cmd": "wa b 7, de p v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, de p v 3 1`] = `
+{
+  "_cmd": "wa b 7, de p v 3",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, de p v 4 1`] = `
+{
+  "_cmd": "wa b 7, de p v 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, de p v 5 1`] = `
+{
+  "_cmd": "wa b 7, de p v 5",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, de p v 6 1`] = `
+{
+  "_cmd": "wa b 7, de p v 6",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, de p v 7 1`] = `
+{
+  "_cmd": "wa b 7, de p v 7",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, de p v 8 1`] = `
+{
+  "_cmd": "wa b 7, de p v 8",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de p v 9 1`] = `
+{
+  "_cmd": "wa b 7, de p v 9",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de p v 10 1`] = `
+{
+  "_cmd": "wa b 7, de p v 10",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, de p v 11 1`] = `
+{
+  "_cmd": "wa b 7, de p v 11",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de p v 12 1`] = `
+{
+  "_cmd": "wa b 7, de p v 12",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de p v 13 1`] = `
+{
+  "_cmd": "wa b 7, de p v 13",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, de p v 14 1`] = `
+{
+  "_cmd": "wa b 7, de p v 14",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, de p v 15 1`] = `
+{
+  "_cmd": "wa b 7, de p v 15",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de p v 16 1`] = `
+{
+  "_cmd": "wa b 7, de p v 16",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de p v 17 1`] = `
+{
+  "_cmd": "wa b 7, de p v 17",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de p v 18 1`] = `
+{
+  "_cmd": "wa b 7, de p v 18",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 7, de p v 19 1`] = `
+{
+  "_cmd": "wa b 7, de p v 19",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 7, de p v 20 1`] = `
+{
+  "_cmd": "wa b 7, de p v 20",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 7, de v 1 1`] = `
+{
+  "_cmd": "wa b 7, de v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, de v 2 1`] = `
+{
+  "_cmd": "wa b 7, de v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, de v 3 1`] = `
+{
+  "_cmd": "wa b 7, de v 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, de v 4 1`] = `
+{
+  "_cmd": "wa b 7, de v 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, de v 5 1`] = `
+{
+  "_cmd": "wa b 7, de v 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, de v 6 1`] = `
+{
+  "_cmd": "wa b 7, de v 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, de v 7 1`] = `
+{
+  "_cmd": "wa b 7, de v 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de v 8 1`] = `
+{
+  "_cmd": "wa b 7, de v 8",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, de v 9 1`] = `
+{
+  "_cmd": "wa b 7, de v 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, de v 10 1`] = `
+{
+  "_cmd": "wa b 7, de v 10",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de v 11 1`] = `
+{
+  "_cmd": "wa b 7, de v 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de v 12 1`] = `
+{
+  "_cmd": "wa b 7, de v 12",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de v 13 1`] = `
+{
+  "_cmd": "wa b 7, de v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, de v 14 1`] = `
+{
+  "_cmd": "wa b 7, de v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de v 15 1`] = `
+{
+  "_cmd": "wa b 7, de v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de v 16 1`] = `
+{
+  "_cmd": "wa b 7, de v 16",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de v 17 1`] = `
+{
+  "_cmd": "wa b 7, de v 17",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, de v 18 1`] = `
+{
+  "_cmd": "wa b 7, de v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 7, de v 19 1`] = `
+{
+  "_cmd": "wa b 7, de v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 7, de v 20 1`] = `
+{
+  "_cmd": "wa b 7, de v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 7, de w 1 1`] = `
+{
+  "_cmd": "wa b 7, de w 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, de w 2 1`] = `
+{
+  "_cmd": "wa b 7, de w 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, de w 3 1`] = `
+{
+  "_cmd": "wa b 7, de w 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, de w 4 1`] = `
+{
+  "_cmd": "wa b 7, de w 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, de w 5 1`] = `
+{
+  "_cmd": "wa b 7, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de w 6 1`] = `
+{
+  "_cmd": "wa b 7, de w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, de w 7 1`] = `
+{
+  "_cmd": "wa b 7, de w 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de w 8 1`] = `
+{
+  "_cmd": "wa b 7, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de w 9 1`] = `
+{
+  "_cmd": "wa b 7, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, de w 10 1`] = `
+{
+  "_cmd": "wa b 7, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, de w 11 1`] = `
+{
+  "_cmd": "wa b 7, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de w 12 1`] = `
+{
+  "_cmd": "wa b 7, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de w 13 1`] = `
+{
+  "_cmd": "wa b 7, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de w 14 1`] = `
+{
+  "_cmd": "wa b 7, de w 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, de w 15 1`] = `
+{
+  "_cmd": "wa b 7, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 7, de w v 1 1`] = `
+{
+  "_cmd": "wa b 7, de w v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, de w v 2 1`] = `
+{
+  "_cmd": "wa b 7, de w v 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, de w v 3 1`] = `
+{
+  "_cmd": "wa b 7, de w v 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, de w v 4 1`] = `
+{
+  "_cmd": "wa b 7, de w v 4",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, de w v 5 1`] = `
+{
+  "_cmd": "wa b 7, de w v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, de w v 6 1`] = `
+{
+  "_cmd": "wa b 7, de w v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, de w v 7 1`] = `
+{
+  "_cmd": "wa b 7, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, de w v 8 1`] = `
+{
+  "_cmd": "wa b 7, de w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, de w v 9 1`] = `
+{
+  "_cmd": "wa b 7, de w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, de w v 10 1`] = `
+{
+  "_cmd": "wa b 7, de w v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, de w v 11 1`] = `
+{
+  "_cmd": "wa b 7, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, de w v 12 1`] = `
+{
+  "_cmd": "wa b 7, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, de w v 13 1`] = `
+{
+  "_cmd": "wa b 7, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, de w v 14 1`] = `
+{
+  "_cmd": "wa b 7, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, de w v 15 1`] = `
+{
+  "_cmd": "wa b 7, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 7, de w v 16 1`] = `
+{
+  "_cmd": "wa b 7, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 7, de w v 17 1`] = `
+{
+  "_cmd": "wa b 7, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 7, de w v 18 1`] = `
+{
+  "_cmd": "wa b 7, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 7, de w v 19 1`] = `
+{
+  "_cmd": "wa b 7, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 7, de w v 20 1`] = `
+{
+  "_cmd": "wa b 7, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b 8, de d 1 1`] = `
+{
+  "_cmd": "wa b 8, de d 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 8, de d 2 1`] = `
+{
+  "_cmd": "wa b 8, de d 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, de d 3 1`] = `
+{
+  "_cmd": "wa b 8, de d 3",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de d 4 1`] = `
+{
+  "_cmd": "wa b 8, de d 4",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, de d 5 1`] = `
+{
+  "_cmd": "wa b 8, de d 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, de d 6 1`] = `
+{
+  "_cmd": "wa b 8, de d 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, de d 7 1`] = `
+{
+  "_cmd": "wa b 8, de d 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, de d 8 1`] = `
+{
+  "_cmd": "wa b 8, de d 8",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de d 9 1`] = `
+{
+  "_cmd": "wa b 8, de d 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, de d 10 1`] = `
+{
+  "_cmd": "wa b 8, de d 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de d 11 1`] = `
+{
+  "_cmd": "wa b 8, de d 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de d 12 1`] = `
+{
+  "_cmd": "wa b 8, de d 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de d 13 1`] = `
+{
+  "_cmd": "wa b 8, de d 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, de d 14 1`] = `
+{
+  "_cmd": "wa b 8, de d 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de d 15 1`] = `
+{
+  "_cmd": "wa b 8, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de d v 1 1`] = `
+{
+  "_cmd": "wa b 8, de d v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 8, de d v 2 1`] = `
+{
+  "_cmd": "wa b 8, de d v 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, de d v 3 1`] = `
+{
+  "_cmd": "wa b 8, de d v 3",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de d v 4 1`] = `
+{
+  "_cmd": "wa b 8, de d v 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, de d v 5 1`] = `
+{
+  "_cmd": "wa b 8, de d v 5",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, de d v 6 1`] = `
+{
+  "_cmd": "wa b 8, de d v 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, de d v 7 1`] = `
+{
+  "_cmd": "wa b 8, de d v 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, de d v 8 1`] = `
+{
+  "_cmd": "wa b 8, de d v 8",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, de d v 9 1`] = `
+{
+  "_cmd": "wa b 8, de d v 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de d v 10 1`] = `
+{
+  "_cmd": "wa b 8, de d v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de d v 11 1`] = `
+{
+  "_cmd": "wa b 8, de d v 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, de d v 12 1`] = `
+{
+  "_cmd": "wa b 8, de d v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de d v 13 1`] = `
+{
+  "_cmd": "wa b 8, de d v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de d v 14 1`] = `
+{
+  "_cmd": "wa b 8, de d v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de d v 15 1`] = `
+{
+  "_cmd": "wa b 8, de d v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 8, de d v 16 1`] = `
+{
+  "_cmd": "wa b 8, de d v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de d v 17 1`] = `
+{
+  "_cmd": "wa b 8, de d v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, de d v 18 1`] = `
+{
+  "_cmd": "wa b 8, de d v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 8, de d v 19 1`] = `
+{
+  "_cmd": "wa b 8, de d v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 8, de d v 20 1`] = `
+{
+  "_cmd": "wa b 8, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 8, de p 1 1`] = `
+{
+  "_cmd": "wa b 8, de p 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 8, de p 2 1`] = `
+{
+  "_cmd": "wa b 8, de p 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, de p 3 1`] = `
+{
+  "_cmd": "wa b 8, de p 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 8, de p 4 1`] = `
+{
+  "_cmd": "wa b 8, de p 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de p 5 1`] = `
+{
+  "_cmd": "wa b 8, de p 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, de p 6 1`] = `
+{
+  "_cmd": "wa b 8, de p 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, de p 7 1`] = `
+{
+  "_cmd": "wa b 8, de p 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, de p 8 1`] = `
+{
+  "_cmd": "wa b 8, de p 8",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, de p 9 1`] = `
+{
+  "_cmd": "wa b 8, de p 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, de p 10 1`] = `
+{
+  "_cmd": "wa b 8, de p 10",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de p 11 1`] = `
+{
+  "_cmd": "wa b 8, de p 11",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de p 12 1`] = `
+{
+  "_cmd": "wa b 8, de p 12",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, de p 13 1`] = `
+{
+  "_cmd": "wa b 8, de p 13",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de p 14 1`] = `
+{
+  "_cmd": "wa b 8, de p 14",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de p 15 1`] = `
+{
+  "_cmd": "wa b 8, de p 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de p v 1 1`] = `
+{
+  "_cmd": "wa b 8, de p v 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 8, de p v 2 1`] = `
+{
+  "_cmd": "wa b 8, de p v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, de p v 3 1`] = `
+{
+  "_cmd": "wa b 8, de p v 3",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, de p v 4 1`] = `
+{
+  "_cmd": "wa b 8, de p v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de p v 5 1`] = `
+{
+  "_cmd": "wa b 8, de p v 5",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, de p v 6 1`] = `
+{
+  "_cmd": "wa b 8, de p v 6",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, de p v 7 1`] = `
+{
+  "_cmd": "wa b 8, de p v 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, de p v 8 1`] = `
+{
+  "_cmd": "wa b 8, de p v 8",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, de p v 9 1`] = `
+{
+  "_cmd": "wa b 8, de p v 9",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, de p v 10 1`] = `
+{
+  "_cmd": "wa b 8, de p v 10",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de p v 11 1`] = `
+{
+  "_cmd": "wa b 8, de p v 11",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, de p v 12 1`] = `
+{
+  "_cmd": "wa b 8, de p v 12",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de p v 13 1`] = `
+{
+  "_cmd": "wa b 8, de p v 13",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, de p v 14 1`] = `
+{
+  "_cmd": "wa b 8, de p v 14",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de p v 15 1`] = `
+{
+  "_cmd": "wa b 8, de p v 15",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, de p v 16 1`] = `
+{
+  "_cmd": "wa b 8, de p v 16",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de p v 17 1`] = `
+{
+  "_cmd": "wa b 8, de p v 17",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 8, de p v 18 1`] = `
+{
+  "_cmd": "wa b 8, de p v 18",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de p v 19 1`] = `
+{
+  "_cmd": "wa b 8, de p v 19",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, de p v 20 1`] = `
+{
+  "_cmd": "wa b 8, de p v 20",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 8, de v 1 1`] = `
+{
+  "_cmd": "wa b 8, de v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 8, de v 2 1`] = `
+{
+  "_cmd": "wa b 8, de v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, de v 3 1`] = `
+{
+  "_cmd": "wa b 8, de v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 8, de v 4 1`] = `
+{
+  "_cmd": "wa b 8, de v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de v 5 1`] = `
+{
+  "_cmd": "wa b 8, de v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, de v 6 1`] = `
+{
+  "_cmd": "wa b 8, de v 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, de v 7 1`] = `
+{
+  "_cmd": "wa b 8, de v 7",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, de v 8 1`] = `
+{
+  "_cmd": "wa b 8, de v 8",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, de v 9 1`] = `
+{
+  "_cmd": "wa b 8, de v 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, de v 10 1`] = `
+{
+  "_cmd": "wa b 8, de v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, de v 11 1`] = `
+{
+  "_cmd": "wa b 8, de v 11",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de v 12 1`] = `
+{
+  "_cmd": "wa b 8, de v 12",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, de v 13 1`] = `
+{
+  "_cmd": "wa b 8, de v 13",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de v 14 1`] = `
+{
+  "_cmd": "wa b 8, de v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, de v 15 1`] = `
+{
+  "_cmd": "wa b 8, de v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de v 16 1`] = `
+{
+  "_cmd": "wa b 8, de v 16",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 8, de v 17 1`] = `
+{
+  "_cmd": "wa b 8, de v 17",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de v 18 1`] = `
+{
+  "_cmd": "wa b 8, de v 18",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, de v 19 1`] = `
+{
+  "_cmd": "wa b 8, de v 19",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 8, de v 20 1`] = `
+{
+  "_cmd": "wa b 8, de v 20",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 8, de w 1 1`] = `
+{
+  "_cmd": "wa b 8, de w 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, de w 2 1`] = `
+{
+  "_cmd": "wa b 8, de w 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, de w 3 1`] = `
+{
+  "_cmd": "wa b 8, de w 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, de w 4 1`] = `
+{
+  "_cmd": "wa b 8, de w 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, de w 5 1`] = `
+{
+  "_cmd": "wa b 8, de w 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, de w 6 1`] = `
+{
+  "_cmd": "wa b 8, de w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de w 7 1`] = `
+{
+  "_cmd": "wa b 8, de w 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, de w 8 1`] = `
+{
+  "_cmd": "wa b 8, de w 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de w 9 1`] = `
+{
+  "_cmd": "wa b 8, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de w 10 1`] = `
+{
+  "_cmd": "wa b 8, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de w 11 1`] = `
+{
+  "_cmd": "wa b 8, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, de w 12 1`] = `
+{
+  "_cmd": "wa b 8, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de w 13 1`] = `
+{
+  "_cmd": "wa b 8, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 8, de w 14 1`] = `
+{
+  "_cmd": "wa b 8, de w 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de w 15 1`] = `
+{
+  "_cmd": "wa b 8, de w 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, de w v 1 1`] = `
+{
+  "_cmd": "wa b 8, de w v 1",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, de w v 2 1`] = `
+{
+  "_cmd": "wa b 8, de w v 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, de w v 3 1`] = `
+{
+  "_cmd": "wa b 8, de w v 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, de w v 4 1`] = `
+{
+  "_cmd": "wa b 8, de w v 4",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, de w v 5 1`] = `
+{
+  "_cmd": "wa b 8, de w v 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, de w v 6 1`] = `
+{
+  "_cmd": "wa b 8, de w v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, de w v 7 1`] = `
+{
+  "_cmd": "wa b 8, de w v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, de w v 8 1`] = `
+{
+  "_cmd": "wa b 8, de w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, de w v 9 1`] = `
+{
+  "_cmd": "wa b 8, de w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, de w v 10 1`] = `
+{
+  "_cmd": "wa b 8, de w v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, de w v 11 1`] = `
+{
+  "_cmd": "wa b 8, de w v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, de w v 12 1`] = `
+{
+  "_cmd": "wa b 8, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, de w v 13 1`] = `
+{
+  "_cmd": "wa b 8, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 8, de w v 14 1`] = `
+{
+  "_cmd": "wa b 8, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, de w v 15 1`] = `
+{
+  "_cmd": "wa b 8, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, de w v 16 1`] = `
+{
+  "_cmd": "wa b 8, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 8, de w v 17 1`] = `
+{
+  "_cmd": "wa b 8, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 8, de w v 18 1`] = `
+{
+  "_cmd": "wa b 8, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 8, de w v 19 1`] = `
+{
+  "_cmd": "wa b 8, de w v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 8, de w v 20 1`] = `
+{
+  "_cmd": "wa b 8, de w v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 9, de d 1 1`] = `
+{
+  "_cmd": "wa b 9, de d 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 9, de d 2 1`] = `
+{
+  "_cmd": "wa b 9, de d 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, de d 3 1`] = `
+{
+  "_cmd": "wa b 9, de d 3",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de d 4 1`] = `
+{
+  "_cmd": "wa b 9, de d 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, de d 5 1`] = `
+{
+  "_cmd": "wa b 9, de d 5",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, de d 6 1`] = `
+{
+  "_cmd": "wa b 9, de d 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, de d 7 1`] = `
+{
+  "_cmd": "wa b 9, de d 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, de d 8 1`] = `
+{
+  "_cmd": "wa b 9, de d 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, de d 9 1`] = `
+{
+  "_cmd": "wa b 9, de d 9",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de d 10 1`] = `
+{
+  "_cmd": "wa b 9, de d 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, de d 11 1`] = `
+{
+  "_cmd": "wa b 9, de d 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de d 12 1`] = `
+{
+  "_cmd": "wa b 9, de d 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de d 13 1`] = `
+{
+  "_cmd": "wa b 9, de d 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de d 14 1`] = `
+{
+  "_cmd": "wa b 9, de d 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, de d 15 1`] = `
+{
+  "_cmd": "wa b 9, de d 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 9, de d v 1 1`] = `
+{
+  "_cmd": "wa b 9, de d v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 9, de d v 2 1`] = `
+{
+  "_cmd": "wa b 9, de d v 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, de d v 3 1`] = `
+{
+  "_cmd": "wa b 9, de d v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, de d v 4 1`] = `
+{
+  "_cmd": "wa b 9, de d v 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, de d v 5 1`] = `
+{
+  "_cmd": "wa b 9, de d v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, de d v 6 1`] = `
+{
+  "_cmd": "wa b 9, de d v 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de d v 7 1`] = `
+{
+  "_cmd": "wa b 9, de d v 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, de d v 8 1`] = `
+{
+  "_cmd": "wa b 9, de d v 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de d v 9 1`] = `
+{
+  "_cmd": "wa b 9, de d v 9",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, de d v 10 1`] = `
+{
+  "_cmd": "wa b 9, de d v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de d v 11 1`] = `
+{
+  "_cmd": "wa b 9, de d v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de d v 12 1`] = `
+{
+  "_cmd": "wa b 9, de d v 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, de d v 13 1`] = `
+{
+  "_cmd": "wa b 9, de d v 13",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de d v 14 1`] = `
+{
+  "_cmd": "wa b 9, de d v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de d v 15 1`] = `
+{
+  "_cmd": "wa b 9, de d v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, de d v 16 1`] = `
+{
+  "_cmd": "wa b 9, de d v 16",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 9, de d v 17 1`] = `
+{
+  "_cmd": "wa b 9, de d v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, de d v 18 1`] = `
+{
+  "_cmd": "wa b 9, de d v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 9, de d v 19 1`] = `
+{
+  "_cmd": "wa b 9, de d v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 9, de d v 20 1`] = `
+{
+  "_cmd": "wa b 9, de d v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 9, de p 1 1`] = `
+{
+  "_cmd": "wa b 9, de p 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, de p 2 1`] = `
+{
+  "_cmd": "wa b 9, de p 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, de p 3 1`] = `
+{
+  "_cmd": "wa b 9, de p 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, de p 4 1`] = `
+{
+  "_cmd": "wa b 9, de p 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de p 5 1`] = `
+{
+  "_cmd": "wa b 9, de p 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, de p 6 1`] = `
+{
+  "_cmd": "wa b 9, de p 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, de p 7 1`] = `
+{
+  "_cmd": "wa b 9, de p 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de p 8 1`] = `
+{
+  "_cmd": "wa b 9, de p 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, de p 9 1`] = `
+{
+  "_cmd": "wa b 9, de p 9",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de p 10 1`] = `
+{
+  "_cmd": "wa b 9, de p 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, de p 11 1`] = `
+{
+  "_cmd": "wa b 9, de p 11",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de p 12 1`] = `
+{
+  "_cmd": "wa b 9, de p 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de p 13 1`] = `
+{
+  "_cmd": "wa b 9, de p 13",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, de p 14 1`] = `
+{
+  "_cmd": "wa b 9, de p 14",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de p 15 1`] = `
+{
+  "_cmd": "wa b 9, de p 15",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de p v 1 1`] = `
+{
+  "_cmd": "wa b 9, de p v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, de p v 2 1`] = `
+{
+  "_cmd": "wa b 9, de p v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, de p v 3 1`] = `
+{
+  "_cmd": "wa b 9, de p v 3",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, de p v 4 1`] = `
+{
+  "_cmd": "wa b 9, de p v 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de p v 5 1`] = `
+{
+  "_cmd": "wa b 9, de p v 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, de p v 6 1`] = `
+{
+  "_cmd": "wa b 9, de p v 6",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, de p v 7 1`] = `
+{
+  "_cmd": "wa b 9, de p v 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de p v 8 1`] = `
+{
+  "_cmd": "wa b 9, de p v 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, de p v 9 1`] = `
+{
+  "_cmd": "wa b 9, de p v 9",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, de p v 10 1`] = `
+{
+  "_cmd": "wa b 9, de p v 10",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de p v 11 1`] = `
+{
+  "_cmd": "wa b 9, de p v 11",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de p v 12 1`] = `
+{
+  "_cmd": "wa b 9, de p v 12",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, de p v 13 1`] = `
+{
+  "_cmd": "wa b 9, de p v 13",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de p v 14 1`] = `
+{
+  "_cmd": "wa b 9, de p v 14",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, de p v 15 1`] = `
+{
+  "_cmd": "wa b 9, de p v 15",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de p v 16 1`] = `
+{
+  "_cmd": "wa b 9, de p v 16",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, de p v 17 1`] = `
+{
+  "_cmd": "wa b 9, de p v 17",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 9, de p v 18 1`] = `
+{
+  "_cmd": "wa b 9, de p v 18",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 9, de p v 19 1`] = `
+{
+  "_cmd": "wa b 9, de p v 19",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, de p v 20 1`] = `
+{
+  "_cmd": "wa b 9, de p v 20",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 9, de v 1 1`] = `
+{
+  "_cmd": "wa b 9, de v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, de v 2 1`] = `
+{
+  "_cmd": "wa b 9, de v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, de v 3 1`] = `
+{
+  "_cmd": "wa b 9, de v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, de v 4 1`] = `
+{
+  "_cmd": "wa b 9, de v 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de v 5 1`] = `
+{
+  "_cmd": "wa b 9, de v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, de v 6 1`] = `
+{
+  "_cmd": "wa b 9, de v 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, de v 7 1`] = `
+{
+  "_cmd": "wa b 9, de v 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de v 8 1`] = `
+{
+  "_cmd": "wa b 9, de v 8",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, de v 9 1`] = `
+{
+  "_cmd": "wa b 9, de v 9",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de v 10 1`] = `
+{
+  "_cmd": "wa b 9, de v 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, de v 11 1`] = `
+{
+  "_cmd": "wa b 9, de v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, de v 12 1`] = `
+{
+  "_cmd": "wa b 9, de v 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de v 13 1`] = `
+{
+  "_cmd": "wa b 9, de v 13",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, de v 14 1`] = `
+{
+  "_cmd": "wa b 9, de v 14",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de v 15 1`] = `
+{
+  "_cmd": "wa b 9, de v 15",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de v 16 1`] = `
+{
+  "_cmd": "wa b 9, de v 16",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 9, de v 17 1`] = `
+{
+  "_cmd": "wa b 9, de v 17",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 9, de v 18 1`] = `
+{
+  "_cmd": "wa b 9, de v 18",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, de v 19 1`] = `
+{
+  "_cmd": "wa b 9, de v 19",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 9, de v 20 1`] = `
+{
+  "_cmd": "wa b 9, de v 20",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 9, de w 1 1`] = `
+{
+  "_cmd": "wa b 9, de w 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, de w 2 1`] = `
+{
+  "_cmd": "wa b 9, de w 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de w 3 1`] = `
+{
+  "_cmd": "wa b 9, de w 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, de w 4 1`] = `
+{
+  "_cmd": "wa b 9, de w 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de w 5 1`] = `
+{
+  "_cmd": "wa b 9, de w 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, de w 6 1`] = `
+{
+  "_cmd": "wa b 9, de w 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de w 7 1`] = `
+{
+  "_cmd": "wa b 9, de w 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de w 8 1`] = `
+{
+  "_cmd": "wa b 9, de w 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, de w 9 1`] = `
+{
+  "_cmd": "wa b 9, de w 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de w 10 1`] = `
+{
+  "_cmd": "wa b 9, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de w 11 1`] = `
+{
+  "_cmd": "wa b 9, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de w 12 1`] = `
+{
+  "_cmd": "wa b 9, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, de w 13 1`] = `
+{
+  "_cmd": "wa b 9, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 9, de w 14 1`] = `
+{
+  "_cmd": "wa b 9, de w 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 9, de w 15 1`] = `
+{
+  "_cmd": "wa b 9, de w 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, de w v 1 1`] = `
+{
+  "_cmd": "wa b 9, de w v 1",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, de w v 2 1`] = `
+{
+  "_cmd": "wa b 9, de w v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, de w v 3 1`] = `
+{
+  "_cmd": "wa b 9, de w v 3",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, de w v 4 1`] = `
+{
+  "_cmd": "wa b 9, de w v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, de w v 5 1`] = `
+{
+  "_cmd": "wa b 9, de w v 5",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, de w v 6 1`] = `
+{
+  "_cmd": "wa b 9, de w v 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, de w v 7 1`] = `
+{
+  "_cmd": "wa b 9, de w v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, de w v 8 1`] = `
+{
+  "_cmd": "wa b 9, de w v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, de w v 9 1`] = `
+{
+  "_cmd": "wa b 9, de w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, de w v 10 1`] = `
+{
+  "_cmd": "wa b 9, de w v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, de w v 11 1`] = `
+{
+  "_cmd": "wa b 9, de w v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, de w v 12 1`] = `
+{
+  "_cmd": "wa b 9, de w v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, de w v 13 1`] = `
+{
+  "_cmd": "wa b 9, de w v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, de w v 14 1`] = `
+{
+  "_cmd": "wa b 9, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 9, de w v 15 1`] = `
+{
+  "_cmd": "wa b 9, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, de w v 16 1`] = `
+{
+  "_cmd": "wa b 9, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 9, de w v 17 1`] = `
+{
+  "_cmd": "wa b 9, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 9, de w v 18 1`] = `
+{
+  "_cmd": "wa b 9, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 9, de w v 19 1`] = `
+{
+  "_cmd": "wa b 9, de w v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 9, de w v 20 1`] = `
+{
+  "_cmd": "wa b 9, de w v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b 10, de d 1 1`] = `
+{
+  "_cmd": "wa b 10, de d 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 10, de d 2 1`] = `
+{
+  "_cmd": "wa b 10, de d 2",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, de d 3 1`] = `
+{
+  "_cmd": "wa b 10, de d 3",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, de d 4 1`] = `
+{
+  "_cmd": "wa b 10, de d 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de d 5 1`] = `
+{
+  "_cmd": "wa b 10, de d 5",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, de d 6 1`] = `
+{
+  "_cmd": "wa b 10, de d 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, de d 7 1`] = `
+{
+  "_cmd": "wa b 10, de d 7",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, de d 8 1`] = `
+{
+  "_cmd": "wa b 10, de d 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, de d 9 1`] = `
+{
+  "_cmd": "wa b 10, de d 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de d 10 1`] = `
+{
+  "_cmd": "wa b 10, de d 10",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de d 11 1`] = `
+{
+  "_cmd": "wa b 10, de d 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, de d 12 1`] = `
+{
+  "_cmd": "wa b 10, de d 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de d 13 1`] = `
+{
+  "_cmd": "wa b 10, de d 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de d 14 1`] = `
+{
+  "_cmd": "wa b 10, de d 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de d 15 1`] = `
+{
+  "_cmd": "wa b 10, de d 15",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, de d v 1 1`] = `
+{
+  "_cmd": "wa b 10, de d v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 10, de d v 2 1`] = `
+{
+  "_cmd": "wa b 10, de d v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de d v 3 1`] = `
+{
+  "_cmd": "wa b 10, de d v 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, de d v 4 1`] = `
+{
+  "_cmd": "wa b 10, de d v 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de d v 5 1`] = `
+{
+  "_cmd": "wa b 10, de d v 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, de d v 6 1`] = `
+{
+  "_cmd": "wa b 10, de d v 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, de d v 7 1`] = `
+{
+  "_cmd": "wa b 10, de d v 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, de d v 8 1`] = `
+{
+  "_cmd": "wa b 10, de d v 8",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, de d v 9 1`] = `
+{
+  "_cmd": "wa b 10, de d v 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, de d v 10 1`] = `
+{
+  "_cmd": "wa b 10, de d v 10",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de d v 11 1`] = `
+{
+  "_cmd": "wa b 10, de d v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de d v 12 1`] = `
+{
+  "_cmd": "wa b 10, de d v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de d v 13 1`] = `
+{
+  "_cmd": "wa b 10, de d v 13",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, de d v 14 1`] = `
+{
+  "_cmd": "wa b 10, de d v 14",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de d v 15 1`] = `
+{
+  "_cmd": "wa b 10, de d v 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de d v 16 1`] = `
+{
+  "_cmd": "wa b 10, de d v 16",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, de d v 17 1`] = `
+{
+  "_cmd": "wa b 10, de d v 17",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, de d v 18 1`] = `
+{
+  "_cmd": "wa b 10, de d v 18",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 10, de d v 19 1`] = `
+{
+  "_cmd": "wa b 10, de d v 19",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 10, de d v 20 1`] = `
+{
+  "_cmd": "wa b 10, de d v 20",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 10, de p 1 1`] = `
+{
+  "_cmd": "wa b 10, de p 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, de p 2 1`] = `
+{
+  "_cmd": "wa b 10, de p 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de p 3 1`] = `
+{
+  "_cmd": "wa b 10, de p 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, de p 4 1`] = `
+{
+  "_cmd": "wa b 10, de p 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, de p 5 1`] = `
+{
+  "_cmd": "wa b 10, de p 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de p 6 1`] = `
+{
+  "_cmd": "wa b 10, de p 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, de p 7 1`] = `
+{
+  "_cmd": "wa b 10, de p 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, de p 8 1`] = `
+{
+  "_cmd": "wa b 10, de p 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, de p 9 1`] = `
+{
+  "_cmd": "wa b 10, de p 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, de p 10 1`] = `
+{
+  "_cmd": "wa b 10, de p 10",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, de p 11 1`] = `
+{
+  "_cmd": "wa b 10, de p 11",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de p 12 1`] = `
+{
+  "_cmd": "wa b 10, de p 12",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de p 13 1`] = `
+{
+  "_cmd": "wa b 10, de p 13",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, de p 14 1`] = `
+{
+  "_cmd": "wa b 10, de p 14",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, de p 15 1`] = `
+{
+  "_cmd": "wa b 10, de p 15",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de p v 1 1`] = `
+{
+  "_cmd": "wa b 10, de p v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, de p v 2 1`] = `
+{
+  "_cmd": "wa b 10, de p v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de p v 3 1`] = `
+{
+  "_cmd": "wa b 10, de p v 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, de p v 4 1`] = `
+{
+  "_cmd": "wa b 10, de p v 4",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, de p v 5 1`] = `
+{
+  "_cmd": "wa b 10, de p v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de p v 6 1`] = `
+{
+  "_cmd": "wa b 10, de p v 6",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, de p v 7 1`] = `
+{
+  "_cmd": "wa b 10, de p v 7",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, de p v 8 1`] = `
+{
+  "_cmd": "wa b 10, de p v 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, de p v 9 1`] = `
+{
+  "_cmd": "wa b 10, de p v 9",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, de p v 10 1`] = `
+{
+  "_cmd": "wa b 10, de p v 10",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, de p v 11 1`] = `
+{
+  "_cmd": "wa b 10, de p v 11",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, de p v 12 1`] = `
+{
+  "_cmd": "wa b 10, de p v 12",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de p v 13 1`] = `
+{
+  "_cmd": "wa b 10, de p v 13",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, de p v 14 1`] = `
+{
+  "_cmd": "wa b 10, de p v 14",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de p v 15 1`] = `
+{
+  "_cmd": "wa b 10, de p v 15",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, de p v 16 1`] = `
+{
+  "_cmd": "wa b 10, de p v 16",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de p v 17 1`] = `
+{
+  "_cmd": "wa b 10, de p v 17",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de p v 18 1`] = `
+{
+  "_cmd": "wa b 10, de p v 18",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 10, de p v 19 1`] = `
+{
+  "_cmd": "wa b 10, de p v 19",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, de p v 20 1`] = `
+{
+  "_cmd": "wa b 10, de p v 20",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 10, de v 1 1`] = `
+{
+  "_cmd": "wa b 10, de v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, de v 2 1`] = `
+{
+  "_cmd": "wa b 10, de v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de v 3 1`] = `
+{
+  "_cmd": "wa b 10, de v 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, de v 4 1`] = `
+{
+  "_cmd": "wa b 10, de v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, de v 5 1`] = `
+{
+  "_cmd": "wa b 10, de v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de v 6 1`] = `
+{
+  "_cmd": "wa b 10, de v 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, de v 7 1`] = `
+{
+  "_cmd": "wa b 10, de v 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, de v 8 1`] = `
+{
+  "_cmd": "wa b 10, de v 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, de v 9 1`] = `
+{
+  "_cmd": "wa b 10, de v 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, de v 10 1`] = `
+{
+  "_cmd": "wa b 10, de v 10",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, de v 11 1`] = `
+{
+  "_cmd": "wa b 10, de v 11",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de v 12 1`] = `
+{
+  "_cmd": "wa b 10, de v 12",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de v 13 1`] = `
+{
+  "_cmd": "wa b 10, de v 13",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de v 14 1`] = `
+{
+  "_cmd": "wa b 10, de v 14",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, de v 15 1`] = `
+{
+  "_cmd": "wa b 10, de v 15",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de v 16 1`] = `
+{
+  "_cmd": "wa b 10, de v 16",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de v 17 1`] = `
+{
+  "_cmd": "wa b 10, de v 17",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, de v 18 1`] = `
+{
+  "_cmd": "wa b 10, de v 18",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, de v 19 1`] = `
+{
+  "_cmd": "wa b 10, de v 19",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 10, de v 20 1`] = `
+{
+  "_cmd": "wa b 10, de v 20",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 10, de w 1 1`] = `
+{
+  "_cmd": "wa b 10, de w 1",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de w 2 1`] = `
+{
+  "_cmd": "wa b 10, de w 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, de w 3 1`] = `
+{
+  "_cmd": "wa b 10, de w 3",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, de w 4 1`] = `
+{
+  "_cmd": "wa b 10, de w 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, de w 5 1`] = `
+{
+  "_cmd": "wa b 10, de w 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, de w 6 1`] = `
+{
+  "_cmd": "wa b 10, de w 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, de w 7 1`] = `
+{
+  "_cmd": "wa b 10, de w 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de w 8 1`] = `
+{
+  "_cmd": "wa b 10, de w 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de w 9 1`] = `
+{
+  "_cmd": "wa b 10, de w 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, de w 10 1`] = `
+{
+  "_cmd": "wa b 10, de w 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de w 11 1`] = `
+{
+  "_cmd": "wa b 10, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de w 12 1`] = `
+{
+  "_cmd": "wa b 10, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de w 13 1`] = `
+{
+  "_cmd": "wa b 10, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, de w 14 1`] = `
+{
+  "_cmd": "wa b 10, de w 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 10, de w 15 1`] = `
+{
+  "_cmd": "wa b 10, de w 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, de w v 1 1`] = `
+{
+  "_cmd": "wa b 10, de w v 1",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, de w v 2 1`] = `
+{
+  "_cmd": "wa b 10, de w v 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, de w v 3 1`] = `
+{
+  "_cmd": "wa b 10, de w v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, de w v 4 1`] = `
+{
+  "_cmd": "wa b 10, de w v 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, de w v 5 1`] = `
+{
+  "_cmd": "wa b 10, de w v 5",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, de w v 6 1`] = `
+{
+  "_cmd": "wa b 10, de w v 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, de w v 7 1`] = `
+{
+  "_cmd": "wa b 10, de w v 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, de w v 8 1`] = `
+{
+  "_cmd": "wa b 10, de w v 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, de w v 9 1`] = `
+{
+  "_cmd": "wa b 10, de w v 9",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, de w v 10 1`] = `
+{
+  "_cmd": "wa b 10, de w v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, de w v 11 1`] = `
+{
+  "_cmd": "wa b 10, de w v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, de w v 12 1`] = `
+{
+  "_cmd": "wa b 10, de w v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, de w v 13 1`] = `
+{
+  "_cmd": "wa b 10, de w v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, de w v 14 1`] = `
+{
+  "_cmd": "wa b 10, de w v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, de w v 15 1`] = `
+{
+  "_cmd": "wa b 10, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, de w v 16 1`] = `
+{
+  "_cmd": "wa b 10, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 10, de w v 17 1`] = `
+{
+  "_cmd": "wa b 10, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 10, de w v 18 1`] = `
+{
+  "_cmd": "wa b 10, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b 10, de w v 19 1`] = `
+{
+  "_cmd": "wa b 10, de w v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b 10, de w v 20 1`] = `
+{
+  "_cmd": "wa b 10, de w v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 1, de d 1 1`] = `
+{
+  "_cmd": "wa b v 1, de d 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 1, de d 2 1`] = `
+{
+  "_cmd": "wa b v 1, de d 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, de d 3 1`] = `
+{
+  "_cmd": "wa b v 1, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de d 4 1`] = `
+{
+  "_cmd": "wa b v 1, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, de d 5 1`] = `
+{
+  "_cmd": "wa b v 1, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de d 6 1`] = `
+{
+  "_cmd": "wa b v 1, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de d 7 1`] = `
+{
+  "_cmd": "wa b v 1, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, de d 8 1`] = `
+{
+  "_cmd": "wa b v 1, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de d 9 1`] = `
+{
+  "_cmd": "wa b v 1, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de d 10 1`] = `
+{
+  "_cmd": "wa b v 1, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de d 11 1`] = `
+{
+  "_cmd": "wa b v 1, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de d 12 1`] = `
+{
+  "_cmd": "wa b v 1, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de d 13 1`] = `
+{
+  "_cmd": "wa b v 1, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de d 14 1`] = `
+{
+  "_cmd": "wa b v 1, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de d 15 1`] = `
+{
+  "_cmd": "wa b v 1, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 1, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 1, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 1, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 1, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 1, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 1, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 1, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b v 1, de p 1 1`] = `
+{
+  "_cmd": "wa b v 1, de p 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 1, de p 2 1`] = `
+{
+  "_cmd": "wa b v 1, de p 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 1, de p 3 1`] = `
+{
+  "_cmd": "wa b v 1, de p 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, de p 4 1`] = `
+{
+  "_cmd": "wa b v 1, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de p 5 1`] = `
+{
+  "_cmd": "wa b v 1, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, de p 6 1`] = `
+{
+  "_cmd": "wa b v 1, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de p 7 1`] = `
+{
+  "_cmd": "wa b v 1, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de p 8 1`] = `
+{
+  "_cmd": "wa b v 1, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de p 9 1`] = `
+{
+  "_cmd": "wa b v 1, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de p 10 1`] = `
+{
+  "_cmd": "wa b v 1, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de p 11 1`] = `
+{
+  "_cmd": "wa b v 1, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de p 12 1`] = `
+{
+  "_cmd": "wa b v 1, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de p 13 1`] = `
+{
+  "_cmd": "wa b v 1, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de p 14 1`] = `
+{
+  "_cmd": "wa b v 1, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de p 15 1`] = `
+{
+  "_cmd": "wa b v 1, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 1, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 1, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 1, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 1, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 1, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 1, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 1, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 1, de v 1 1`] = `
+{
+  "_cmd": "wa b v 1, de v 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 1, de v 2 1`] = `
+{
+  "_cmd": "wa b v 1, de v 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 1, de v 3 1`] = `
+{
+  "_cmd": "wa b v 1, de v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, de v 4 1`] = `
+{
+  "_cmd": "wa b v 1, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, de v 5 1`] = `
+{
+  "_cmd": "wa b v 1, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, de v 6 1`] = `
+{
+  "_cmd": "wa b v 1, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de v 7 1`] = `
+{
+  "_cmd": "wa b v 1, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de v 8 1`] = `
+{
+  "_cmd": "wa b v 1, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de v 9 1`] = `
+{
+  "_cmd": "wa b v 1, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de v 10 1`] = `
+{
+  "_cmd": "wa b v 1, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de v 11 1`] = `
+{
+  "_cmd": "wa b v 1, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de v 12 1`] = `
+{
+  "_cmd": "wa b v 1, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de v 13 1`] = `
+{
+  "_cmd": "wa b v 1, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de v 14 1`] = `
+{
+  "_cmd": "wa b v 1, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de v 15 1`] = `
+{
+  "_cmd": "wa b v 1, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de v 16 1`] = `
+{
+  "_cmd": "wa b v 1, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 1, de v 17 1`] = `
+{
+  "_cmd": "wa b v 1, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 1, de v 18 1`] = `
+{
+  "_cmd": "wa b v 1, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 1, de v 19 1`] = `
+{
+  "_cmd": "wa b v 1, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 1, de v 20 1`] = `
+{
+  "_cmd": "wa b v 1, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 1, de w 1 1`] = `
+{
+  "_cmd": "wa b v 1, de w 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, de w 2 1`] = `
+{
+  "_cmd": "wa b v 1, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de w 3 1`] = `
+{
+  "_cmd": "wa b v 1, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, de w 4 1`] = `
+{
+  "_cmd": "wa b v 1, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, de w 5 1`] = `
+{
+  "_cmd": "wa b v 1, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, de w 6 1`] = `
+{
+  "_cmd": "wa b v 1, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, de w 7 1`] = `
+{
+  "_cmd": "wa b v 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de w 8 1`] = `
+{
+  "_cmd": "wa b v 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de w 9 1`] = `
+{
+  "_cmd": "wa b v 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de w 10 1`] = `
+{
+  "_cmd": "wa b v 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de w 11 1`] = `
+{
+  "_cmd": "wa b v 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de w 12 1`] = `
+{
+  "_cmd": "wa b v 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de w 13 1`] = `
+{
+  "_cmd": "wa b v 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de w 14 1`] = `
+{
+  "_cmd": "wa b v 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de w 15 1`] = `
+{
+  "_cmd": "wa b v 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 1, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 1, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 1, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 1, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 1, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 1, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b v 2, de d 1 1`] = `
+{
+  "_cmd": "wa b v 2, de d 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 2, de d 2 1`] = `
+{
+  "_cmd": "wa b v 2, de d 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, de d 3 1`] = `
+{
+  "_cmd": "wa b v 2, de d 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, de d 4 1`] = `
+{
+  "_cmd": "wa b v 2, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, de d 5 1`] = `
+{
+  "_cmd": "wa b v 2, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de d 6 1`] = `
+{
+  "_cmd": "wa b v 2, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de d 7 1`] = `
+{
+  "_cmd": "wa b v 2, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de d 8 1`] = `
+{
+  "_cmd": "wa b v 2, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de d 9 1`] = `
+{
+  "_cmd": "wa b v 2, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, de d 10 1`] = `
+{
+  "_cmd": "wa b v 2, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de d 11 1`] = `
+{
+  "_cmd": "wa b v 2, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de d 12 1`] = `
+{
+  "_cmd": "wa b v 2, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de d 13 1`] = `
+{
+  "_cmd": "wa b v 2, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de d 14 1`] = `
+{
+  "_cmd": "wa b v 2, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de d 15 1`] = `
+{
+  "_cmd": "wa b v 2, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 1",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 2, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 2, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 2, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 2, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 2, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 2, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 2, de p 1 1`] = `
+{
+  "_cmd": "wa b v 2, de p 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 2, de p 2 1`] = `
+{
+  "_cmd": "wa b v 2, de p 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 2, de p 3 1`] = `
+{
+  "_cmd": "wa b v 2, de p 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, de p 4 1`] = `
+{
+  "_cmd": "wa b v 2, de p 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, de p 5 1`] = `
+{
+  "_cmd": "wa b v 2, de p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, de p 6 1`] = `
+{
+  "_cmd": "wa b v 2, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de p 7 1`] = `
+{
+  "_cmd": "wa b v 2, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de p 8 1`] = `
+{
+  "_cmd": "wa b v 2, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de p 9 1`] = `
+{
+  "_cmd": "wa b v 2, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de p 10 1`] = `
+{
+  "_cmd": "wa b v 2, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, de p 11 1`] = `
+{
+  "_cmd": "wa b v 2, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de p 12 1`] = `
+{
+  "_cmd": "wa b v 2, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de p 13 1`] = `
+{
+  "_cmd": "wa b v 2, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de p 14 1`] = `
+{
+  "_cmd": "wa b v 2, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de p 15 1`] = `
+{
+  "_cmd": "wa b v 2, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 2, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 2, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 2, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 2, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 2, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 2, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 2, de v 1 1`] = `
+{
+  "_cmd": "wa b v 2, de v 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 2, de v 2 1`] = `
+{
+  "_cmd": "wa b v 2, de v 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 2, de v 3 1`] = `
+{
+  "_cmd": "wa b v 2, de v 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, de v 4 1`] = `
+{
+  "_cmd": "wa b v 2, de v 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, de v 5 1`] = `
+{
+  "_cmd": "wa b v 2, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, de v 6 1`] = `
+{
+  "_cmd": "wa b v 2, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de v 7 1`] = `
+{
+  "_cmd": "wa b v 2, de v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de v 8 1`] = `
+{
+  "_cmd": "wa b v 2, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, de v 9 1`] = `
+{
+  "_cmd": "wa b v 2, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de v 10 1`] = `
+{
+  "_cmd": "wa b v 2, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, de v 11 1`] = `
+{
+  "_cmd": "wa b v 2, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de v 12 1`] = `
+{
+  "_cmd": "wa b v 2, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de v 13 1`] = `
+{
+  "_cmd": "wa b v 2, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de v 14 1`] = `
+{
+  "_cmd": "wa b v 2, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de v 15 1`] = `
+{
+  "_cmd": "wa b v 2, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de v 16 1`] = `
+{
+  "_cmd": "wa b v 2, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, de v 17 1`] = `
+{
+  "_cmd": "wa b v 2, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 2, de v 18 1`] = `
+{
+  "_cmd": "wa b v 2, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 2, de v 19 1`] = `
+{
+  "_cmd": "wa b v 2, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 2, de v 20 1`] = `
+{
+  "_cmd": "wa b v 2, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 2, de w 1 1`] = `
+{
+  "_cmd": "wa b v 2, de w 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, de w 2 1`] = `
+{
+  "_cmd": "wa b v 2, de w 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, de w 3 1`] = `
+{
+  "_cmd": "wa b v 2, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, de w 4 1`] = `
+{
+  "_cmd": "wa b v 2, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de w 5 1`] = `
+{
+  "_cmd": "wa b v 2, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de w 6 1`] = `
+{
+  "_cmd": "wa b v 2, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de w 7 1`] = `
+{
+  "_cmd": "wa b v 2, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, de w 8 1`] = `
+{
+  "_cmd": "wa b v 2, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de w 9 1`] = `
+{
+  "_cmd": "wa b v 2, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de w 10 1`] = `
+{
+  "_cmd": "wa b v 2, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de w 11 1`] = `
+{
+  "_cmd": "wa b v 2, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, de w 12 1`] = `
+{
+  "_cmd": "wa b v 2, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de w 13 1`] = `
+{
+  "_cmd": "wa b v 2, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de w 14 1`] = `
+{
+  "_cmd": "wa b v 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de w 15 1`] = `
+{
+  "_cmd": "wa b v 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 2, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 2, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 2, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 2, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b v 3, de d 1 1`] = `
+{
+  "_cmd": "wa b v 3, de d 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 3, de d 2 1`] = `
+{
+  "_cmd": "wa b v 3, de d 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, de d 3 1`] = `
+{
+  "_cmd": "wa b v 3, de d 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, de d 4 1`] = `
+{
+  "_cmd": "wa b v 3, de d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, de d 5 1`] = `
+{
+  "_cmd": "wa b v 3, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de d 6 1`] = `
+{
+  "_cmd": "wa b v 3, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, de d 7 1`] = `
+{
+  "_cmd": "wa b v 3, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de d 8 1`] = `
+{
+  "_cmd": "wa b v 3, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de d 9 1`] = `
+{
+  "_cmd": "wa b v 3, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de d 10 1`] = `
+{
+  "_cmd": "wa b v 3, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de d 11 1`] = `
+{
+  "_cmd": "wa b v 3, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de d 12 1`] = `
+{
+  "_cmd": "wa b v 3, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de d 13 1`] = `
+{
+  "_cmd": "wa b v 3, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de d 14 1`] = `
+{
+  "_cmd": "wa b v 3, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, de d 15 1`] = `
+{
+  "_cmd": "wa b v 3, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 3, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 1",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 3, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 3, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 3, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 3, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 3, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 3, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 3, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 3, de p 1 1`] = `
+{
+  "_cmd": "wa b v 3, de p 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, de p 2 1`] = `
+{
+  "_cmd": "wa b v 3, de p 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 3, de p 3 1`] = `
+{
+  "_cmd": "wa b v 3, de p 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, de p 4 1`] = `
+{
+  "_cmd": "wa b v 3, de p 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, de p 5 1`] = `
+{
+  "_cmd": "wa b v 3, de p 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, de p 6 1`] = `
+{
+  "_cmd": "wa b v 3, de p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de p 7 1`] = `
+{
+  "_cmd": "wa b v 3, de p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, de p 8 1`] = `
+{
+  "_cmd": "wa b v 3, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de p 9 1`] = `
+{
+  "_cmd": "wa b v 3, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de p 10 1`] = `
+{
+  "_cmd": "wa b v 3, de p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de p 11 1`] = `
+{
+  "_cmd": "wa b v 3, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de p 12 1`] = `
+{
+  "_cmd": "wa b v 3, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, de p 13 1`] = `
+{
+  "_cmd": "wa b v 3, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de p 14 1`] = `
+{
+  "_cmd": "wa b v 3, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de p 15 1`] = `
+{
+  "_cmd": "wa b v 3, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 3, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 4",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 3, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 3, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 3, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 3, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 3, de v 1 1`] = `
+{
+  "_cmd": "wa b v 3, de v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, de v 2 1`] = `
+{
+  "_cmd": "wa b v 3, de v 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 3, de v 3 1`] = `
+{
+  "_cmd": "wa b v 3, de v 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, de v 4 1`] = `
+{
+  "_cmd": "wa b v 3, de v 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, de v 5 1`] = `
+{
+  "_cmd": "wa b v 3, de v 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, de v 6 1`] = `
+{
+  "_cmd": "wa b v 3, de v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de v 7 1`] = `
+{
+  "_cmd": "wa b v 3, de v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, de v 8 1`] = `
+{
+  "_cmd": "wa b v 3, de v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de v 9 1`] = `
+{
+  "_cmd": "wa b v 3, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de v 10 1`] = `
+{
+  "_cmd": "wa b v 3, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de v 11 1`] = `
+{
+  "_cmd": "wa b v 3, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de v 12 1`] = `
+{
+  "_cmd": "wa b v 3, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de v 13 1`] = `
+{
+  "_cmd": "wa b v 3, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de v 14 1`] = `
+{
+  "_cmd": "wa b v 3, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de v 15 1`] = `
+{
+  "_cmd": "wa b v 3, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, de v 16 1`] = `
+{
+  "_cmd": "wa b v 3, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 3, de v 17 1`] = `
+{
+  "_cmd": "wa b v 3, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, de v 18 1`] = `
+{
+  "_cmd": "wa b v 3, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 3, de v 19 1`] = `
+{
+  "_cmd": "wa b v 3, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 3, de v 20 1`] = `
+{
+  "_cmd": "wa b v 3, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 3, de w 1 1`] = `
+{
+  "_cmd": "wa b v 3, de w 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, de w 2 1`] = `
+{
+  "_cmd": "wa b v 3, de w 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, de w 3 1`] = `
+{
+  "_cmd": "wa b v 3, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, de w 4 1`] = `
+{
+  "_cmd": "wa b v 3, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de w 5 1`] = `
+{
+  "_cmd": "wa b v 3, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, de w 6 1`] = `
+{
+  "_cmd": "wa b v 3, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de w 7 1`] = `
+{
+  "_cmd": "wa b v 3, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de w 8 1`] = `
+{
+  "_cmd": "wa b v 3, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de w 9 1`] = `
+{
+  "_cmd": "wa b v 3, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de w 10 1`] = `
+{
+  "_cmd": "wa b v 3, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, de w 11 1`] = `
+{
+  "_cmd": "wa b v 3, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de w 12 1`] = `
+{
+  "_cmd": "wa b v 3, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de w 13 1`] = `
+{
+  "_cmd": "wa b v 3, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de w 14 1`] = `
+{
+  "_cmd": "wa b v 3, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 3, de w 15 1`] = `
+{
+  "_cmd": "wa b v 3, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 3, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 3, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 3, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 3, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 3, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa b v 4, de d 1 1`] = `
+{
+  "_cmd": "wa b v 4, de d 1",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 4, de d 2 1`] = `
+{
+  "_cmd": "wa b v 4, de d 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, de d 3 1`] = `
+{
+  "_cmd": "wa b v 4, de d 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, de d 4 1`] = `
+{
+  "_cmd": "wa b v 4, de d 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, de d 5 1`] = `
+{
+  "_cmd": "wa b v 4, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de d 6 1`] = `
+{
+  "_cmd": "wa b v 4, de d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, de d 7 1`] = `
+{
+  "_cmd": "wa b v 4, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de d 8 1`] = `
+{
+  "_cmd": "wa b v 4, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, de d 9 1`] = `
+{
+  "_cmd": "wa b v 4, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de d 10 1`] = `
+{
+  "_cmd": "wa b v 4, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de d 11 1`] = `
+{
+  "_cmd": "wa b v 4, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de d 12 1`] = `
+{
+  "_cmd": "wa b v 4, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de d 13 1`] = `
+{
+  "_cmd": "wa b v 4, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de d 14 1`] = `
+{
+  "_cmd": "wa b v 4, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de d 15 1`] = `
+{
+  "_cmd": "wa b v 4, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 1",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 4, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 2",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 4, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 4, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 4, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 4, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 4, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 4, de p 1 1`] = `
+{
+  "_cmd": "wa b v 4, de p 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 4, de p 2 1`] = `
+{
+  "_cmd": "wa b v 4, de p 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 4, de p 3 1`] = `
+{
+  "_cmd": "wa b v 4, de p 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, de p 4 1`] = `
+{
+  "_cmd": "wa b v 4, de p 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, de p 5 1`] = `
+{
+  "_cmd": "wa b v 4, de p 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, de p 6 1`] = `
+{
+  "_cmd": "wa b v 4, de p 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, de p 7 1`] = `
+{
+  "_cmd": "wa b v 4, de p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de p 8 1`] = `
+{
+  "_cmd": "wa b v 4, de p 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de p 9 1`] = `
+{
+  "_cmd": "wa b v 4, de p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, de p 10 1`] = `
+{
+  "_cmd": "wa b v 4, de p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, de p 11 1`] = `
+{
+  "_cmd": "wa b v 4, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de p 12 1`] = `
+{
+  "_cmd": "wa b v 4, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de p 13 1`] = `
+{
+  "_cmd": "wa b v 4, de p 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de p 14 1`] = `
+{
+  "_cmd": "wa b v 4, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de p 15 1`] = `
+{
+  "_cmd": "wa b v 4, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 4, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 4, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 4, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 5",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 4, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 4, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 4, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 4, de v 1 1`] = `
+{
+  "_cmd": "wa b v 4, de v 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 4, de v 2 1`] = `
+{
+  "_cmd": "wa b v 4, de v 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 4, de v 3 1`] = `
+{
+  "_cmd": "wa b v 4, de v 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, de v 4 1`] = `
+{
+  "_cmd": "wa b v 4, de v 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, de v 5 1`] = `
+{
+  "_cmd": "wa b v 4, de v 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, de v 6 1`] = `
+{
+  "_cmd": "wa b v 4, de v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, de v 7 1`] = `
+{
+  "_cmd": "wa b v 4, de v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, de v 8 1`] = `
+{
+  "_cmd": "wa b v 4, de v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de v 9 1`] = `
+{
+  "_cmd": "wa b v 4, de v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, de v 10 1`] = `
+{
+  "_cmd": "wa b v 4, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de v 11 1`] = `
+{
+  "_cmd": "wa b v 4, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de v 12 1`] = `
+{
+  "_cmd": "wa b v 4, de v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de v 13 1`] = `
+{
+  "_cmd": "wa b v 4, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de v 14 1`] = `
+{
+  "_cmd": "wa b v 4, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de v 15 1`] = `
+{
+  "_cmd": "wa b v 4, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de v 16 1`] = `
+{
+  "_cmd": "wa b v 4, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de v 17 1`] = `
+{
+  "_cmd": "wa b v 4, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 4, de v 18 1`] = `
+{
+  "_cmd": "wa b v 4, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 4, de v 19 1`] = `
+{
+  "_cmd": "wa b v 4, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 4, de v 20 1`] = `
+{
+  "_cmd": "wa b v 4, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 4, de w 1 1`] = `
+{
+  "_cmd": "wa b v 4, de w 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, de w 2 1`] = `
+{
+  "_cmd": "wa b v 4, de w 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, de w 3 1`] = `
+{
+  "_cmd": "wa b v 4, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, de w 4 1`] = `
+{
+  "_cmd": "wa b v 4, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de w 5 1`] = `
+{
+  "_cmd": "wa b v 4, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, de w 6 1`] = `
+{
+  "_cmd": "wa b v 4, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, de w 7 1`] = `
+{
+  "_cmd": "wa b v 4, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, de w 8 1`] = `
+{
+  "_cmd": "wa b v 4, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de w 9 1`] = `
+{
+  "_cmd": "wa b v 4, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de w 10 1`] = `
+{
+  "_cmd": "wa b v 4, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de w 11 1`] = `
+{
+  "_cmd": "wa b v 4, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de w 12 1`] = `
+{
+  "_cmd": "wa b v 4, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de w 13 1`] = `
+{
+  "_cmd": "wa b v 4, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de w 14 1`] = `
+{
+  "_cmd": "wa b v 4, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, de w 15 1`] = `
+{
+  "_cmd": "wa b v 4, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 4, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 4, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 4, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 4, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 4, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 5, de d 1 1`] = `
+{
+  "_cmd": "wa b v 5, de d 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 5, de d 2 1`] = `
+{
+  "_cmd": "wa b v 5, de d 2",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, de d 3 1`] = `
+{
+  "_cmd": "wa b v 5, de d 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, de d 4 1`] = `
+{
+  "_cmd": "wa b v 5, de d 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, de d 5 1`] = `
+{
+  "_cmd": "wa b v 5, de d 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, de d 6 1`] = `
+{
+  "_cmd": "wa b v 5, de d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de d 7 1`] = `
+{
+  "_cmd": "wa b v 5, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, de d 8 1`] = `
+{
+  "_cmd": "wa b v 5, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, de d 9 1`] = `
+{
+  "_cmd": "wa b v 5, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de d 10 1`] = `
+{
+  "_cmd": "wa b v 5, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de d 11 1`] = `
+{
+  "_cmd": "wa b v 5, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de d 12 1`] = `
+{
+  "_cmd": "wa b v 5, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, de d 13 1`] = `
+{
+  "_cmd": "wa b v 5, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de d 14 1`] = `
+{
+  "_cmd": "wa b v 5, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de d 15 1`] = `
+{
+  "_cmd": "wa b v 5, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 1",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 5, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 2",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 5, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 5, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 5, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 5, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 5, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 5, de p 1 1`] = `
+{
+  "_cmd": "wa b v 5, de p 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, de p 2 1`] = `
+{
+  "_cmd": "wa b v 5, de p 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, de p 3 1`] = `
+{
+  "_cmd": "wa b v 5, de p 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 5, de p 4 1`] = `
+{
+  "_cmd": "wa b v 5, de p 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, de p 5 1`] = `
+{
+  "_cmd": "wa b v 5, de p 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, de p 6 1`] = `
+{
+  "_cmd": "wa b v 5, de p 6",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, de p 7 1`] = `
+{
+  "_cmd": "wa b v 5, de p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de p 8 1`] = `
+{
+  "_cmd": "wa b v 5, de p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, de p 9 1`] = `
+{
+  "_cmd": "wa b v 5, de p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, de p 10 1`] = `
+{
+  "_cmd": "wa b v 5, de p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de p 11 1`] = `
+{
+  "_cmd": "wa b v 5, de p 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, de p 12 1`] = `
+{
+  "_cmd": "wa b v 5, de p 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de p 13 1`] = `
+{
+  "_cmd": "wa b v 5, de p 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de p 14 1`] = `
+{
+  "_cmd": "wa b v 5, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de p 15 1`] = `
+{
+  "_cmd": "wa b v 5, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 5, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 6",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 5, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 5, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 5, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 5, de v 1 1`] = `
+{
+  "_cmd": "wa b v 5, de v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, de v 2 1`] = `
+{
+  "_cmd": "wa b v 5, de v 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, de v 3 1`] = `
+{
+  "_cmd": "wa b v 5, de v 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 5, de v 4 1`] = `
+{
+  "_cmd": "wa b v 5, de v 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, de v 5 1`] = `
+{
+  "_cmd": "wa b v 5, de v 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, de v 6 1`] = `
+{
+  "_cmd": "wa b v 5, de v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, de v 7 1`] = `
+{
+  "_cmd": "wa b v 5, de v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de v 8 1`] = `
+{
+  "_cmd": "wa b v 5, de v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, de v 9 1`] = `
+{
+  "_cmd": "wa b v 5, de v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, de v 10 1`] = `
+{
+  "_cmd": "wa b v 5, de v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de v 11 1`] = `
+{
+  "_cmd": "wa b v 5, de v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, de v 12 1`] = `
+{
+  "_cmd": "wa b v 5, de v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de v 13 1`] = `
+{
+  "_cmd": "wa b v 5, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, de v 14 1`] = `
+{
+  "_cmd": "wa b v 5, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de v 15 1`] = `
+{
+  "_cmd": "wa b v 5, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de v 16 1`] = `
+{
+  "_cmd": "wa b v 5, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de v 17 1`] = `
+{
+  "_cmd": "wa b v 5, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 5, de v 18 1`] = `
+{
+  "_cmd": "wa b v 5, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 5, de v 19 1`] = `
+{
+  "_cmd": "wa b v 5, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 5, de v 20 1`] = `
+{
+  "_cmd": "wa b v 5, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 5, de w 1 1`] = `
+{
+  "_cmd": "wa b v 5, de w 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, de w 2 1`] = `
+{
+  "_cmd": "wa b v 5, de w 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, de w 3 1`] = `
+{
+  "_cmd": "wa b v 5, de w 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, de w 4 1`] = `
+{
+  "_cmd": "wa b v 5, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, de w 5 1`] = `
+{
+  "_cmd": "wa b v 5, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, de w 6 1`] = `
+{
+  "_cmd": "wa b v 5, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, de w 7 1`] = `
+{
+  "_cmd": "wa b v 5, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de w 8 1`] = `
+{
+  "_cmd": "wa b v 5, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, de w 9 1`] = `
+{
+  "_cmd": "wa b v 5, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, de w 10 1`] = `
+{
+  "_cmd": "wa b v 5, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de w 11 1`] = `
+{
+  "_cmd": "wa b v 5, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, de w 12 1`] = `
+{
+  "_cmd": "wa b v 5, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de w 13 1`] = `
+{
+  "_cmd": "wa b v 5, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de w 14 1`] = `
+{
+  "_cmd": "wa b v 5, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de w 15 1`] = `
+{
+  "_cmd": "wa b v 5, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 5, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 5, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 5, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 5, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 5, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 5, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 5, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 6, de d 1 1`] = `
+{
+  "_cmd": "wa b v 6, de d 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 6, de d 2 1`] = `
+{
+  "_cmd": "wa b v 6, de d 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, de d 3 1`] = `
+{
+  "_cmd": "wa b v 6, de d 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, de d 4 1`] = `
+{
+  "_cmd": "wa b v 6, de d 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, de d 5 1`] = `
+{
+  "_cmd": "wa b v 6, de d 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, de d 6 1`] = `
+{
+  "_cmd": "wa b v 6, de d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, de d 7 1`] = `
+{
+  "_cmd": "wa b v 6, de d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de d 8 1`] = `
+{
+  "_cmd": "wa b v 6, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de d 9 1`] = `
+{
+  "_cmd": "wa b v 6, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, de d 10 1`] = `
+{
+  "_cmd": "wa b v 6, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de d 11 1`] = `
+{
+  "_cmd": "wa b v 6, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de d 12 1`] = `
+{
+  "_cmd": "wa b v 6, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de d 13 1`] = `
+{
+  "_cmd": "wa b v 6, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de d 14 1`] = `
+{
+  "_cmd": "wa b v 6, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de d 15 1`] = `
+{
+  "_cmd": "wa b v 6, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 6, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 2",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 3",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 6, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 6, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 6, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 6, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 6, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 6, de p 1 1`] = `
+{
+  "_cmd": "wa b v 6, de p 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, de p 2 1`] = `
+{
+  "_cmd": "wa b v 6, de p 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, de p 3 1`] = `
+{
+  "_cmd": "wa b v 6, de p 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, de p 4 1`] = `
+{
+  "_cmd": "wa b v 6, de p 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, de p 5 1`] = `
+{
+  "_cmd": "wa b v 6, de p 5",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, de p 6 1`] = `
+{
+  "_cmd": "wa b v 6, de p 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, de p 7 1`] = `
+{
+  "_cmd": "wa b v 6, de p 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, de p 8 1`] = `
+{
+  "_cmd": "wa b v 6, de p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de p 9 1`] = `
+{
+  "_cmd": "wa b v 6, de p 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, de p 10 1`] = `
+{
+  "_cmd": "wa b v 6, de p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de p 11 1`] = `
+{
+  "_cmd": "wa b v 6, de p 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de p 12 1`] = `
+{
+  "_cmd": "wa b v 6, de p 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de p 13 1`] = `
+{
+  "_cmd": "wa b v 6, de p 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, de p 14 1`] = `
+{
+  "_cmd": "wa b v 6, de p 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de p 15 1`] = `
+{
+  "_cmd": "wa b v 6, de p 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 6, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 5",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 6, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 6, de p v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 6, de v 1 1`] = `
+{
+  "_cmd": "wa b v 6, de v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, de v 2 1`] = `
+{
+  "_cmd": "wa b v 6, de v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, de v 3 1`] = `
+{
+  "_cmd": "wa b v 6, de v 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, de v 4 1`] = `
+{
+  "_cmd": "wa b v 6, de v 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, de v 5 1`] = `
+{
+  "_cmd": "wa b v 6, de v 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, de v 6 1`] = `
+{
+  "_cmd": "wa b v 6, de v 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, de v 7 1`] = `
+{
+  "_cmd": "wa b v 6, de v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, de v 8 1`] = `
+{
+  "_cmd": "wa b v 6, de v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de v 9 1`] = `
+{
+  "_cmd": "wa b v 6, de v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, de v 10 1`] = `
+{
+  "_cmd": "wa b v 6, de v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de v 11 1`] = `
+{
+  "_cmd": "wa b v 6, de v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de v 12 1`] = `
+{
+  "_cmd": "wa b v 6, de v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de v 13 1`] = `
+{
+  "_cmd": "wa b v 6, de v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, de v 14 1`] = `
+{
+  "_cmd": "wa b v 6, de v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de v 15 1`] = `
+{
+  "_cmd": "wa b v 6, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de v 16 1`] = `
+{
+  "_cmd": "wa b v 6, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, de v 17 1`] = `
+{
+  "_cmd": "wa b v 6, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, de v 18 1`] = `
+{
+  "_cmd": "wa b v 6, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 6, de v 19 1`] = `
+{
+  "_cmd": "wa b v 6, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 6, de v 20 1`] = `
+{
+  "_cmd": "wa b v 6, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 6, de w 1 1`] = `
+{
+  "_cmd": "wa b v 6, de w 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, de w 2 1`] = `
+{
+  "_cmd": "wa b v 6, de w 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, de w 3 1`] = `
+{
+  "_cmd": "wa b v 6, de w 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, de w 4 1`] = `
+{
+  "_cmd": "wa b v 6, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, de w 5 1`] = `
+{
+  "_cmd": "wa b v 6, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, de w 6 1`] = `
+{
+  "_cmd": "wa b v 6, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, de w 7 1`] = `
+{
+  "_cmd": "wa b v 6, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de w 8 1`] = `
+{
+  "_cmd": "wa b v 6, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, de w 9 1`] = `
+{
+  "_cmd": "wa b v 6, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de w 10 1`] = `
+{
+  "_cmd": "wa b v 6, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, de w 11 1`] = `
+{
+  "_cmd": "wa b v 6, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de w 12 1`] = `
+{
+  "_cmd": "wa b v 6, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de w 13 1`] = `
+{
+  "_cmd": "wa b v 6, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de w 14 1`] = `
+{
+  "_cmd": "wa b v 6, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, de w 15 1`] = `
+{
+  "_cmd": "wa b v 6, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 6, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 6, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 6, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 6, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 6, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 7, de d 1 1`] = `
+{
+  "_cmd": "wa b v 7, de d 1",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 7, de d 2 1`] = `
+{
+  "_cmd": "wa b v 7, de d 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, de d 3 1`] = `
+{
+  "_cmd": "wa b v 7, de d 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, de d 4 1`] = `
+{
+  "_cmd": "wa b v 7, de d 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, de d 5 1`] = `
+{
+  "_cmd": "wa b v 7, de d 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, de d 6 1`] = `
+{
+  "_cmd": "wa b v 7, de d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de d 7 1`] = `
+{
+  "_cmd": "wa b v 7, de d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, de d 8 1`] = `
+{
+  "_cmd": "wa b v 7, de d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de d 9 1`] = `
+{
+  "_cmd": "wa b v 7, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de d 10 1`] = `
+{
+  "_cmd": "wa b v 7, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de d 11 1`] = `
+{
+  "_cmd": "wa b v 7, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, de d 12 1`] = `
+{
+  "_cmd": "wa b v 7, de d 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de d 13 1`] = `
+{
+  "_cmd": "wa b v 7, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de d 14 1`] = `
+{
+  "_cmd": "wa b v 7, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, de d 15 1`] = `
+{
+  "_cmd": "wa b v 7, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 1",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 7, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 2",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 7, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 7, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 7, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 7, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 7, de p 1 1`] = `
+{
+  "_cmd": "wa b v 7, de p 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, de p 2 1`] = `
+{
+  "_cmd": "wa b v 7, de p 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 7, de p 3 1`] = `
+{
+  "_cmd": "wa b v 7, de p 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, de p 4 1`] = `
+{
+  "_cmd": "wa b v 7, de p 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, de p 5 1`] = `
+{
+  "_cmd": "wa b v 7, de p 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, de p 6 1`] = `
+{
+  "_cmd": "wa b v 7, de p 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, de p 7 1`] = `
+{
+  "_cmd": "wa b v 7, de p 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, de p 8 1`] = `
+{
+  "_cmd": "wa b v 7, de p 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de p 9 1`] = `
+{
+  "_cmd": "wa b v 7, de p 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de p 10 1`] = `
+{
+  "_cmd": "wa b v 7, de p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de p 11 1`] = `
+{
+  "_cmd": "wa b v 7, de p 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de p 12 1`] = `
+{
+  "_cmd": "wa b v 7, de p 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de p 13 1`] = `
+{
+  "_cmd": "wa b v 7, de p 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de p 14 1`] = `
+{
+  "_cmd": "wa b v 7, de p 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de p 15 1`] = `
+{
+  "_cmd": "wa b v 7, de p 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 7, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 8",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 10",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 16",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 7, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 7, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 7, de p v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 7, de v 1 1`] = `
+{
+  "_cmd": "wa b v 7, de v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, de v 2 1`] = `
+{
+  "_cmd": "wa b v 7, de v 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 7, de v 3 1`] = `
+{
+  "_cmd": "wa b v 7, de v 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, de v 4 1`] = `
+{
+  "_cmd": "wa b v 7, de v 4",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, de v 5 1`] = `
+{
+  "_cmd": "wa b v 7, de v 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, de v 6 1`] = `
+{
+  "_cmd": "wa b v 7, de v 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, de v 7 1`] = `
+{
+  "_cmd": "wa b v 7, de v 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, de v 8 1`] = `
+{
+  "_cmd": "wa b v 7, de v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de v 9 1`] = `
+{
+  "_cmd": "wa b v 7, de v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de v 10 1`] = `
+{
+  "_cmd": "wa b v 7, de v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de v 11 1`] = `
+{
+  "_cmd": "wa b v 7, de v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de v 12 1`] = `
+{
+  "_cmd": "wa b v 7, de v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, de v 13 1`] = `
+{
+  "_cmd": "wa b v 7, de v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de v 14 1`] = `
+{
+  "_cmd": "wa b v 7, de v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de v 15 1`] = `
+{
+  "_cmd": "wa b v 7, de v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, de v 16 1`] = `
+{
+  "_cmd": "wa b v 7, de v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, de v 17 1`] = `
+{
+  "_cmd": "wa b v 7, de v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de v 18 1`] = `
+{
+  "_cmd": "wa b v 7, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 7, de v 19 1`] = `
+{
+  "_cmd": "wa b v 7, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 7, de v 20 1`] = `
+{
+  "_cmd": "wa b v 7, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 7, de w 1 1`] = `
+{
+  "_cmd": "wa b v 7, de w 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, de w 2 1`] = `
+{
+  "_cmd": "wa b v 7, de w 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, de w 3 1`] = `
+{
+  "_cmd": "wa b v 7, de w 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, de w 4 1`] = `
+{
+  "_cmd": "wa b v 7, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, de w 5 1`] = `
+{
+  "_cmd": "wa b v 7, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de w 6 1`] = `
+{
+  "_cmd": "wa b v 7, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, de w 7 1`] = `
+{
+  "_cmd": "wa b v 7, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de w 8 1`] = `
+{
+  "_cmd": "wa b v 7, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de w 9 1`] = `
+{
+  "_cmd": "wa b v 7, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de w 10 1`] = `
+{
+  "_cmd": "wa b v 7, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de w 11 1`] = `
+{
+  "_cmd": "wa b v 7, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de w 12 1`] = `
+{
+  "_cmd": "wa b v 7, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, de w 13 1`] = `
+{
+  "_cmd": "wa b v 7, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, de w 14 1`] = `
+{
+  "_cmd": "wa b v 7, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de w 15 1`] = `
+{
+  "_cmd": "wa b v 7, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 7, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 7, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 7, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 7, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 7, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 7, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 7, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 7, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 8, de d 1 1`] = `
+{
+  "_cmd": "wa b v 8, de d 1",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 8, de d 2 1`] = `
+{
+  "_cmd": "wa b v 8, de d 2",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, de d 3 1`] = `
+{
+  "_cmd": "wa b v 8, de d 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, de d 4 1`] = `
+{
+  "_cmd": "wa b v 8, de d 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, de d 5 1`] = `
+{
+  "_cmd": "wa b v 8, de d 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, de d 6 1`] = `
+{
+  "_cmd": "wa b v 8, de d 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, de d 7 1`] = `
+{
+  "_cmd": "wa b v 8, de d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, de d 8 1`] = `
+{
+  "_cmd": "wa b v 8, de d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, de d 9 1`] = `
+{
+  "_cmd": "wa b v 8, de d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de d 10 1`] = `
+{
+  "_cmd": "wa b v 8, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de d 11 1`] = `
+{
+  "_cmd": "wa b v 8, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de d 12 1`] = `
+{
+  "_cmd": "wa b v 8, de d 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, de d 13 1`] = `
+{
+  "_cmd": "wa b v 8, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, de d 14 1`] = `
+{
+  "_cmd": "wa b v 8, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de d 15 1`] = `
+{
+  "_cmd": "wa b v 8, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 2",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 4",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 8, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 8, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 8, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 8, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 8, de p 1 1`] = `
+{
+  "_cmd": "wa b v 8, de p 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, de p 2 1`] = `
+{
+  "_cmd": "wa b v 8, de p 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, de p 3 1`] = `
+{
+  "_cmd": "wa b v 8, de p 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, de p 4 1`] = `
+{
+  "_cmd": "wa b v 8, de p 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, de p 5 1`] = `
+{
+  "_cmd": "wa b v 8, de p 5",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, de p 6 1`] = `
+{
+  "_cmd": "wa b v 8, de p 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, de p 7 1`] = `
+{
+  "_cmd": "wa b v 8, de p 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, de p 8 1`] = `
+{
+  "_cmd": "wa b v 8, de p 8",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de p 9 1`] = `
+{
+  "_cmd": "wa b v 8, de p 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, de p 10 1`] = `
+{
+  "_cmd": "wa b v 8, de p 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de p 11 1`] = `
+{
+  "_cmd": "wa b v 8, de p 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de p 12 1`] = `
+{
+  "_cmd": "wa b v 8, de p 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de p 13 1`] = `
+{
+  "_cmd": "wa b v 8, de p 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de p 14 1`] = `
+{
+  "_cmd": "wa b v 8, de p 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, de p 15 1`] = `
+{
+  "_cmd": "wa b v 8, de p 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 8, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 8, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 7",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 8",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 9",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 11",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 12",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 13",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 16",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 17",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 18",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 8, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 19",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 8, de p v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 8, de v 1 1`] = `
+{
+  "_cmd": "wa b v 8, de v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, de v 2 1`] = `
+{
+  "_cmd": "wa b v 8, de v 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, de v 3 1`] = `
+{
+  "_cmd": "wa b v 8, de v 3",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 8, de v 4 1`] = `
+{
+  "_cmd": "wa b v 8, de v 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, de v 5 1`] = `
+{
+  "_cmd": "wa b v 8, de v 5",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, de v 6 1`] = `
+{
+  "_cmd": "wa b v 8, de v 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, de v 7 1`] = `
+{
+  "_cmd": "wa b v 8, de v 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, de v 8 1`] = `
+{
+  "_cmd": "wa b v 8, de v 8",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de v 9 1`] = `
+{
+  "_cmd": "wa b v 8, de v 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, de v 10 1`] = `
+{
+  "_cmd": "wa b v 8, de v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de v 11 1`] = `
+{
+  "_cmd": "wa b v 8, de v 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de v 12 1`] = `
+{
+  "_cmd": "wa b v 8, de v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de v 13 1`] = `
+{
+  "_cmd": "wa b v 8, de v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de v 14 1`] = `
+{
+  "_cmd": "wa b v 8, de v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, de v 15 1`] = `
+{
+  "_cmd": "wa b v 8, de v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de v 16 1`] = `
+{
+  "_cmd": "wa b v 8, de v 16",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de v 17 1`] = `
+{
+  "_cmd": "wa b v 8, de v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 8, de v 18 1`] = `
+{
+  "_cmd": "wa b v 8, de v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, de v 19 1`] = `
+{
+  "_cmd": "wa b v 8, de v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 8, de v 20 1`] = `
+{
+  "_cmd": "wa b v 8, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 8, de w 1 1`] = `
+{
+  "_cmd": "wa b v 8, de w 1",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, de w 2 1`] = `
+{
+  "_cmd": "wa b v 8, de w 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, de w 3 1`] = `
+{
+  "_cmd": "wa b v 8, de w 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, de w 4 1`] = `
+{
+  "_cmd": "wa b v 8, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, de w 5 1`] = `
+{
+  "_cmd": "wa b v 8, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de w 6 1`] = `
+{
+  "_cmd": "wa b v 8, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, de w 7 1`] = `
+{
+  "_cmd": "wa b v 8, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, de w 8 1`] = `
+{
+  "_cmd": "wa b v 8, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de w 9 1`] = `
+{
+  "_cmd": "wa b v 8, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de w 10 1`] = `
+{
+  "_cmd": "wa b v 8, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de w 11 1`] = `
+{
+  "_cmd": "wa b v 8, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, de w 12 1`] = `
+{
+  "_cmd": "wa b v 8, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de w 13 1`] = `
+{
+  "_cmd": "wa b v 8, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de w 14 1`] = `
+{
+  "_cmd": "wa b v 8, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 8, de w 15 1`] = `
+{
+  "_cmd": "wa b v 8, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 8, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 8, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 8, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 8, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 8, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 9, de d 1 1`] = `
+{
+  "_cmd": "wa b v 9, de d 1",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 9, de d 2 1`] = `
+{
+  "_cmd": "wa b v 9, de d 2",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, de d 3 1`] = `
+{
+  "_cmd": "wa b v 9, de d 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, de d 4 1`] = `
+{
+  "_cmd": "wa b v 9, de d 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, de d 5 1`] = `
+{
+  "_cmd": "wa b v 9, de d 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de d 6 1`] = `
+{
+  "_cmd": "wa b v 9, de d 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, de d 7 1`] = `
+{
+  "_cmd": "wa b v 9, de d 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de d 8 1`] = `
+{
+  "_cmd": "wa b v 9, de d 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, de d 9 1`] = `
+{
+  "_cmd": "wa b v 9, de d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de d 10 1`] = `
+{
+  "_cmd": "wa b v 9, de d 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, de d 11 1`] = `
+{
+  "_cmd": "wa b v 9, de d 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de d 12 1`] = `
+{
+  "_cmd": "wa b v 9, de d 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de d 13 1`] = `
+{
+  "_cmd": "wa b v 9, de d 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de d 14 1`] = `
+{
+  "_cmd": "wa b v 9, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 9, de d 15 1`] = `
+{
+  "_cmd": "wa b v 9, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 3",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 9, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 9",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 9, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 9, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 9, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 9, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 9, de p 1 1`] = `
+{
+  "_cmd": "wa b v 9, de p 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, de p 2 1`] = `
+{
+  "_cmd": "wa b v 9, de p 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, de p 3 1`] = `
+{
+  "_cmd": "wa b v 9, de p 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, de p 4 1`] = `
+{
+  "_cmd": "wa b v 9, de p 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, de p 5 1`] = `
+{
+  "_cmd": "wa b v 9, de p 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, de p 6 1`] = `
+{
+  "_cmd": "wa b v 9, de p 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de p 7 1`] = `
+{
+  "_cmd": "wa b v 9, de p 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, de p 8 1`] = `
+{
+  "_cmd": "wa b v 9, de p 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de p 9 1`] = `
+{
+  "_cmd": "wa b v 9, de p 9",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de p 10 1`] = `
+{
+  "_cmd": "wa b v 9, de p 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, de p 11 1`] = `
+{
+  "_cmd": "wa b v 9, de p 11",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de p 12 1`] = `
+{
+  "_cmd": "wa b v 9, de p 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de p 13 1`] = `
+{
+  "_cmd": "wa b v 9, de p 13",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de p 14 1`] = `
+{
+  "_cmd": "wa b v 9, de p 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de p 15 1`] = `
+{
+  "_cmd": "wa b v 9, de p 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 9, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 9, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 9, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 8",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 9",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 10",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 13",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 14",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 16",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 9, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 17",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 18",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 19",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 9, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 9, de p v 20",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 9, de v 1 1`] = `
+{
+  "_cmd": "wa b v 9, de v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, de v 2 1`] = `
+{
+  "_cmd": "wa b v 9, de v 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, de v 3 1`] = `
+{
+  "_cmd": "wa b v 9, de v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, de v 4 1`] = `
+{
+  "_cmd": "wa b v 9, de v 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, de v 5 1`] = `
+{
+  "_cmd": "wa b v 9, de v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, de v 6 1`] = `
+{
+  "_cmd": "wa b v 9, de v 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de v 7 1`] = `
+{
+  "_cmd": "wa b v 9, de v 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, de v 8 1`] = `
+{
+  "_cmd": "wa b v 9, de v 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de v 9 1`] = `
+{
+  "_cmd": "wa b v 9, de v 9",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de v 10 1`] = `
+{
+  "_cmd": "wa b v 9, de v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, de v 11 1`] = `
+{
+  "_cmd": "wa b v 9, de v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, de v 12 1`] = `
+{
+  "_cmd": "wa b v 9, de v 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de v 13 1`] = `
+{
+  "_cmd": "wa b v 9, de v 13",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de v 14 1`] = `
+{
+  "_cmd": "wa b v 9, de v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de v 15 1`] = `
+{
+  "_cmd": "wa b v 9, de v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de v 16 1`] = `
+{
+  "_cmd": "wa b v 9, de v 16",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de v 17 1`] = `
+{
+  "_cmd": "wa b v 9, de v 17",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, de v 18 1`] = `
+{
+  "_cmd": "wa b v 9, de v 18",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 9, de v 19 1`] = `
+{
+  "_cmd": "wa b v 9, de v 19",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 9, de v 20 1`] = `
+{
+  "_cmd": "wa b v 9, de v 20",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 9, de w 1 1`] = `
+{
+  "_cmd": "wa b v 9, de w 1",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, de w 2 1`] = `
+{
+  "_cmd": "wa b v 9, de w 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, de w 3 1`] = `
+{
+  "_cmd": "wa b v 9, de w 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, de w 4 1`] = `
+{
+  "_cmd": "wa b v 9, de w 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, de w 5 1`] = `
+{
+  "_cmd": "wa b v 9, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, de w 6 1`] = `
+{
+  "_cmd": "wa b v 9, de w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de w 7 1`] = `
+{
+  "_cmd": "wa b v 9, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de w 8 1`] = `
+{
+  "_cmd": "wa b v 9, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, de w 9 1`] = `
+{
+  "_cmd": "wa b v 9, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de w 10 1`] = `
+{
+  "_cmd": "wa b v 9, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de w 11 1`] = `
+{
+  "_cmd": "wa b v 9, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de w 12 1`] = `
+{
+  "_cmd": "wa b v 9, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de w 13 1`] = `
+{
+  "_cmd": "wa b v 9, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de w 14 1`] = `
+{
+  "_cmd": "wa b v 9, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, de w 15 1`] = `
+{
+  "_cmd": "wa b v 9, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 9, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 2",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 9, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 9, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 9, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 9, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 9, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 9, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 10, de d 1 1`] = `
+{
+  "_cmd": "wa b v 10, de d 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, de d 2 1`] = `
+{
+  "_cmd": "wa b v 10, de d 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, de d 3 1`] = `
+{
+  "_cmd": "wa b v 10, de d 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, de d 4 1`] = `
+{
+  "_cmd": "wa b v 10, de d 4",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, de d 5 1`] = `
+{
+  "_cmd": "wa b v 10, de d 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, de d 6 1`] = `
+{
+  "_cmd": "wa b v 10, de d 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de d 7 1`] = `
+{
+  "_cmd": "wa b v 10, de d 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, de d 8 1`] = `
+{
+  "_cmd": "wa b v 10, de d 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de d 9 1`] = `
+{
+  "_cmd": "wa b v 10, de d 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, de d 10 1`] = `
+{
+  "_cmd": "wa b v 10, de d 10",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de d 11 1`] = `
+{
+  "_cmd": "wa b v 10, de d 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, de d 12 1`] = `
+{
+  "_cmd": "wa b v 10, de d 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de d 13 1`] = `
+{
+  "_cmd": "wa b v 10, de d 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de d 14 1`] = `
+{
+  "_cmd": "wa b v 10, de d 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, de d 15 1`] = `
+{
+  "_cmd": "wa b v 10, de d 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 10, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 2",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 3",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 4",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 5",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 7",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 10",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 13",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 14",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 15",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 16",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 10, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 17",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 10, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 10, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 10, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 10, de d v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 10, de p 1 1`] = `
+{
+  "_cmd": "wa b v 10, de p 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, de p 2 1`] = `
+{
+  "_cmd": "wa b v 10, de p 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, de p 3 1`] = `
+{
+  "_cmd": "wa b v 10, de p 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, de p 4 1`] = `
+{
+  "_cmd": "wa b v 10, de p 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, de p 5 1`] = `
+{
+  "_cmd": "wa b v 10, de p 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, de p 6 1`] = `
+{
+  "_cmd": "wa b v 10, de p 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, de p 7 1`] = `
+{
+  "_cmd": "wa b v 10, de p 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, de p 8 1`] = `
+{
+  "_cmd": "wa b v 10, de p 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de p 9 1`] = `
+{
+  "_cmd": "wa b v 10, de p 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de p 10 1`] = `
+{
+  "_cmd": "wa b v 10, de p 10",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de p 11 1`] = `
+{
+  "_cmd": "wa b v 10, de p 11",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, de p 12 1`] = `
+{
+  "_cmd": "wa b v 10, de p 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de p 13 1`] = `
+{
+  "_cmd": "wa b v 10, de p 13",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de p 14 1`] = `
+{
+  "_cmd": "wa b v 10, de p 14",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de p 15 1`] = `
+{
+  "_cmd": "wa b v 10, de p 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 10, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 10",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 11",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 12",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 13",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 14",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 15",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 16",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 17",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 10, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 18",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 10, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 19",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 10, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 10, de p v 20",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 10, de v 1 1`] = `
+{
+  "_cmd": "wa b v 10, de v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, de v 2 1`] = `
+{
+  "_cmd": "wa b v 10, de v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, de v 3 1`] = `
+{
+  "_cmd": "wa b v 10, de v 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, de v 4 1`] = `
+{
+  "_cmd": "wa b v 10, de v 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, de v 5 1`] = `
+{
+  "_cmd": "wa b v 10, de v 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, de v 6 1`] = `
+{
+  "_cmd": "wa b v 10, de v 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, de v 7 1`] = `
+{
+  "_cmd": "wa b v 10, de v 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, de v 8 1`] = `
+{
+  "_cmd": "wa b v 10, de v 8",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de v 9 1`] = `
+{
+  "_cmd": "wa b v 10, de v 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de v 10 1`] = `
+{
+  "_cmd": "wa b v 10, de v 10",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de v 11 1`] = `
+{
+  "_cmd": "wa b v 10, de v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, de v 12 1`] = `
+{
+  "_cmd": "wa b v 10, de v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, de v 13 1`] = `
+{
+  "_cmd": "wa b v 10, de v 13",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de v 14 1`] = `
+{
+  "_cmd": "wa b v 10, de v 14",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de v 15 1`] = `
+{
+  "_cmd": "wa b v 10, de v 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de v 16 1`] = `
+{
+  "_cmd": "wa b v 10, de v 16",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, de v 17 1`] = `
+{
+  "_cmd": "wa b v 10, de v 17",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 10, de v 18 1`] = `
+{
+  "_cmd": "wa b v 10, de v 18",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 10, de v 19 1`] = `
+{
+  "_cmd": "wa b v 10, de v 19",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 10, de v 20 1`] = `
+{
+  "_cmd": "wa b v 10, de v 20",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 10, de w 1 1`] = `
+{
+  "_cmd": "wa b v 10, de w 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, de w 2 1`] = `
+{
+  "_cmd": "wa b v 10, de w 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, de w 3 1`] = `
+{
+  "_cmd": "wa b v 10, de w 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, de w 4 1`] = `
+{
+  "_cmd": "wa b v 10, de w 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, de w 5 1`] = `
+{
+  "_cmd": "wa b v 10, de w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, de w 6 1`] = `
+{
+  "_cmd": "wa b v 10, de w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, de w 7 1`] = `
+{
+  "_cmd": "wa b v 10, de w 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de w 8 1`] = `
+{
+  "_cmd": "wa b v 10, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de w 9 1`] = `
+{
+  "_cmd": "wa b v 10, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, de w 10 1`] = `
+{
+  "_cmd": "wa b v 10, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de w 11 1`] = `
+{
+  "_cmd": "wa b v 10, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de w 12 1`] = `
+{
+  "_cmd": "wa b v 10, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de w 13 1`] = `
+{
+  "_cmd": "wa b v 10, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, de w 14 1`] = `
+{
+  "_cmd": "wa b v 10, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 10, de w 15 1`] = `
+{
+  "_cmd": "wa b v 10, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 10, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 5",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 10, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 10, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 10, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 10, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 10, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 10, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 10, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 11, de d 1 1`] = `
+{
+  "_cmd": "wa b v 11, de d 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, de d 2 1`] = `
+{
+  "_cmd": "wa b v 11, de d 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, de d 3 1`] = `
+{
+  "_cmd": "wa b v 11, de d 3",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, de d 4 1`] = `
+{
+  "_cmd": "wa b v 11, de d 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, de d 5 1`] = `
+{
+  "_cmd": "wa b v 11, de d 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, de d 6 1`] = `
+{
+  "_cmd": "wa b v 11, de d 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de d 7 1`] = `
+{
+  "_cmd": "wa b v 11, de d 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, de d 8 1`] = `
+{
+  "_cmd": "wa b v 11, de d 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, de d 9 1`] = `
+{
+  "_cmd": "wa b v 11, de d 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de d 10 1`] = `
+{
+  "_cmd": "wa b v 11, de d 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, de d 11 1`] = `
+{
+  "_cmd": "wa b v 11, de d 11",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de d 12 1`] = `
+{
+  "_cmd": "wa b v 11, de d 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, de d 13 1`] = `
+{
+  "_cmd": "wa b v 11, de d 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de d 14 1`] = `
+{
+  "_cmd": "wa b v 11, de d 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de d 15 1`] = `
+{
+  "_cmd": "wa b v 11, de d 15",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 2",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 3",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 4",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 5",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 7",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 8",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 11",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 15",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 16",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 17",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 11, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 18",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 11, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 19",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 11, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 11, de d v 20",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 11, de p 1 1`] = `
+{
+  "_cmd": "wa b v 11, de p 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, de p 2 1`] = `
+{
+  "_cmd": "wa b v 11, de p 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, de p 3 1`] = `
+{
+  "_cmd": "wa b v 11, de p 3",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, de p 4 1`] = `
+{
+  "_cmd": "wa b v 11, de p 4",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, de p 5 1`] = `
+{
+  "_cmd": "wa b v 11, de p 5",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, de p 6 1`] = `
+{
+  "_cmd": "wa b v 11, de p 6",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, de p 7 1`] = `
+{
+  "_cmd": "wa b v 11, de p 7",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de p 8 1`] = `
+{
+  "_cmd": "wa b v 11, de p 8",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, de p 9 1`] = `
+{
+  "_cmd": "wa b v 11, de p 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, de p 10 1`] = `
+{
+  "_cmd": "wa b v 11, de p 10",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de p 11 1`] = `
+{
+  "_cmd": "wa b v 11, de p 11",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de p 12 1`] = `
+{
+  "_cmd": "wa b v 11, de p 12",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, de p 13 1`] = `
+{
+  "_cmd": "wa b v 11, de p 13",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de p 14 1`] = `
+{
+  "_cmd": "wa b v 11, de p 14",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de p 15 1`] = `
+{
+  "_cmd": "wa b v 11, de p 15",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 1",
+  "attacker": 11,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 11, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 3",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 4",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 5",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 6",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 7",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 8",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 10",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 11",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 12",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 14",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 15",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 16",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 17",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 18",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 19",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 11, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 11, de p v 20",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 11, de v 1 1`] = `
+{
+  "_cmd": "wa b v 11, de v 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, de v 2 1`] = `
+{
+  "_cmd": "wa b v 11, de v 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, de v 3 1`] = `
+{
+  "_cmd": "wa b v 11, de v 3",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, de v 4 1`] = `
+{
+  "_cmd": "wa b v 11, de v 4",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, de v 5 1`] = `
+{
+  "_cmd": "wa b v 11, de v 5",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, de v 6 1`] = `
+{
+  "_cmd": "wa b v 11, de v 6",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, de v 7 1`] = `
+{
+  "_cmd": "wa b v 11, de v 7",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de v 8 1`] = `
+{
+  "_cmd": "wa b v 11, de v 8",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, de v 9 1`] = `
+{
+  "_cmd": "wa b v 11, de v 9",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, de v 10 1`] = `
+{
+  "_cmd": "wa b v 11, de v 10",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de v 11 1`] = `
+{
+  "_cmd": "wa b v 11, de v 11",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de v 12 1`] = `
+{
+  "_cmd": "wa b v 11, de v 12",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, de v 13 1`] = `
+{
+  "_cmd": "wa b v 11, de v 13",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, de v 14 1`] = `
+{
+  "_cmd": "wa b v 11, de v 14",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de v 15 1`] = `
+{
+  "_cmd": "wa b v 11, de v 15",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de v 16 1`] = `
+{
+  "_cmd": "wa b v 11, de v 16",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de v 17 1`] = `
+{
+  "_cmd": "wa b v 11, de v 17",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de v 18 1`] = `
+{
+  "_cmd": "wa b v 11, de v 18",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 11, de v 19 1`] = `
+{
+  "_cmd": "wa b v 11, de v 19",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 11, de v 20 1`] = `
+{
+  "_cmd": "wa b v 11, de v 20",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 11, de w 1 1`] = `
+{
+  "_cmd": "wa b v 11, de w 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, de w 2 1`] = `
+{
+  "_cmd": "wa b v 11, de w 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, de w 3 1`] = `
+{
+  "_cmd": "wa b v 11, de w 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, de w 4 1`] = `
+{
+  "_cmd": "wa b v 11, de w 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, de w 5 1`] = `
+{
+  "_cmd": "wa b v 11, de w 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, de w 6 1`] = `
+{
+  "_cmd": "wa b v 11, de w 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, de w 7 1`] = `
+{
+  "_cmd": "wa b v 11, de w 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de w 8 1`] = `
+{
+  "_cmd": "wa b v 11, de w 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de w 9 1`] = `
+{
+  "_cmd": "wa b v 11, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de w 10 1`] = `
+{
+  "_cmd": "wa b v 11, de w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, de w 11 1`] = `
+{
+  "_cmd": "wa b v 11, de w 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de w 12 1`] = `
+{
+  "_cmd": "wa b v 11, de w 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de w 13 1`] = `
+{
+  "_cmd": "wa b v 11, de w 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de w 14 1`] = `
+{
+  "_cmd": "wa b v 11, de w 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de w 15 1`] = `
+{
+  "_cmd": "wa b v 11, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 11, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 2",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 11, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 11, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 11, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 11, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 11, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 11, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa b v 12, de d 1 1`] = `
+{
+  "_cmd": "wa b v 12, de d 1",
+  "attacker": 12,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 12, de d 2 1`] = `
+{
+  "_cmd": "wa b v 12, de d 2",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, de d 3 1`] = `
+{
+  "_cmd": "wa b v 12, de d 3",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de d 4 1`] = `
+{
+  "_cmd": "wa b v 12, de d 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, de d 5 1`] = `
+{
+  "_cmd": "wa b v 12, de d 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, de d 6 1`] = `
+{
+  "_cmd": "wa b v 12, de d 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, de d 7 1`] = `
+{
+  "_cmd": "wa b v 12, de d 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, de d 8 1`] = `
+{
+  "_cmd": "wa b v 12, de d 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de d 9 1`] = `
+{
+  "_cmd": "wa b v 12, de d 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, de d 10 1`] = `
+{
+  "_cmd": "wa b v 12, de d 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de d 11 1`] = `
+{
+  "_cmd": "wa b v 12, de d 11",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de d 12 1`] = `
+{
+  "_cmd": "wa b v 12, de d 12",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de d 13 1`] = `
+{
+  "_cmd": "wa b v 12, de d 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, de d 14 1`] = `
+{
+  "_cmd": "wa b v 12, de d 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de d 15 1`] = `
+{
+  "_cmd": "wa b v 12, de d 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 1",
+  "attacker": 12,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 12, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 2",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 3",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 4",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 5",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 6",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 8",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 9",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 11",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 12",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 13",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 12, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 16",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 17",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 18",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 12, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 19",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 12, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 12, de d v 20",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 12, de p 1 1`] = `
+{
+  "_cmd": "wa b v 12, de p 1",
+  "attacker": 12,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 12, de p 2 1`] = `
+{
+  "_cmd": "wa b v 12, de p 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, de p 3 1`] = `
+{
+  "_cmd": "wa b v 12, de p 3",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 12, de p 4 1`] = `
+{
+  "_cmd": "wa b v 12, de p 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de p 5 1`] = `
+{
+  "_cmd": "wa b v 12, de p 5",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, de p 6 1`] = `
+{
+  "_cmd": "wa b v 12, de p 6",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, de p 7 1`] = `
+{
+  "_cmd": "wa b v 12, de p 7",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, de p 8 1`] = `
+{
+  "_cmd": "wa b v 12, de p 8",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, de p 9 1`] = `
+{
+  "_cmd": "wa b v 12, de p 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, de p 10 1`] = `
+{
+  "_cmd": "wa b v 12, de p 10",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de p 11 1`] = `
+{
+  "_cmd": "wa b v 12, de p 11",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de p 12 1`] = `
+{
+  "_cmd": "wa b v 12, de p 12",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, de p 13 1`] = `
+{
+  "_cmd": "wa b v 12, de p 13",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de p 14 1`] = `
+{
+  "_cmd": "wa b v 12, de p 14",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de p 15 1`] = `
+{
+  "_cmd": "wa b v 12, de p 15",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 1",
+  "attacker": 12,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 12, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 3",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 5",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 6",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 7",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 8",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 9",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 11",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 12",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 13",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 14",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 15",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 16",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 17",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 12, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 18",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 19",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 12, de p v 20",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 12, de v 1 1`] = `
+{
+  "_cmd": "wa b v 12, de v 1",
+  "attacker": 12,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 12, de v 2 1`] = `
+{
+  "_cmd": "wa b v 12, de v 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, de v 3 1`] = `
+{
+  "_cmd": "wa b v 12, de v 3",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 12, de v 4 1`] = `
+{
+  "_cmd": "wa b v 12, de v 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de v 5 1`] = `
+{
+  "_cmd": "wa b v 12, de v 5",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, de v 6 1`] = `
+{
+  "_cmd": "wa b v 12, de v 6",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, de v 7 1`] = `
+{
+  "_cmd": "wa b v 12, de v 7",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, de v 8 1`] = `
+{
+  "_cmd": "wa b v 12, de v 8",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, de v 9 1`] = `
+{
+  "_cmd": "wa b v 12, de v 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, de v 10 1`] = `
+{
+  "_cmd": "wa b v 12, de v 10",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, de v 11 1`] = `
+{
+  "_cmd": "wa b v 12, de v 11",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de v 12 1`] = `
+{
+  "_cmd": "wa b v 12, de v 12",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, de v 13 1`] = `
+{
+  "_cmd": "wa b v 12, de v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de v 14 1`] = `
+{
+  "_cmd": "wa b v 12, de v 14",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, de v 15 1`] = `
+{
+  "_cmd": "wa b v 12, de v 15",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de v 16 1`] = `
+{
+  "_cmd": "wa b v 12, de v 16",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 12, de v 17 1`] = `
+{
+  "_cmd": "wa b v 12, de v 17",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de v 18 1`] = `
+{
+  "_cmd": "wa b v 12, de v 18",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, de v 19 1`] = `
+{
+  "_cmd": "wa b v 12, de v 19",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 12, de v 20 1`] = `
+{
+  "_cmd": "wa b v 12, de v 20",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 12, de w 1 1`] = `
+{
+  "_cmd": "wa b v 12, de w 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, de w 2 1`] = `
+{
+  "_cmd": "wa b v 12, de w 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, de w 3 1`] = `
+{
+  "_cmd": "wa b v 12, de w 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, de w 4 1`] = `
+{
+  "_cmd": "wa b v 12, de w 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, de w 5 1`] = `
+{
+  "_cmd": "wa b v 12, de w 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, de w 6 1`] = `
+{
+  "_cmd": "wa b v 12, de w 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de w 7 1`] = `
+{
+  "_cmd": "wa b v 12, de w 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, de w 8 1`] = `
+{
+  "_cmd": "wa b v 12, de w 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de w 9 1`] = `
+{
+  "_cmd": "wa b v 12, de w 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de w 10 1`] = `
+{
+  "_cmd": "wa b v 12, de w 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de w 11 1`] = `
+{
+  "_cmd": "wa b v 12, de w 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, de w 12 1`] = `
+{
+  "_cmd": "wa b v 12, de w 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de w 13 1`] = `
+{
+  "_cmd": "wa b v 12, de w 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 12, de w 14 1`] = `
+{
+  "_cmd": "wa b v 12, de w 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de w 15 1`] = `
+{
+  "_cmd": "wa b v 12, de w 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 1",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 3",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 12, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 16",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 12, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 17",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 12, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 18",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 12, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 12, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 12, de w v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 13, de d 1 1`] = `
+{
+  "_cmd": "wa b v 13, de d 1",
+  "attacker": 13,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 13, de d 2 1`] = `
+{
+  "_cmd": "wa b v 13, de d 2",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, de d 3 1`] = `
+{
+  "_cmd": "wa b v 13, de d 3",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, de d 4 1`] = `
+{
+  "_cmd": "wa b v 13, de d 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, de d 5 1`] = `
+{
+  "_cmd": "wa b v 13, de d 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, de d 6 1`] = `
+{
+  "_cmd": "wa b v 13, de d 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, de d 7 1`] = `
+{
+  "_cmd": "wa b v 13, de d 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, de d 8 1`] = `
+{
+  "_cmd": "wa b v 13, de d 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de d 9 1`] = `
+{
+  "_cmd": "wa b v 13, de d 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, de d 10 1`] = `
+{
+  "_cmd": "wa b v 13, de d 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, de d 11 1`] = `
+{
+  "_cmd": "wa b v 13, de d 11",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de d 12 1`] = `
+{
+  "_cmd": "wa b v 13, de d 12",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de d 13 1`] = `
+{
+  "_cmd": "wa b v 13, de d 13",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de d 14 1`] = `
+{
+  "_cmd": "wa b v 13, de d 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 13, de d 15 1`] = `
+{
+  "_cmd": "wa b v 13, de d 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 1",
+  "attacker": 13,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 13, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 2",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 4",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 6",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 7",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 8",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 9",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 10",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 12",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 13",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 14",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 16",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 13, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 17",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 18",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 13, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 19",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 13, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 13, de d v 20",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 13, de p 1 1`] = `
+{
+  "_cmd": "wa b v 13, de p 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, de p 2 1`] = `
+{
+  "_cmd": "wa b v 13, de p 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, de p 3 1`] = `
+{
+  "_cmd": "wa b v 13, de p 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, de p 4 1`] = `
+{
+  "_cmd": "wa b v 13, de p 4",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, de p 5 1`] = `
+{
+  "_cmd": "wa b v 13, de p 5",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, de p 6 1`] = `
+{
+  "_cmd": "wa b v 13, de p 6",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, de p 7 1`] = `
+{
+  "_cmd": "wa b v 13, de p 7",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de p 8 1`] = `
+{
+  "_cmd": "wa b v 13, de p 8",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, de p 9 1`] = `
+{
+  "_cmd": "wa b v 13, de p 9",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, de p 10 1`] = `
+{
+  "_cmd": "wa b v 13, de p 10",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de p 11 1`] = `
+{
+  "_cmd": "wa b v 13, de p 11",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, de p 12 1`] = `
+{
+  "_cmd": "wa b v 13, de p 12",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de p 13 1`] = `
+{
+  "_cmd": "wa b v 13, de p 13",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de p 14 1`] = `
+{
+  "_cmd": "wa b v 13, de p 14",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de p 15 1`] = `
+{
+  "_cmd": "wa b v 13, de p 15",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 3",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 4",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 5",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 6",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 7",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 8",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 9",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 10",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 11",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 12",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 13",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 14",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 15",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 16",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 13, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 17",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 18",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 13, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 19",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 13, de p v 20",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 13, de v 1 1`] = `
+{
+  "_cmd": "wa b v 13, de v 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, de v 2 1`] = `
+{
+  "_cmd": "wa b v 13, de v 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, de v 3 1`] = `
+{
+  "_cmd": "wa b v 13, de v 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, de v 4 1`] = `
+{
+  "_cmd": "wa b v 13, de v 4",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, de v 5 1`] = `
+{
+  "_cmd": "wa b v 13, de v 5",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, de v 6 1`] = `
+{
+  "_cmd": "wa b v 13, de v 6",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, de v 7 1`] = `
+{
+  "_cmd": "wa b v 13, de v 7",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de v 8 1`] = `
+{
+  "_cmd": "wa b v 13, de v 8",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, de v 9 1`] = `
+{
+  "_cmd": "wa b v 13, de v 9",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, de v 10 1`] = `
+{
+  "_cmd": "wa b v 13, de v 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de v 11 1`] = `
+{
+  "_cmd": "wa b v 13, de v 11",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, de v 12 1`] = `
+{
+  "_cmd": "wa b v 13, de v 12",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de v 13 1`] = `
+{
+  "_cmd": "wa b v 13, de v 13",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de v 14 1`] = `
+{
+  "_cmd": "wa b v 13, de v 14",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de v 15 1`] = `
+{
+  "_cmd": "wa b v 13, de v 15",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de v 16 1`] = `
+{
+  "_cmd": "wa b v 13, de v 16",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de v 17 1`] = `
+{
+  "_cmd": "wa b v 13, de v 17",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 13, de v 18 1`] = `
+{
+  "_cmd": "wa b v 13, de v 18",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, de v 19 1`] = `
+{
+  "_cmd": "wa b v 13, de v 19",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 13, de v 20 1`] = `
+{
+  "_cmd": "wa b v 13, de v 20",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 13, de w 1 1`] = `
+{
+  "_cmd": "wa b v 13, de w 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, de w 2 1`] = `
+{
+  "_cmd": "wa b v 13, de w 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, de w 3 1`] = `
+{
+  "_cmd": "wa b v 13, de w 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, de w 4 1`] = `
+{
+  "_cmd": "wa b v 13, de w 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de w 5 1`] = `
+{
+  "_cmd": "wa b v 13, de w 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, de w 6 1`] = `
+{
+  "_cmd": "wa b v 13, de w 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de w 7 1`] = `
+{
+  "_cmd": "wa b v 13, de w 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, de w 8 1`] = `
+{
+  "_cmd": "wa b v 13, de w 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, de w 9 1`] = `
+{
+  "_cmd": "wa b v 13, de w 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de w 10 1`] = `
+{
+  "_cmd": "wa b v 13, de w 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de w 11 1`] = `
+{
+  "_cmd": "wa b v 13, de w 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de w 12 1`] = `
+{
+  "_cmd": "wa b v 13, de w 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 13, de w 13 1`] = `
+{
+  "_cmd": "wa b v 13, de w 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de w 14 1`] = `
+{
+  "_cmd": "wa b v 13, de w 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 13, de w 15 1`] = `
+{
+  "_cmd": "wa b v 13, de w 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 1",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 2",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 13, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 16",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 13, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 17",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 13, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 18",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 13, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 19",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 13, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 13, de w v 20",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 14, de d 1 1`] = `
+{
+  "_cmd": "wa b v 14, de d 1",
+  "attacker": 14,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 14, de d 2 1`] = `
+{
+  "_cmd": "wa b v 14, de d 2",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, de d 3 1`] = `
+{
+  "_cmd": "wa b v 14, de d 3",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, de d 4 1`] = `
+{
+  "_cmd": "wa b v 14, de d 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, de d 5 1`] = `
+{
+  "_cmd": "wa b v 14, de d 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, de d 6 1`] = `
+{
+  "_cmd": "wa b v 14, de d 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, de d 7 1`] = `
+{
+  "_cmd": "wa b v 14, de d 7",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, de d 8 1`] = `
+{
+  "_cmd": "wa b v 14, de d 8",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de d 9 1`] = `
+{
+  "_cmd": "wa b v 14, de d 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de d 10 1`] = `
+{
+  "_cmd": "wa b v 14, de d 10",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, de d 11 1`] = `
+{
+  "_cmd": "wa b v 14, de d 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de d 12 1`] = `
+{
+  "_cmd": "wa b v 14, de d 12",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de d 13 1`] = `
+{
+  "_cmd": "wa b v 14, de d 13",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de d 14 1`] = `
+{
+  "_cmd": "wa b v 14, de d 14",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, de d 15 1`] = `
+{
+  "_cmd": "wa b v 14, de d 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 14, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 1",
+  "attacker": 14,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 14, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 2",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 3",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 4",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 5",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 6",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 7",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 8",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 9",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 10",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 11",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 13",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 14",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 15",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 16",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 14, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 17",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 18",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 14, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 19",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 14, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 14, de d v 20",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 14, de p 1 1`] = `
+{
+  "_cmd": "wa b v 14, de p 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, de p 2 1`] = `
+{
+  "_cmd": "wa b v 14, de p 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, de p 3 1`] = `
+{
+  "_cmd": "wa b v 14, de p 3",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, de p 4 1`] = `
+{
+  "_cmd": "wa b v 14, de p 4",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, de p 5 1`] = `
+{
+  "_cmd": "wa b v 14, de p 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, de p 6 1`] = `
+{
+  "_cmd": "wa b v 14, de p 6",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, de p 7 1`] = `
+{
+  "_cmd": "wa b v 14, de p 7",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, de p 8 1`] = `
+{
+  "_cmd": "wa b v 14, de p 8",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, de p 9 1`] = `
+{
+  "_cmd": "wa b v 14, de p 9",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de p 10 1`] = `
+{
+  "_cmd": "wa b v 14, de p 10",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, de p 11 1`] = `
+{
+  "_cmd": "wa b v 14, de p 11",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de p 12 1`] = `
+{
+  "_cmd": "wa b v 14, de p 12",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, de p 13 1`] = `
+{
+  "_cmd": "wa b v 14, de p 13",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de p 14 1`] = `
+{
+  "_cmd": "wa b v 14, de p 14",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de p 15 1`] = `
+{
+  "_cmd": "wa b v 14, de p 15",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 3",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 4",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 6",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 7",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 8",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 9",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 10",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 11",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 12",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 13",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 14",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 15",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 16",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 17",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 14, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 18",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 14, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 19",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 14, de p v 20",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 14, de v 1 1`] = `
+{
+  "_cmd": "wa b v 14, de v 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, de v 2 1`] = `
+{
+  "_cmd": "wa b v 14, de v 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, de v 3 1`] = `
+{
+  "_cmd": "wa b v 14, de v 3",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, de v 4 1`] = `
+{
+  "_cmd": "wa b v 14, de v 4",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, de v 5 1`] = `
+{
+  "_cmd": "wa b v 14, de v 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, de v 6 1`] = `
+{
+  "_cmd": "wa b v 14, de v 6",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, de v 7 1`] = `
+{
+  "_cmd": "wa b v 14, de v 7",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, de v 8 1`] = `
+{
+  "_cmd": "wa b v 14, de v 8",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, de v 9 1`] = `
+{
+  "_cmd": "wa b v 14, de v 9",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de v 10 1`] = `
+{
+  "_cmd": "wa b v 14, de v 10",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, de v 11 1`] = `
+{
+  "_cmd": "wa b v 14, de v 11",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de v 12 1`] = `
+{
+  "_cmd": "wa b v 14, de v 12",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de v 13 1`] = `
+{
+  "_cmd": "wa b v 14, de v 13",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de v 14 1`] = `
+{
+  "_cmd": "wa b v 14, de v 14",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de v 15 1`] = `
+{
+  "_cmd": "wa b v 14, de v 15",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de v 16 1`] = `
+{
+  "_cmd": "wa b v 14, de v 16",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, de v 17 1`] = `
+{
+  "_cmd": "wa b v 14, de v 17",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 14, de v 18 1`] = `
+{
+  "_cmd": "wa b v 14, de v 18",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, de v 19 1`] = `
+{
+  "_cmd": "wa b v 14, de v 19",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 14, de v 20 1`] = `
+{
+  "_cmd": "wa b v 14, de v 20",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 14, de w 1 1`] = `
+{
+  "_cmd": "wa b v 14, de w 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, de w 2 1`] = `
+{
+  "_cmd": "wa b v 14, de w 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, de w 3 1`] = `
+{
+  "_cmd": "wa b v 14, de w 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, de w 4 1`] = `
+{
+  "_cmd": "wa b v 14, de w 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, de w 5 1`] = `
+{
+  "_cmd": "wa b v 14, de w 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, de w 6 1`] = `
+{
+  "_cmd": "wa b v 14, de w 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de w 7 1`] = `
+{
+  "_cmd": "wa b v 14, de w 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de w 8 1`] = `
+{
+  "_cmd": "wa b v 14, de w 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, de w 9 1`] = `
+{
+  "_cmd": "wa b v 14, de w 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de w 10 1`] = `
+{
+  "_cmd": "wa b v 14, de w 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de w 11 1`] = `
+{
+  "_cmd": "wa b v 14, de w 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de w 12 1`] = `
+{
+  "_cmd": "wa b v 14, de w 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, de w 13 1`] = `
+{
+  "_cmd": "wa b v 14, de w 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 14, de w 14 1`] = `
+{
+  "_cmd": "wa b v 14, de w 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 14, de w 15 1`] = `
+{
+  "_cmd": "wa b v 14, de w 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 1",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 4",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 14, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 16",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 14, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 17",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 14, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 18",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 14, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 19",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 14, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 14, de w v 20",
+  "attacker": 3,
+  "defender": 18,
+}
+`;
+
+exports[`wa b v 15, de d 1 1`] = `
+{
+  "_cmd": "wa b v 15, de d 1",
+  "attacker": 15,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 15, de d 2 1`] = `
+{
+  "_cmd": "wa b v 15, de d 2",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, de d 3 1`] = `
+{
+  "_cmd": "wa b v 15, de d 3",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, de d 4 1`] = `
+{
+  "_cmd": "wa b v 15, de d 4",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de d 5 1`] = `
+{
+  "_cmd": "wa b v 15, de d 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, de d 6 1`] = `
+{
+  "_cmd": "wa b v 15, de d 6",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, de d 7 1`] = `
+{
+  "_cmd": "wa b v 15, de d 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, de d 8 1`] = `
+{
+  "_cmd": "wa b v 15, de d 8",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, de d 9 1`] = `
+{
+  "_cmd": "wa b v 15, de d 9",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de d 10 1`] = `
+{
+  "_cmd": "wa b v 15, de d 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de d 11 1`] = `
+{
+  "_cmd": "wa b v 15, de d 11",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, de d 12 1`] = `
+{
+  "_cmd": "wa b v 15, de d 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de d 13 1`] = `
+{
+  "_cmd": "wa b v 15, de d 13",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de d 14 1`] = `
+{
+  "_cmd": "wa b v 15, de d 14",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de d 15 1`] = `
+{
+  "_cmd": "wa b v 15, de d 15",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, de d v 1 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 1",
+  "attacker": 15,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 15, de d v 2 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de d v 3 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 3",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, de d v 4 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 4",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de d v 5 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 5",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, de d v 6 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 6",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, de d v 7 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 7",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, de d v 8 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 8",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, de d v 9 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 9",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, de d v 10 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 10",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de d v 11 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 11",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de d v 12 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 12",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de d v 13 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, de d v 14 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 14",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de d v 15 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 15",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de d v 16 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 16",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, de d v 17 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 17",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 15, de d v 18 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 18",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 15, de d v 19 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 19",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 15, de d v 20 1`] = `
+{
+  "_cmd": "wa b v 15, de d v 20",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 15, de p 1 1`] = `
+{
+  "_cmd": "wa b v 15, de p 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, de p 2 1`] = `
+{
+  "_cmd": "wa b v 15, de p 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de p 3 1`] = `
+{
+  "_cmd": "wa b v 15, de p 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, de p 4 1`] = `
+{
+  "_cmd": "wa b v 15, de p 4",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, de p 5 1`] = `
+{
+  "_cmd": "wa b v 15, de p 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de p 6 1`] = `
+{
+  "_cmd": "wa b v 15, de p 6",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, de p 7 1`] = `
+{
+  "_cmd": "wa b v 15, de p 7",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, de p 8 1`] = `
+{
+  "_cmd": "wa b v 15, de p 8",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, de p 9 1`] = `
+{
+  "_cmd": "wa b v 15, de p 9",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, de p 10 1`] = `
+{
+  "_cmd": "wa b v 15, de p 10",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, de p 11 1`] = `
+{
+  "_cmd": "wa b v 15, de p 11",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de p 12 1`] = `
+{
+  "_cmd": "wa b v 15, de p 12",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de p 13 1`] = `
+{
+  "_cmd": "wa b v 15, de p 13",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, de p 14 1`] = `
+{
+  "_cmd": "wa b v 15, de p 14",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, de p 15 1`] = `
+{
+  "_cmd": "wa b v 15, de p 15",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de p v 1 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, de p v 2 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de p v 3 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, de p v 4 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 4",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, de p v 5 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de p v 6 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 6",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, de p v 7 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 7",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, de p v 8 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 8",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, de p v 9 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 9",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, de p v 10 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 10",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, de p v 11 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 11",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, de p v 12 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 12",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de p v 13 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 13",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, de p v 14 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 14",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de p v 15 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 15",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, de p v 16 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 16",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de p v 17 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 17",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de p v 18 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 18",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 15, de p v 19 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 19",
+  "attacker": 9,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 15, de p v 20 1`] = `
+{
+  "_cmd": "wa b v 15, de p v 20",
+  "attacker": 9,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 15, de v 1 1`] = `
+{
+  "_cmd": "wa b v 15, de v 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, de v 2 1`] = `
+{
+  "_cmd": "wa b v 15, de v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de v 3 1`] = `
+{
+  "_cmd": "wa b v 15, de v 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, de v 4 1`] = `
+{
+  "_cmd": "wa b v 15, de v 4",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, de v 5 1`] = `
+{
+  "_cmd": "wa b v 15, de v 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de v 6 1`] = `
+{
+  "_cmd": "wa b v 15, de v 6",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, de v 7 1`] = `
+{
+  "_cmd": "wa b v 15, de v 7",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, de v 8 1`] = `
+{
+  "_cmd": "wa b v 15, de v 8",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, de v 9 1`] = `
+{
+  "_cmd": "wa b v 15, de v 9",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, de v 10 1`] = `
+{
+  "_cmd": "wa b v 15, de v 10",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, de v 11 1`] = `
+{
+  "_cmd": "wa b v 15, de v 11",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de v 12 1`] = `
+{
+  "_cmd": "wa b v 15, de v 12",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de v 13 1`] = `
+{
+  "_cmd": "wa b v 15, de v 13",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de v 14 1`] = `
+{
+  "_cmd": "wa b v 15, de v 14",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, de v 15 1`] = `
+{
+  "_cmd": "wa b v 15, de v 15",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de v 16 1`] = `
+{
+  "_cmd": "wa b v 15, de v 16",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de v 17 1`] = `
+{
+  "_cmd": "wa b v 15, de v 17",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, de v 18 1`] = `
+{
+  "_cmd": "wa b v 15, de v 18",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 15, de v 19 1`] = `
+{
+  "_cmd": "wa b v 15, de v 19",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 15, de v 20 1`] = `
+{
+  "_cmd": "wa b v 15, de v 20",
+  "attacker": 8,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 15, de w 1 1`] = `
+{
+  "_cmd": "wa b v 15, de w 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de w 2 1`] = `
+{
+  "_cmd": "wa b v 15, de w 2",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, de w 3 1`] = `
+{
+  "_cmd": "wa b v 15, de w 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, de w 4 1`] = `
+{
+  "_cmd": "wa b v 15, de w 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, de w 5 1`] = `
+{
+  "_cmd": "wa b v 15, de w 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, de w 6 1`] = `
+{
+  "_cmd": "wa b v 15, de w 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, de w 7 1`] = `
+{
+  "_cmd": "wa b v 15, de w 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de w 8 1`] = `
+{
+  "_cmd": "wa b v 15, de w 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de w 9 1`] = `
+{
+  "_cmd": "wa b v 15, de w 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, de w 10 1`] = `
+{
+  "_cmd": "wa b v 15, de w 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de w 11 1`] = `
+{
+  "_cmd": "wa b v 15, de w 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de w 12 1`] = `
+{
+  "_cmd": "wa b v 15, de w 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de w 13 1`] = `
+{
+  "_cmd": "wa b v 15, de w 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, de w 14 1`] = `
+{
+  "_cmd": "wa b v 15, de w 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 15, de w 15 1`] = `
+{
+  "_cmd": "wa b v 15, de w 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 15, de w v 1 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, de w v 2 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, de w v 3 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, de w v 4 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, de w v 5 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, de w v 6 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 6",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, de w v 7 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, de w v 8 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, de w v 9 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, de w v 10 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, de w v 11 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, de w v 12 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, de w v 13 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, de w v 14 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, de w v 15 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 15, de w v 16 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 15, de w v 17 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 17",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 15, de w v 18 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 18",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`wa b v 15, de w v 19 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 19",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`wa b v 15, de w v 20 1`] = `
+{
+  "_cmd": "wa b v 15, de w v 20",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 1, de d 1 1`] = `
+{
+  "_cmd": "wa v 1, de d 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 1, de d 2 1`] = `
+{
+  "_cmd": "wa v 1, de d 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, de d 3 1`] = `
+{
+  "_cmd": "wa v 1, de d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de d 4 1`] = `
+{
+  "_cmd": "wa v 1, de d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, de d 5 1`] = `
+{
+  "_cmd": "wa v 1, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de d 6 1`] = `
+{
+  "_cmd": "wa v 1, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de d 7 1`] = `
+{
+  "_cmd": "wa v 1, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de d 8 1`] = `
+{
+  "_cmd": "wa v 1, de d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de d 9 1`] = `
+{
+  "_cmd": "wa v 1, de d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de d 10 1`] = `
+{
+  "_cmd": "wa v 1, de d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de d 11 1`] = `
+{
+  "_cmd": "wa v 1, de d 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de d 12 1`] = `
+{
+  "_cmd": "wa v 1, de d 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de d 13 1`] = `
+{
+  "_cmd": "wa v 1, de d 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de d 14 1`] = `
+{
+  "_cmd": "wa v 1, de d 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de d 15 1`] = `
+{
+  "_cmd": "wa v 1, de d 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, de d v 1 1`] = `
+{
+  "_cmd": "wa v 1, de d v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 1, de d v 2 1`] = `
+{
+  "_cmd": "wa v 1, de d v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, de d v 3 1`] = `
+{
+  "_cmd": "wa v 1, de d v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de d v 4 1`] = `
+{
+  "_cmd": "wa v 1, de d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, de d v 5 1`] = `
+{
+  "_cmd": "wa v 1, de d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de d v 6 1`] = `
+{
+  "_cmd": "wa v 1, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de d v 7 1`] = `
+{
+  "_cmd": "wa v 1, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de d v 8 1`] = `
+{
+  "_cmd": "wa v 1, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de d v 9 1`] = `
+{
+  "_cmd": "wa v 1, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de d v 10 1`] = `
+{
+  "_cmd": "wa v 1, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de d v 11 1`] = `
+{
+  "_cmd": "wa v 1, de d v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de d v 12 1`] = `
+{
+  "_cmd": "wa v 1, de d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de d v 13 1`] = `
+{
+  "_cmd": "wa v 1, de d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de d v 14 1`] = `
+{
+  "_cmd": "wa v 1, de d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de d v 15 1`] = `
+{
+  "_cmd": "wa v 1, de d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, de d v 16 1`] = `
+{
+  "_cmd": "wa v 1, de d v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 1, de d v 17 1`] = `
+{
+  "_cmd": "wa v 1, de d v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 1, de d v 18 1`] = `
+{
+  "_cmd": "wa v 1, de d v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 1, de d v 19 1`] = `
+{
+  "_cmd": "wa v 1, de d v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 1, de d v 20 1`] = `
+{
+  "_cmd": "wa v 1, de d v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 1, de p 1 1`] = `
+{
+  "_cmd": "wa v 1, de p 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 1, de p 2 1`] = `
+{
+  "_cmd": "wa v 1, de p 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, de p 3 1`] = `
+{
+  "_cmd": "wa v 1, de p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, de p 4 1`] = `
+{
+  "_cmd": "wa v 1, de p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de p 5 1`] = `
+{
+  "_cmd": "wa v 1, de p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de p 6 1`] = `
+{
+  "_cmd": "wa v 1, de p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de p 7 1`] = `
+{
+  "_cmd": "wa v 1, de p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de p 8 1`] = `
+{
+  "_cmd": "wa v 1, de p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de p 9 1`] = `
+{
+  "_cmd": "wa v 1, de p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de p 10 1`] = `
+{
+  "_cmd": "wa v 1, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de p 11 1`] = `
+{
+  "_cmd": "wa v 1, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de p 12 1`] = `
+{
+  "_cmd": "wa v 1, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de p 13 1`] = `
+{
+  "_cmd": "wa v 1, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de p 14 1`] = `
+{
+  "_cmd": "wa v 1, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de p 15 1`] = `
+{
+  "_cmd": "wa v 1, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de p v 1 1`] = `
+{
+  "_cmd": "wa v 1, de p v 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 1, de p v 2 1`] = `
+{
+  "_cmd": "wa v 1, de p v 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, de p v 3 1`] = `
+{
+  "_cmd": "wa v 1, de p v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, de p v 4 1`] = `
+{
+  "_cmd": "wa v 1, de p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de p v 5 1`] = `
+{
+  "_cmd": "wa v 1, de p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, de p v 6 1`] = `
+{
+  "_cmd": "wa v 1, de p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de p v 7 1`] = `
+{
+  "_cmd": "wa v 1, de p v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de p v 8 1`] = `
+{
+  "_cmd": "wa v 1, de p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de p v 9 1`] = `
+{
+  "_cmd": "wa v 1, de p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de p v 10 1`] = `
+{
+  "_cmd": "wa v 1, de p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de p v 11 1`] = `
+{
+  "_cmd": "wa v 1, de p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de p v 12 1`] = `
+{
+  "_cmd": "wa v 1, de p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de p v 13 1`] = `
+{
+  "_cmd": "wa v 1, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de p v 14 1`] = `
+{
+  "_cmd": "wa v 1, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de p v 15 1`] = `
+{
+  "_cmd": "wa v 1, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de p v 16 1`] = `
+{
+  "_cmd": "wa v 1, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, de p v 17 1`] = `
+{
+  "_cmd": "wa v 1, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 1, de p v 18 1`] = `
+{
+  "_cmd": "wa v 1, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 1, de p v 19 1`] = `
+{
+  "_cmd": "wa v 1, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 1, de p v 20 1`] = `
+{
+  "_cmd": "wa v 1, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 1, de v 1 1`] = `
+{
+  "_cmd": "wa v 1, de v 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 1, de v 2 1`] = `
+{
+  "_cmd": "wa v 1, de v 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, de v 3 1`] = `
+{
+  "_cmd": "wa v 1, de v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, de v 4 1`] = `
+{
+  "_cmd": "wa v 1, de v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de v 5 1`] = `
+{
+  "_cmd": "wa v 1, de v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de v 6 1`] = `
+{
+  "_cmd": "wa v 1, de v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de v 7 1`] = `
+{
+  "_cmd": "wa v 1, de v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de v 8 1`] = `
+{
+  "_cmd": "wa v 1, de v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de v 9 1`] = `
+{
+  "_cmd": "wa v 1, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de v 10 1`] = `
+{
+  "_cmd": "wa v 1, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de v 11 1`] = `
+{
+  "_cmd": "wa v 1, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de v 12 1`] = `
+{
+  "_cmd": "wa v 1, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de v 13 1`] = `
+{
+  "_cmd": "wa v 1, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de v 14 1`] = `
+{
+  "_cmd": "wa v 1, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de v 15 1`] = `
+{
+  "_cmd": "wa v 1, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de v 16 1`] = `
+{
+  "_cmd": "wa v 1, de v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 1, de v 17 1`] = `
+{
+  "_cmd": "wa v 1, de v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 1, de v 18 1`] = `
+{
+  "_cmd": "wa v 1, de v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 1, de v 19 1`] = `
+{
+  "_cmd": "wa v 1, de v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 1, de v 20 1`] = `
+{
+  "_cmd": "wa v 1, de v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 1, de w 1 1`] = `
+{
+  "_cmd": "wa v 1, de w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, de w 2 1`] = `
+{
+  "_cmd": "wa v 1, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, de w 3 1`] = `
+{
+  "_cmd": "wa v 1, de w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, de w 4 1`] = `
+{
+  "_cmd": "wa v 1, de w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de w 5 1`] = `
+{
+  "_cmd": "wa v 1, de w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de w 6 1`] = `
+{
+  "_cmd": "wa v 1, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de w 7 1`] = `
+{
+  "_cmd": "wa v 1, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de w 8 1`] = `
+{
+  "_cmd": "wa v 1, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de w 9 1`] = `
+{
+  "_cmd": "wa v 1, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de w 10 1`] = `
+{
+  "_cmd": "wa v 1, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de w 11 1`] = `
+{
+  "_cmd": "wa v 1, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de w 12 1`] = `
+{
+  "_cmd": "wa v 1, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de w 13 1`] = `
+{
+  "_cmd": "wa v 1, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de w 14 1`] = `
+{
+  "_cmd": "wa v 1, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de w 15 1`] = `
+{
+  "_cmd": "wa v 1, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, de w v 1 1`] = `
+{
+  "_cmd": "wa v 1, de w v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, de w v 2 1`] = `
+{
+  "_cmd": "wa v 1, de w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, de w v 3 1`] = `
+{
+  "_cmd": "wa v 1, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, de w v 4 1`] = `
+{
+  "_cmd": "wa v 1, de w v 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, de w v 5 1`] = `
+{
+  "_cmd": "wa v 1, de w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, de w v 6 1`] = `
+{
+  "_cmd": "wa v 1, de w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, de w v 7 1`] = `
+{
+  "_cmd": "wa v 1, de w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, de w v 8 1`] = `
+{
+  "_cmd": "wa v 1, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, de w v 9 1`] = `
+{
+  "_cmd": "wa v 1, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, de w v 10 1`] = `
+{
+  "_cmd": "wa v 1, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, de w v 11 1`] = `
+{
+  "_cmd": "wa v 1, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, de w v 12 1`] = `
+{
+  "_cmd": "wa v 1, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, de w v 13 1`] = `
+{
+  "_cmd": "wa v 1, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, de w v 14 1`] = `
+{
+  "_cmd": "wa v 1, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, de w v 15 1`] = `
+{
+  "_cmd": "wa v 1, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, de w v 16 1`] = `
+{
+  "_cmd": "wa v 1, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 1, de w v 17 1`] = `
+{
+  "_cmd": "wa v 1, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 1, de w v 18 1`] = `
+{
+  "_cmd": "wa v 1, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 1, de w v 19 1`] = `
+{
+  "_cmd": "wa v 1, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 1, de w v 20 1`] = `
+{
+  "_cmd": "wa v 1, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 2, de d 1 1`] = `
+{
+  "_cmd": "wa v 2, de d 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 2, de d 2 1`] = `
+{
+  "_cmd": "wa v 2, de d 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, de d 3 1`] = `
+{
+  "_cmd": "wa v 2, de d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, de d 4 1`] = `
+{
+  "_cmd": "wa v 2, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, de d 5 1`] = `
+{
+  "_cmd": "wa v 2, de d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, de d 6 1`] = `
+{
+  "_cmd": "wa v 2, de d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de d 7 1`] = `
+{
+  "_cmd": "wa v 2, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de d 8 1`] = `
+{
+  "_cmd": "wa v 2, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, de d 9 1`] = `
+{
+  "_cmd": "wa v 2, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de d 10 1`] = `
+{
+  "_cmd": "wa v 2, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de d 11 1`] = `
+{
+  "_cmd": "wa v 2, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de d 12 1`] = `
+{
+  "_cmd": "wa v 2, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de d 13 1`] = `
+{
+  "_cmd": "wa v 2, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de d 14 1`] = `
+{
+  "_cmd": "wa v 2, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de d 15 1`] = `
+{
+  "_cmd": "wa v 2, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de d v 1 1`] = `
+{
+  "_cmd": "wa v 2, de d v 1",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 2, de d v 2 1`] = `
+{
+  "_cmd": "wa v 2, de d v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, de d v 3 1`] = `
+{
+  "_cmd": "wa v 2, de d v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, de d v 4 1`] = `
+{
+  "_cmd": "wa v 2, de d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, de d v 5 1`] = `
+{
+  "_cmd": "wa v 2, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de d v 6 1`] = `
+{
+  "_cmd": "wa v 2, de d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de d v 7 1`] = `
+{
+  "_cmd": "wa v 2, de d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de d v 8 1`] = `
+{
+  "_cmd": "wa v 2, de d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, de d v 9 1`] = `
+{
+  "_cmd": "wa v 2, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de d v 10 1`] = `
+{
+  "_cmd": "wa v 2, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de d v 11 1`] = `
+{
+  "_cmd": "wa v 2, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de d v 12 1`] = `
+{
+  "_cmd": "wa v 2, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de d v 13 1`] = `
+{
+  "_cmd": "wa v 2, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de d v 14 1`] = `
+{
+  "_cmd": "wa v 2, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de d v 15 1`] = `
+{
+  "_cmd": "wa v 2, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de d v 16 1`] = `
+{
+  "_cmd": "wa v 2, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, de d v 17 1`] = `
+{
+  "_cmd": "wa v 2, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 2, de d v 18 1`] = `
+{
+  "_cmd": "wa v 2, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 2, de d v 19 1`] = `
+{
+  "_cmd": "wa v 2, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 2, de d v 20 1`] = `
+{
+  "_cmd": "wa v 2, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 2, de p 1 1`] = `
+{
+  "_cmd": "wa v 2, de p 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 2, de p 2 1`] = `
+{
+  "_cmd": "wa v 2, de p 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, de p 3 1`] = `
+{
+  "_cmd": "wa v 2, de p 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, de p 4 1`] = `
+{
+  "_cmd": "wa v 2, de p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, de p 5 1`] = `
+{
+  "_cmd": "wa v 2, de p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de p 6 1`] = `
+{
+  "_cmd": "wa v 2, de p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, de p 7 1`] = `
+{
+  "_cmd": "wa v 2, de p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de p 8 1`] = `
+{
+  "_cmd": "wa v 2, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de p 9 1`] = `
+{
+  "_cmd": "wa v 2, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, de p 10 1`] = `
+{
+  "_cmd": "wa v 2, de p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de p 11 1`] = `
+{
+  "_cmd": "wa v 2, de p 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de p 12 1`] = `
+{
+  "_cmd": "wa v 2, de p 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de p 13 1`] = `
+{
+  "_cmd": "wa v 2, de p 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de p 14 1`] = `
+{
+  "_cmd": "wa v 2, de p 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de p 15 1`] = `
+{
+  "_cmd": "wa v 2, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de p v 1 1`] = `
+{
+  "_cmd": "wa v 2, de p v 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 2, de p v 2 1`] = `
+{
+  "_cmd": "wa v 2, de p v 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 2, de p v 3 1`] = `
+{
+  "_cmd": "wa v 2, de p v 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, de p v 4 1`] = `
+{
+  "_cmd": "wa v 2, de p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, de p v 5 1`] = `
+{
+  "_cmd": "wa v 2, de p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, de p v 6 1`] = `
+{
+  "_cmd": "wa v 2, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de p v 7 1`] = `
+{
+  "_cmd": "wa v 2, de p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de p v 8 1`] = `
+{
+  "_cmd": "wa v 2, de p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de p v 9 1`] = `
+{
+  "_cmd": "wa v 2, de p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, de p v 10 1`] = `
+{
+  "_cmd": "wa v 2, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de p v 11 1`] = `
+{
+  "_cmd": "wa v 2, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de p v 12 1`] = `
+{
+  "_cmd": "wa v 2, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de p v 13 1`] = `
+{
+  "_cmd": "wa v 2, de p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de p v 14 1`] = `
+{
+  "_cmd": "wa v 2, de p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de p v 15 1`] = `
+{
+  "_cmd": "wa v 2, de p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de p v 16 1`] = `
+{
+  "_cmd": "wa v 2, de p v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, de p v 17 1`] = `
+{
+  "_cmd": "wa v 2, de p v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 2, de p v 18 1`] = `
+{
+  "_cmd": "wa v 2, de p v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 2, de p v 19 1`] = `
+{
+  "_cmd": "wa v 2, de p v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 2, de p v 20 1`] = `
+{
+  "_cmd": "wa v 2, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 2, de v 1 1`] = `
+{
+  "_cmd": "wa v 2, de v 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 2, de v 2 1`] = `
+{
+  "_cmd": "wa v 2, de v 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, de v 3 1`] = `
+{
+  "_cmd": "wa v 2, de v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, de v 4 1`] = `
+{
+  "_cmd": "wa v 2, de v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, de v 5 1`] = `
+{
+  "_cmd": "wa v 2, de v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de v 6 1`] = `
+{
+  "_cmd": "wa v 2, de v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, de v 7 1`] = `
+{
+  "_cmd": "wa v 2, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de v 8 1`] = `
+{
+  "_cmd": "wa v 2, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de v 9 1`] = `
+{
+  "_cmd": "wa v 2, de v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de v 10 1`] = `
+{
+  "_cmd": "wa v 2, de v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de v 11 1`] = `
+{
+  "_cmd": "wa v 2, de v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de v 12 1`] = `
+{
+  "_cmd": "wa v 2, de v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de v 13 1`] = `
+{
+  "_cmd": "wa v 2, de v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de v 14 1`] = `
+{
+  "_cmd": "wa v 2, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de v 15 1`] = `
+{
+  "_cmd": "wa v 2, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de v 16 1`] = `
+{
+  "_cmd": "wa v 2, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, de v 17 1`] = `
+{
+  "_cmd": "wa v 2, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 2, de v 18 1`] = `
+{
+  "_cmd": "wa v 2, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 2, de v 19 1`] = `
+{
+  "_cmd": "wa v 2, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 2, de v 20 1`] = `
+{
+  "_cmd": "wa v 2, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 2, de w 1 1`] = `
+{
+  "_cmd": "wa v 2, de w 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, de w 2 1`] = `
+{
+  "_cmd": "wa v 2, de w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, de w 3 1`] = `
+{
+  "_cmd": "wa v 2, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, de w 4 1`] = `
+{
+  "_cmd": "wa v 2, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de w 5 1`] = `
+{
+  "_cmd": "wa v 2, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, de w 6 1`] = `
+{
+  "_cmd": "wa v 2, de w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de w 7 1`] = `
+{
+  "_cmd": "wa v 2, de w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, de w 8 1`] = `
+{
+  "_cmd": "wa v 2, de w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de w 9 1`] = `
+{
+  "_cmd": "wa v 2, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de w 10 1`] = `
+{
+  "_cmd": "wa v 2, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de w 11 1`] = `
+{
+  "_cmd": "wa v 2, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de w 12 1`] = `
+{
+  "_cmd": "wa v 2, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de w 13 1`] = `
+{
+  "_cmd": "wa v 2, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de w 14 1`] = `
+{
+  "_cmd": "wa v 2, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de w 15 1`] = `
+{
+  "_cmd": "wa v 2, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, de w v 1 1`] = `
+{
+  "_cmd": "wa v 2, de w v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, de w v 2 1`] = `
+{
+  "_cmd": "wa v 2, de w v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, de w v 3 1`] = `
+{
+  "_cmd": "wa v 2, de w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, de w v 4 1`] = `
+{
+  "_cmd": "wa v 2, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, de w v 5 1`] = `
+{
+  "_cmd": "wa v 2, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, de w v 6 1`] = `
+{
+  "_cmd": "wa v 2, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, de w v 7 1`] = `
+{
+  "_cmd": "wa v 2, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, de w v 8 1`] = `
+{
+  "_cmd": "wa v 2, de w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, de w v 9 1`] = `
+{
+  "_cmd": "wa v 2, de w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, de w v 10 1`] = `
+{
+  "_cmd": "wa v 2, de w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, de w v 11 1`] = `
+{
+  "_cmd": "wa v 2, de w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, de w v 12 1`] = `
+{
+  "_cmd": "wa v 2, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, de w v 13 1`] = `
+{
+  "_cmd": "wa v 2, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, de w v 14 1`] = `
+{
+  "_cmd": "wa v 2, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, de w v 15 1`] = `
+{
+  "_cmd": "wa v 2, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, de w v 16 1`] = `
+{
+  "_cmd": "wa v 2, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 2, de w v 17 1`] = `
+{
+  "_cmd": "wa v 2, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 2, de w v 18 1`] = `
+{
+  "_cmd": "wa v 2, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 2, de w v 19 1`] = `
+{
+  "_cmd": "wa v 2, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 2, de w v 20 1`] = `
+{
+  "_cmd": "wa v 2, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 3, de d 1 1`] = `
+{
+  "_cmd": "wa v 3, de d 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 3, de d 2 1`] = `
+{
+  "_cmd": "wa v 3, de d 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, de d 3 1`] = `
+{
+  "_cmd": "wa v 3, de d 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de d 4 1`] = `
+{
+  "_cmd": "wa v 3, de d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, de d 5 1`] = `
+{
+  "_cmd": "wa v 3, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de d 6 1`] = `
+{
+  "_cmd": "wa v 3, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de d 7 1`] = `
+{
+  "_cmd": "wa v 3, de d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de d 8 1`] = `
+{
+  "_cmd": "wa v 3, de d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, de d 9 1`] = `
+{
+  "_cmd": "wa v 3, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de d 10 1`] = `
+{
+  "_cmd": "wa v 3, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de d 11 1`] = `
+{
+  "_cmd": "wa v 3, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de d 12 1`] = `
+{
+  "_cmd": "wa v 3, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de d 13 1`] = `
+{
+  "_cmd": "wa v 3, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de d 14 1`] = `
+{
+  "_cmd": "wa v 3, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de d 15 1`] = `
+{
+  "_cmd": "wa v 3, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de d v 1 1`] = `
+{
+  "_cmd": "wa v 3, de d v 1",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 3, de d v 2 1`] = `
+{
+  "_cmd": "wa v 3, de d v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, de d v 3 1`] = `
+{
+  "_cmd": "wa v 3, de d v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de d v 4 1`] = `
+{
+  "_cmd": "wa v 3, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, de d v 5 1`] = `
+{
+  "_cmd": "wa v 3, de d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de d v 6 1`] = `
+{
+  "_cmd": "wa v 3, de d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de d v 7 1`] = `
+{
+  "_cmd": "wa v 3, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, de d v 8 1`] = `
+{
+  "_cmd": "wa v 3, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de d v 9 1`] = `
+{
+  "_cmd": "wa v 3, de d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de d v 10 1`] = `
+{
+  "_cmd": "wa v 3, de d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de d v 11 1`] = `
+{
+  "_cmd": "wa v 3, de d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de d v 12 1`] = `
+{
+  "_cmd": "wa v 3, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de d v 13 1`] = `
+{
+  "_cmd": "wa v 3, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de d v 14 1`] = `
+{
+  "_cmd": "wa v 3, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de d v 15 1`] = `
+{
+  "_cmd": "wa v 3, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de d v 16 1`] = `
+{
+  "_cmd": "wa v 3, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, de d v 17 1`] = `
+{
+  "_cmd": "wa v 3, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 3, de d v 18 1`] = `
+{
+  "_cmd": "wa v 3, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 3, de d v 19 1`] = `
+{
+  "_cmd": "wa v 3, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 3, de d v 20 1`] = `
+{
+  "_cmd": "wa v 3, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 3, de p 1 1`] = `
+{
+  "_cmd": "wa v 3, de p 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, de p 2 1`] = `
+{
+  "_cmd": "wa v 3, de p 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, de p 3 1`] = `
+{
+  "_cmd": "wa v 3, de p 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 3, de p 4 1`] = `
+{
+  "_cmd": "wa v 3, de p 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de p 5 1`] = `
+{
+  "_cmd": "wa v 3, de p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, de p 6 1`] = `
+{
+  "_cmd": "wa v 3, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de p 7 1`] = `
+{
+  "_cmd": "wa v 3, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de p 8 1`] = `
+{
+  "_cmd": "wa v 3, de p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de p 9 1`] = `
+{
+  "_cmd": "wa v 3, de p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, de p 10 1`] = `
+{
+  "_cmd": "wa v 3, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de p 11 1`] = `
+{
+  "_cmd": "wa v 3, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de p 12 1`] = `
+{
+  "_cmd": "wa v 3, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de p 13 1`] = `
+{
+  "_cmd": "wa v 3, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de p 14 1`] = `
+{
+  "_cmd": "wa v 3, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de p 15 1`] = `
+{
+  "_cmd": "wa v 3, de p 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de p v 1 1`] = `
+{
+  "_cmd": "wa v 3, de p v 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, de p v 2 1`] = `
+{
+  "_cmd": "wa v 3, de p v 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 3, de p v 3 1`] = `
+{
+  "_cmd": "wa v 3, de p v 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, de p v 4 1`] = `
+{
+  "_cmd": "wa v 3, de p v 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de p v 5 1`] = `
+{
+  "_cmd": "wa v 3, de p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, de p v 6 1`] = `
+{
+  "_cmd": "wa v 3, de p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de p v 7 1`] = `
+{
+  "_cmd": "wa v 3, de p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de p v 8 1`] = `
+{
+  "_cmd": "wa v 3, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, de p v 9 1`] = `
+{
+  "_cmd": "wa v 3, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de p v 10 1`] = `
+{
+  "_cmd": "wa v 3, de p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de p v 11 1`] = `
+{
+  "_cmd": "wa v 3, de p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de p v 12 1`] = `
+{
+  "_cmd": "wa v 3, de p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de p v 13 1`] = `
+{
+  "_cmd": "wa v 3, de p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de p v 14 1`] = `
+{
+  "_cmd": "wa v 3, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de p v 15 1`] = `
+{
+  "_cmd": "wa v 3, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de p v 16 1`] = `
+{
+  "_cmd": "wa v 3, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de p v 17 1`] = `
+{
+  "_cmd": "wa v 3, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, de p v 18 1`] = `
+{
+  "_cmd": "wa v 3, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 3, de p v 19 1`] = `
+{
+  "_cmd": "wa v 3, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 3, de p v 20 1`] = `
+{
+  "_cmd": "wa v 3, de p v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 3, de v 1 1`] = `
+{
+  "_cmd": "wa v 3, de v 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, de v 2 1`] = `
+{
+  "_cmd": "wa v 3, de v 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, de v 3 1`] = `
+{
+  "_cmd": "wa v 3, de v 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 3, de v 4 1`] = `
+{
+  "_cmd": "wa v 3, de v 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de v 5 1`] = `
+{
+  "_cmd": "wa v 3, de v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, de v 6 1`] = `
+{
+  "_cmd": "wa v 3, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de v 7 1`] = `
+{
+  "_cmd": "wa v 3, de v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, de v 8 1`] = `
+{
+  "_cmd": "wa v 3, de v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de v 9 1`] = `
+{
+  "_cmd": "wa v 3, de v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, de v 10 1`] = `
+{
+  "_cmd": "wa v 3, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de v 11 1`] = `
+{
+  "_cmd": "wa v 3, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de v 12 1`] = `
+{
+  "_cmd": "wa v 3, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de v 13 1`] = `
+{
+  "_cmd": "wa v 3, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de v 14 1`] = `
+{
+  "_cmd": "wa v 3, de v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de v 15 1`] = `
+{
+  "_cmd": "wa v 3, de v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de v 16 1`] = `
+{
+  "_cmd": "wa v 3, de v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, de v 17 1`] = `
+{
+  "_cmd": "wa v 3, de v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 3, de v 18 1`] = `
+{
+  "_cmd": "wa v 3, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 3, de v 19 1`] = `
+{
+  "_cmd": "wa v 3, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 3, de v 20 1`] = `
+{
+  "_cmd": "wa v 3, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 3, de w 1 1`] = `
+{
+  "_cmd": "wa v 3, de w 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, de w 2 1`] = `
+{
+  "_cmd": "wa v 3, de w 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de w 3 1`] = `
+{
+  "_cmd": "wa v 3, de w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, de w 4 1`] = `
+{
+  "_cmd": "wa v 3, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de w 5 1`] = `
+{
+  "_cmd": "wa v 3, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de w 6 1`] = `
+{
+  "_cmd": "wa v 3, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, de w 7 1`] = `
+{
+  "_cmd": "wa v 3, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de w 8 1`] = `
+{
+  "_cmd": "wa v 3, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, de w 9 1`] = `
+{
+  "_cmd": "wa v 3, de w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de w 10 1`] = `
+{
+  "_cmd": "wa v 3, de w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de w 11 1`] = `
+{
+  "_cmd": "wa v 3, de w 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, de w 12 1`] = `
+{
+  "_cmd": "wa v 3, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de w 13 1`] = `
+{
+  "_cmd": "wa v 3, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de w 14 1`] = `
+{
+  "_cmd": "wa v 3, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de w 15 1`] = `
+{
+  "_cmd": "wa v 3, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, de w v 1 1`] = `
+{
+  "_cmd": "wa v 3, de w v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, de w v 2 1`] = `
+{
+  "_cmd": "wa v 3, de w v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, de w v 3 1`] = `
+{
+  "_cmd": "wa v 3, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, de w v 4 1`] = `
+{
+  "_cmd": "wa v 3, de w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, de w v 5 1`] = `
+{
+  "_cmd": "wa v 3, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, de w v 6 1`] = `
+{
+  "_cmd": "wa v 3, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, de w v 7 1`] = `
+{
+  "_cmd": "wa v 3, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, de w v 8 1`] = `
+{
+  "_cmd": "wa v 3, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, de w v 9 1`] = `
+{
+  "_cmd": "wa v 3, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, de w v 10 1`] = `
+{
+  "_cmd": "wa v 3, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, de w v 11 1`] = `
+{
+  "_cmd": "wa v 3, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, de w v 12 1`] = `
+{
+  "_cmd": "wa v 3, de w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, de w v 13 1`] = `
+{
+  "_cmd": "wa v 3, de w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, de w v 14 1`] = `
+{
+  "_cmd": "wa v 3, de w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, de w v 15 1`] = `
+{
+  "_cmd": "wa v 3, de w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, de w v 16 1`] = `
+{
+  "_cmd": "wa v 3, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 3, de w v 17 1`] = `
+{
+  "_cmd": "wa v 3, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 3, de w v 18 1`] = `
+{
+  "_cmd": "wa v 3, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 3, de w v 19 1`] = `
+{
+  "_cmd": "wa v 3, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 3, de w v 20 1`] = `
+{
+  "_cmd": "wa v 3, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 4, de d 1 1`] = `
+{
+  "_cmd": "wa v 4, de d 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 4, de d 2 1`] = `
+{
+  "_cmd": "wa v 4, de d 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, de d 3 1`] = `
+{
+  "_cmd": "wa v 4, de d 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, de d 4 1`] = `
+{
+  "_cmd": "wa v 4, de d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de d 5 1`] = `
+{
+  "_cmd": "wa v 4, de d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de d 6 1`] = `
+{
+  "_cmd": "wa v 4, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, de d 7 1`] = `
+{
+  "_cmd": "wa v 4, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de d 8 1`] = `
+{
+  "_cmd": "wa v 4, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de d 9 1`] = `
+{
+  "_cmd": "wa v 4, de d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de d 10 1`] = `
+{
+  "_cmd": "wa v 4, de d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de d 11 1`] = `
+{
+  "_cmd": "wa v 4, de d 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de d 12 1`] = `
+{
+  "_cmd": "wa v 4, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, de d 13 1`] = `
+{
+  "_cmd": "wa v 4, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de d 14 1`] = `
+{
+  "_cmd": "wa v 4, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de d 15 1`] = `
+{
+  "_cmd": "wa v 4, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de d v 1 1`] = `
+{
+  "_cmd": "wa v 4, de d v 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 4, de d v 2 1`] = `
+{
+  "_cmd": "wa v 4, de d v 2",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, de d v 3 1`] = `
+{
+  "_cmd": "wa v 4, de d v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, de d v 4 1`] = `
+{
+  "_cmd": "wa v 4, de d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de d v 5 1`] = `
+{
+  "_cmd": "wa v 4, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, de d v 6 1`] = `
+{
+  "_cmd": "wa v 4, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de d v 7 1`] = `
+{
+  "_cmd": "wa v 4, de d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de d v 8 1`] = `
+{
+  "_cmd": "wa v 4, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de d v 9 1`] = `
+{
+  "_cmd": "wa v 4, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, de d v 10 1`] = `
+{
+  "_cmd": "wa v 4, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de d v 11 1`] = `
+{
+  "_cmd": "wa v 4, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de d v 12 1`] = `
+{
+  "_cmd": "wa v 4, de d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, de d v 13 1`] = `
+{
+  "_cmd": "wa v 4, de d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de d v 14 1`] = `
+{
+  "_cmd": "wa v 4, de d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de d v 15 1`] = `
+{
+  "_cmd": "wa v 4, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de d v 16 1`] = `
+{
+  "_cmd": "wa v 4, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 4, de d v 17 1`] = `
+{
+  "_cmd": "wa v 4, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 4, de d v 18 1`] = `
+{
+  "_cmd": "wa v 4, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 4, de d v 19 1`] = `
+{
+  "_cmd": "wa v 4, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 4, de d v 20 1`] = `
+{
+  "_cmd": "wa v 4, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 4, de p 1 1`] = `
+{
+  "_cmd": "wa v 4, de p 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 4, de p 2 1`] = `
+{
+  "_cmd": "wa v 4, de p 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, de p 3 1`] = `
+{
+  "_cmd": "wa v 4, de p 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, de p 4 1`] = `
+{
+  "_cmd": "wa v 4, de p 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, de p 5 1`] = `
+{
+  "_cmd": "wa v 4, de p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de p 6 1`] = `
+{
+  "_cmd": "wa v 4, de p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de p 7 1`] = `
+{
+  "_cmd": "wa v 4, de p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, de p 8 1`] = `
+{
+  "_cmd": "wa v 4, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de p 9 1`] = `
+{
+  "_cmd": "wa v 4, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de p 10 1`] = `
+{
+  "_cmd": "wa v 4, de p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de p 11 1`] = `
+{
+  "_cmd": "wa v 4, de p 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de p 12 1`] = `
+{
+  "_cmd": "wa v 4, de p 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de p 13 1`] = `
+{
+  "_cmd": "wa v 4, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, de p 14 1`] = `
+{
+  "_cmd": "wa v 4, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de p 15 1`] = `
+{
+  "_cmd": "wa v 4, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de p v 1 1`] = `
+{
+  "_cmd": "wa v 4, de p v 1",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 4, de p v 2 1`] = `
+{
+  "_cmd": "wa v 4, de p v 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, de p v 3 1`] = `
+{
+  "_cmd": "wa v 4, de p v 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, de p v 4 1`] = `
+{
+  "_cmd": "wa v 4, de p v 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, de p v 5 1`] = `
+{
+  "_cmd": "wa v 4, de p v 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, de p v 6 1`] = `
+{
+  "_cmd": "wa v 4, de p v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, de p v 7 1`] = `
+{
+  "_cmd": "wa v 4, de p v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de p v 8 1`] = `
+{
+  "_cmd": "wa v 4, de p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de p v 9 1`] = `
+{
+  "_cmd": "wa v 4, de p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de p v 10 1`] = `
+{
+  "_cmd": "wa v 4, de p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, de p v 11 1`] = `
+{
+  "_cmd": "wa v 4, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de p v 12 1`] = `
+{
+  "_cmd": "wa v 4, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de p v 13 1`] = `
+{
+  "_cmd": "wa v 4, de p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de p v 14 1`] = `
+{
+  "_cmd": "wa v 4, de p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de p v 15 1`] = `
+{
+  "_cmd": "wa v 4, de p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de p v 16 1`] = `
+{
+  "_cmd": "wa v 4, de p v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de p v 17 1`] = `
+{
+  "_cmd": "wa v 4, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 4, de p v 18 1`] = `
+{
+  "_cmd": "wa v 4, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 4, de p v 19 1`] = `
+{
+  "_cmd": "wa v 4, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 4, de p v 20 1`] = `
+{
+  "_cmd": "wa v 4, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 4, de v 1 1`] = `
+{
+  "_cmd": "wa v 4, de v 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 4, de v 2 1`] = `
+{
+  "_cmd": "wa v 4, de v 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, de v 3 1`] = `
+{
+  "_cmd": "wa v 4, de v 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, de v 4 1`] = `
+{
+  "_cmd": "wa v 4, de v 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, de v 5 1`] = `
+{
+  "_cmd": "wa v 4, de v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de v 6 1`] = `
+{
+  "_cmd": "wa v 4, de v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de v 7 1`] = `
+{
+  "_cmd": "wa v 4, de v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, de v 8 1`] = `
+{
+  "_cmd": "wa v 4, de v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de v 9 1`] = `
+{
+  "_cmd": "wa v 4, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de v 10 1`] = `
+{
+  "_cmd": "wa v 4, de v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de v 11 1`] = `
+{
+  "_cmd": "wa v 4, de v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de v 12 1`] = `
+{
+  "_cmd": "wa v 4, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de v 13 1`] = `
+{
+  "_cmd": "wa v 4, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, de v 14 1`] = `
+{
+  "_cmd": "wa v 4, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de v 15 1`] = `
+{
+  "_cmd": "wa v 4, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de v 16 1`] = `
+{
+  "_cmd": "wa v 4, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de v 17 1`] = `
+{
+  "_cmd": "wa v 4, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 4, de v 18 1`] = `
+{
+  "_cmd": "wa v 4, de v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 4, de v 19 1`] = `
+{
+  "_cmd": "wa v 4, de v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 4, de v 20 1`] = `
+{
+  "_cmd": "wa v 4, de v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 4, de w 1 1`] = `
+{
+  "_cmd": "wa v 4, de w 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, de w 2 1`] = `
+{
+  "_cmd": "wa v 4, de w 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, de w 3 1`] = `
+{
+  "_cmd": "wa v 4, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de w 4 1`] = `
+{
+  "_cmd": "wa v 4, de w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, de w 5 1`] = `
+{
+  "_cmd": "wa v 4, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, de w 6 1`] = `
+{
+  "_cmd": "wa v 4, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de w 7 1`] = `
+{
+  "_cmd": "wa v 4, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de w 8 1`] = `
+{
+  "_cmd": "wa v 4, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, de w 9 1`] = `
+{
+  "_cmd": "wa v 4, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de w 10 1`] = `
+{
+  "_cmd": "wa v 4, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de w 11 1`] = `
+{
+  "_cmd": "wa v 4, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de w 12 1`] = `
+{
+  "_cmd": "wa v 4, de w 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de w 13 1`] = `
+{
+  "_cmd": "wa v 4, de w 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de w 14 1`] = `
+{
+  "_cmd": "wa v 4, de w 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de w 15 1`] = `
+{
+  "_cmd": "wa v 4, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 4, de w v 1 1`] = `
+{
+  "_cmd": "wa v 4, de w v 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, de w v 2 1`] = `
+{
+  "_cmd": "wa v 4, de w v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, de w v 3 1`] = `
+{
+  "_cmd": "wa v 4, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, de w v 4 1`] = `
+{
+  "_cmd": "wa v 4, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, de w v 5 1`] = `
+{
+  "_cmd": "wa v 4, de w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, de w v 6 1`] = `
+{
+  "_cmd": "wa v 4, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, de w v 7 1`] = `
+{
+  "_cmd": "wa v 4, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, de w v 8 1`] = `
+{
+  "_cmd": "wa v 4, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, de w v 9 1`] = `
+{
+  "_cmd": "wa v 4, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, de w v 10 1`] = `
+{
+  "_cmd": "wa v 4, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, de w v 11 1`] = `
+{
+  "_cmd": "wa v 4, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, de w v 12 1`] = `
+{
+  "_cmd": "wa v 4, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, de w v 13 1`] = `
+{
+  "_cmd": "wa v 4, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, de w v 14 1`] = `
+{
+  "_cmd": "wa v 4, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, de w v 15 1`] = `
+{
+  "_cmd": "wa v 4, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, de w v 16 1`] = `
+{
+  "_cmd": "wa v 4, de w v 16",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 4, de w v 17 1`] = `
+{
+  "_cmd": "wa v 4, de w v 17",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 4, de w v 18 1`] = `
+{
+  "_cmd": "wa v 4, de w v 18",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 4, de w v 19 1`] = `
+{
+  "_cmd": "wa v 4, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 4, de w v 20 1`] = `
+{
+  "_cmd": "wa v 4, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 5, de d 1 1`] = `
+{
+  "_cmd": "wa v 5, de d 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 5, de d 2 1`] = `
+{
+  "_cmd": "wa v 5, de d 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, de d 3 1`] = `
+{
+  "_cmd": "wa v 5, de d 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de d 4 1`] = `
+{
+  "_cmd": "wa v 5, de d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de d 5 1`] = `
+{
+  "_cmd": "wa v 5, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de d 6 1`] = `
+{
+  "_cmd": "wa v 5, de d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, de d 7 1`] = `
+{
+  "_cmd": "wa v 5, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de d 8 1`] = `
+{
+  "_cmd": "wa v 5, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de d 9 1`] = `
+{
+  "_cmd": "wa v 5, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de d 10 1`] = `
+{
+  "_cmd": "wa v 5, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de d 11 1`] = `
+{
+  "_cmd": "wa v 5, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de d 12 1`] = `
+{
+  "_cmd": "wa v 5, de d 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de d 13 1`] = `
+{
+  "_cmd": "wa v 5, de d 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de d 14 1`] = `
+{
+  "_cmd": "wa v 5, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de d 15 1`] = `
+{
+  "_cmd": "wa v 5, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 5, de d v 1 1`] = `
+{
+  "_cmd": "wa v 5, de d v 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 5, de d v 2 1`] = `
+{
+  "_cmd": "wa v 5, de d v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, de d v 3 1`] = `
+{
+  "_cmd": "wa v 5, de d v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de d v 4 1`] = `
+{
+  "_cmd": "wa v 5, de d v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, de d v 5 1`] = `
+{
+  "_cmd": "wa v 5, de d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de d v 6 1`] = `
+{
+  "_cmd": "wa v 5, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, de d v 7 1`] = `
+{
+  "_cmd": "wa v 5, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, de d v 8 1`] = `
+{
+  "_cmd": "wa v 5, de d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de d v 9 1`] = `
+{
+  "_cmd": "wa v 5, de d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de d v 10 1`] = `
+{
+  "_cmd": "wa v 5, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de d v 11 1`] = `
+{
+  "_cmd": "wa v 5, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de d v 12 1`] = `
+{
+  "_cmd": "wa v 5, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, de d v 13 1`] = `
+{
+  "_cmd": "wa v 5, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de d v 14 1`] = `
+{
+  "_cmd": "wa v 5, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de d v 15 1`] = `
+{
+  "_cmd": "wa v 5, de d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 5, de d v 16 1`] = `
+{
+  "_cmd": "wa v 5, de d v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 5, de d v 17 1`] = `
+{
+  "_cmd": "wa v 5, de d v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 5, de d v 18 1`] = `
+{
+  "_cmd": "wa v 5, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 5, de d v 19 1`] = `
+{
+  "_cmd": "wa v 5, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 5, de d v 20 1`] = `
+{
+  "_cmd": "wa v 5, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 5, de p 1 1`] = `
+{
+  "_cmd": "wa v 5, de p 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 5, de p 2 1`] = `
+{
+  "_cmd": "wa v 5, de p 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, de p 3 1`] = `
+{
+  "_cmd": "wa v 5, de p 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, de p 4 1`] = `
+{
+  "_cmd": "wa v 5, de p 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de p 5 1`] = `
+{
+  "_cmd": "wa v 5, de p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de p 6 1`] = `
+{
+  "_cmd": "wa v 5, de p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de p 7 1`] = `
+{
+  "_cmd": "wa v 5, de p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, de p 8 1`] = `
+{
+  "_cmd": "wa v 5, de p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de p 9 1`] = `
+{
+  "_cmd": "wa v 5, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de p 10 1`] = `
+{
+  "_cmd": "wa v 5, de p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de p 11 1`] = `
+{
+  "_cmd": "wa v 5, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de p 12 1`] = `
+{
+  "_cmd": "wa v 5, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de p 13 1`] = `
+{
+  "_cmd": "wa v 5, de p 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de p 14 1`] = `
+{
+  "_cmd": "wa v 5, de p 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de p 15 1`] = `
+{
+  "_cmd": "wa v 5, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de p v 1 1`] = `
+{
+  "_cmd": "wa v 5, de p v 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 5, de p v 2 1`] = `
+{
+  "_cmd": "wa v 5, de p v 2",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 5, de p v 3 1`] = `
+{
+  "_cmd": "wa v 5, de p v 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, de p v 4 1`] = `
+{
+  "_cmd": "wa v 5, de p v 4",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 5, de p v 5 1`] = `
+{
+  "_cmd": "wa v 5, de p v 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, de p v 6 1`] = `
+{
+  "_cmd": "wa v 5, de p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de p v 7 1`] = `
+{
+  "_cmd": "wa v 5, de p v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, de p v 8 1`] = `
+{
+  "_cmd": "wa v 5, de p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, de p v 9 1`] = `
+{
+  "_cmd": "wa v 5, de p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de p v 10 1`] = `
+{
+  "_cmd": "wa v 5, de p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de p v 11 1`] = `
+{
+  "_cmd": "wa v 5, de p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de p v 12 1`] = `
+{
+  "_cmd": "wa v 5, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de p v 13 1`] = `
+{
+  "_cmd": "wa v 5, de p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, de p v 14 1`] = `
+{
+  "_cmd": "wa v 5, de p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de p v 15 1`] = `
+{
+  "_cmd": "wa v 5, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de p v 16 1`] = `
+{
+  "_cmd": "wa v 5, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de p v 17 1`] = `
+{
+  "_cmd": "wa v 5, de p v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 5, de p v 18 1`] = `
+{
+  "_cmd": "wa v 5, de p v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 5, de p v 19 1`] = `
+{
+  "_cmd": "wa v 5, de p v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 5, de p v 20 1`] = `
+{
+  "_cmd": "wa v 5, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 5, de v 1 1`] = `
+{
+  "_cmd": "wa v 5, de v 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 5, de v 2 1`] = `
+{
+  "_cmd": "wa v 5, de v 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, de v 3 1`] = `
+{
+  "_cmd": "wa v 5, de v 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 5, de v 4 1`] = `
+{
+  "_cmd": "wa v 5, de v 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de v 5 1`] = `
+{
+  "_cmd": "wa v 5, de v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de v 6 1`] = `
+{
+  "_cmd": "wa v 5, de v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de v 7 1`] = `
+{
+  "_cmd": "wa v 5, de v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, de v 8 1`] = `
+{
+  "_cmd": "wa v 5, de v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de v 9 1`] = `
+{
+  "_cmd": "wa v 5, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de v 10 1`] = `
+{
+  "_cmd": "wa v 5, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de v 11 1`] = `
+{
+  "_cmd": "wa v 5, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de v 12 1`] = `
+{
+  "_cmd": "wa v 5, de v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, de v 13 1`] = `
+{
+  "_cmd": "wa v 5, de v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de v 14 1`] = `
+{
+  "_cmd": "wa v 5, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de v 15 1`] = `
+{
+  "_cmd": "wa v 5, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de v 16 1`] = `
+{
+  "_cmd": "wa v 5, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 5, de v 17 1`] = `
+{
+  "_cmd": "wa v 5, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 5, de v 18 1`] = `
+{
+  "_cmd": "wa v 5, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 5, de v 19 1`] = `
+{
+  "_cmd": "wa v 5, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 5, de v 20 1`] = `
+{
+  "_cmd": "wa v 5, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 5, de w 1 1`] = `
+{
+  "_cmd": "wa v 5, de w 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, de w 2 1`] = `
+{
+  "_cmd": "wa v 5, de w 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de w 3 1`] = `
+{
+  "_cmd": "wa v 5, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de w 4 1`] = `
+{
+  "_cmd": "wa v 5, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de w 5 1`] = `
+{
+  "_cmd": "wa v 5, de w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, de w 6 1`] = `
+{
+  "_cmd": "wa v 5, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de w 7 1`] = `
+{
+  "_cmd": "wa v 5, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de w 8 1`] = `
+{
+  "_cmd": "wa v 5, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de w 9 1`] = `
+{
+  "_cmd": "wa v 5, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de w 10 1`] = `
+{
+  "_cmd": "wa v 5, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de w 11 1`] = `
+{
+  "_cmd": "wa v 5, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, de w 12 1`] = `
+{
+  "_cmd": "wa v 5, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de w 13 1`] = `
+{
+  "_cmd": "wa v 5, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de w 14 1`] = `
+{
+  "_cmd": "wa v 5, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de w 15 1`] = `
+{
+  "_cmd": "wa v 5, de w 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 5, de w v 1 1`] = `
+{
+  "_cmd": "wa v 5, de w v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, de w v 2 1`] = `
+{
+  "_cmd": "wa v 5, de w v 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, de w v 3 1`] = `
+{
+  "_cmd": "wa v 5, de w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, de w v 4 1`] = `
+{
+  "_cmd": "wa v 5, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, de w v 5 1`] = `
+{
+  "_cmd": "wa v 5, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, de w v 6 1`] = `
+{
+  "_cmd": "wa v 5, de w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, de w v 7 1`] = `
+{
+  "_cmd": "wa v 5, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, de w v 8 1`] = `
+{
+  "_cmd": "wa v 5, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, de w v 9 1`] = `
+{
+  "_cmd": "wa v 5, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, de w v 10 1`] = `
+{
+  "_cmd": "wa v 5, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, de w v 11 1`] = `
+{
+  "_cmd": "wa v 5, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, de w v 12 1`] = `
+{
+  "_cmd": "wa v 5, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, de w v 13 1`] = `
+{
+  "_cmd": "wa v 5, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, de w v 14 1`] = `
+{
+  "_cmd": "wa v 5, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, de w v 15 1`] = `
+{
+  "_cmd": "wa v 5, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 5, de w v 16 1`] = `
+{
+  "_cmd": "wa v 5, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 5, de w v 17 1`] = `
+{
+  "_cmd": "wa v 5, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 5, de w v 18 1`] = `
+{
+  "_cmd": "wa v 5, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 5, de w v 19 1`] = `
+{
+  "_cmd": "wa v 5, de w v 19",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 5, de w v 20 1`] = `
+{
+  "_cmd": "wa v 5, de w v 20",
+  "attacker": 0,
+  "defender": 20,
+}
+`;
+
+exports[`wa v 6, de d 1 1`] = `
+{
+  "_cmd": "wa v 6, de d 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 6, de d 2 1`] = `
+{
+  "_cmd": "wa v 6, de d 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, de d 3 1`] = `
+{
+  "_cmd": "wa v 6, de d 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, de d 4 1`] = `
+{
+  "_cmd": "wa v 6, de d 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de d 5 1`] = `
+{
+  "_cmd": "wa v 6, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de d 6 1`] = `
+{
+  "_cmd": "wa v 6, de d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de d 7 1`] = `
+{
+  "_cmd": "wa v 6, de d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, de d 8 1`] = `
+{
+  "_cmd": "wa v 6, de d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de d 9 1`] = `
+{
+  "_cmd": "wa v 6, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de d 10 1`] = `
+{
+  "_cmd": "wa v 6, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de d 11 1`] = `
+{
+  "_cmd": "wa v 6, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de d 12 1`] = `
+{
+  "_cmd": "wa v 6, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de d 13 1`] = `
+{
+  "_cmd": "wa v 6, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de d 14 1`] = `
+{
+  "_cmd": "wa v 6, de d 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de d 15 1`] = `
+{
+  "_cmd": "wa v 6, de d 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de d v 1 1`] = `
+{
+  "_cmd": "wa v 6, de d v 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 6, de d v 2 1`] = `
+{
+  "_cmd": "wa v 6, de d v 2",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, de d v 3 1`] = `
+{
+  "_cmd": "wa v 6, de d v 3",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, de d v 4 1`] = `
+{
+  "_cmd": "wa v 6, de d v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de d v 5 1`] = `
+{
+  "_cmd": "wa v 6, de d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, de d v 6 1`] = `
+{
+  "_cmd": "wa v 6, de d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de d v 7 1`] = `
+{
+  "_cmd": "wa v 6, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, de d v 8 1`] = `
+{
+  "_cmd": "wa v 6, de d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, de d v 9 1`] = `
+{
+  "_cmd": "wa v 6, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de d v 10 1`] = `
+{
+  "_cmd": "wa v 6, de d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de d v 11 1`] = `
+{
+  "_cmd": "wa v 6, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de d v 12 1`] = `
+{
+  "_cmd": "wa v 6, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de d v 13 1`] = `
+{
+  "_cmd": "wa v 6, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de d v 14 1`] = `
+{
+  "_cmd": "wa v 6, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, de d v 15 1`] = `
+{
+  "_cmd": "wa v 6, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de d v 16 1`] = `
+{
+  "_cmd": "wa v 6, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de d v 17 1`] = `
+{
+  "_cmd": "wa v 6, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 6, de d v 18 1`] = `
+{
+  "_cmd": "wa v 6, de d v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 6, de d v 19 1`] = `
+{
+  "_cmd": "wa v 6, de d v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 6, de d v 20 1`] = `
+{
+  "_cmd": "wa v 6, de d v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 6, de p 1 1`] = `
+{
+  "_cmd": "wa v 6, de p 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, de p 2 1`] = `
+{
+  "_cmd": "wa v 6, de p 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, de p 3 1`] = `
+{
+  "_cmd": "wa v 6, de p 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, de p 4 1`] = `
+{
+  "_cmd": "wa v 6, de p 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, de p 5 1`] = `
+{
+  "_cmd": "wa v 6, de p 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de p 6 1`] = `
+{
+  "_cmd": "wa v 6, de p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de p 7 1`] = `
+{
+  "_cmd": "wa v 6, de p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de p 8 1`] = `
+{
+  "_cmd": "wa v 6, de p 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, de p 9 1`] = `
+{
+  "_cmd": "wa v 6, de p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de p 10 1`] = `
+{
+  "_cmd": "wa v 6, de p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de p 11 1`] = `
+{
+  "_cmd": "wa v 6, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de p 12 1`] = `
+{
+  "_cmd": "wa v 6, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de p 13 1`] = `
+{
+  "_cmd": "wa v 6, de p 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de p 14 1`] = `
+{
+  "_cmd": "wa v 6, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de p 15 1`] = `
+{
+  "_cmd": "wa v 6, de p 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de p v 1 1`] = `
+{
+  "_cmd": "wa v 6, de p v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, de p v 2 1`] = `
+{
+  "_cmd": "wa v 6, de p v 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, de p v 3 1`] = `
+{
+  "_cmd": "wa v 6, de p v 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, de p v 4 1`] = `
+{
+  "_cmd": "wa v 6, de p v 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, de p v 5 1`] = `
+{
+  "_cmd": "wa v 6, de p v 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de p v 6 1`] = `
+{
+  "_cmd": "wa v 6, de p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, de p v 7 1`] = `
+{
+  "_cmd": "wa v 6, de p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de p v 8 1`] = `
+{
+  "_cmd": "wa v 6, de p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, de p v 9 1`] = `
+{
+  "_cmd": "wa v 6, de p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, de p v 10 1`] = `
+{
+  "_cmd": "wa v 6, de p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de p v 11 1`] = `
+{
+  "_cmd": "wa v 6, de p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de p v 12 1`] = `
+{
+  "_cmd": "wa v 6, de p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de p v 13 1`] = `
+{
+  "_cmd": "wa v 6, de p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de p v 14 1`] = `
+{
+  "_cmd": "wa v 6, de p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de p v 15 1`] = `
+{
+  "_cmd": "wa v 6, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, de p v 16 1`] = `
+{
+  "_cmd": "wa v 6, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de p v 17 1`] = `
+{
+  "_cmd": "wa v 6, de p v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de p v 18 1`] = `
+{
+  "_cmd": "wa v 6, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 6, de p v 19 1`] = `
+{
+  "_cmd": "wa v 6, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 6, de p v 20 1`] = `
+{
+  "_cmd": "wa v 6, de p v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 6, de v 1 1`] = `
+{
+  "_cmd": "wa v 6, de v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, de v 2 1`] = `
+{
+  "_cmd": "wa v 6, de v 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, de v 3 1`] = `
+{
+  "_cmd": "wa v 6, de v 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, de v 4 1`] = `
+{
+  "_cmd": "wa v 6, de v 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, de v 5 1`] = `
+{
+  "_cmd": "wa v 6, de v 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de v 6 1`] = `
+{
+  "_cmd": "wa v 6, de v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de v 7 1`] = `
+{
+  "_cmd": "wa v 6, de v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de v 8 1`] = `
+{
+  "_cmd": "wa v 6, de v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, de v 9 1`] = `
+{
+  "_cmd": "wa v 6, de v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de v 10 1`] = `
+{
+  "_cmd": "wa v 6, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de v 11 1`] = `
+{
+  "_cmd": "wa v 6, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de v 12 1`] = `
+{
+  "_cmd": "wa v 6, de v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de v 13 1`] = `
+{
+  "_cmd": "wa v 6, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de v 14 1`] = `
+{
+  "_cmd": "wa v 6, de v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, de v 15 1`] = `
+{
+  "_cmd": "wa v 6, de v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de v 16 1`] = `
+{
+  "_cmd": "wa v 6, de v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de v 17 1`] = `
+{
+  "_cmd": "wa v 6, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 6, de v 18 1`] = `
+{
+  "_cmd": "wa v 6, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 6, de v 19 1`] = `
+{
+  "_cmd": "wa v 6, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 6, de v 20 1`] = `
+{
+  "_cmd": "wa v 6, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 6, de w 1 1`] = `
+{
+  "_cmd": "wa v 6, de w 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, de w 2 1`] = `
+{
+  "_cmd": "wa v 6, de w 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, de w 3 1`] = `
+{
+  "_cmd": "wa v 6, de w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, de w 4 1`] = `
+{
+  "_cmd": "wa v 6, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de w 5 1`] = `
+{
+  "_cmd": "wa v 6, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de w 6 1`] = `
+{
+  "_cmd": "wa v 6, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, de w 7 1`] = `
+{
+  "_cmd": "wa v 6, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de w 8 1`] = `
+{
+  "_cmd": "wa v 6, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de w 9 1`] = `
+{
+  "_cmd": "wa v 6, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de w 10 1`] = `
+{
+  "_cmd": "wa v 6, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de w 11 1`] = `
+{
+  "_cmd": "wa v 6, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de w 12 1`] = `
+{
+  "_cmd": "wa v 6, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de w 13 1`] = `
+{
+  "_cmd": "wa v 6, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, de w 14 1`] = `
+{
+  "_cmd": "wa v 6, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de w 15 1`] = `
+{
+  "_cmd": "wa v 6, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de w v 1 1`] = `
+{
+  "_cmd": "wa v 6, de w v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, de w v 2 1`] = `
+{
+  "_cmd": "wa v 6, de w v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, de w v 3 1`] = `
+{
+  "_cmd": "wa v 6, de w v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, de w v 4 1`] = `
+{
+  "_cmd": "wa v 6, de w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, de w v 5 1`] = `
+{
+  "_cmd": "wa v 6, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, de w v 6 1`] = `
+{
+  "_cmd": "wa v 6, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, de w v 7 1`] = `
+{
+  "_cmd": "wa v 6, de w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, de w v 8 1`] = `
+{
+  "_cmd": "wa v 6, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, de w v 9 1`] = `
+{
+  "_cmd": "wa v 6, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, de w v 10 1`] = `
+{
+  "_cmd": "wa v 6, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, de w v 11 1`] = `
+{
+  "_cmd": "wa v 6, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, de w v 12 1`] = `
+{
+  "_cmd": "wa v 6, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, de w v 13 1`] = `
+{
+  "_cmd": "wa v 6, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, de w v 14 1`] = `
+{
+  "_cmd": "wa v 6, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, de w v 15 1`] = `
+{
+  "_cmd": "wa v 6, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, de w v 16 1`] = `
+{
+  "_cmd": "wa v 6, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 6, de w v 17 1`] = `
+{
+  "_cmd": "wa v 6, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 6, de w v 18 1`] = `
+{
+  "_cmd": "wa v 6, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 6, de w v 19 1`] = `
+{
+  "_cmd": "wa v 6, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 6, de w v 20 1`] = `
+{
+  "_cmd": "wa v 6, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 7, de d 1 1`] = `
+{
+  "_cmd": "wa v 7, de d 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 7, de d 2 1`] = `
+{
+  "_cmd": "wa v 7, de d 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, de d 3 1`] = `
+{
+  "_cmd": "wa v 7, de d 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, de d 4 1`] = `
+{
+  "_cmd": "wa v 7, de d 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, de d 5 1`] = `
+{
+  "_cmd": "wa v 7, de d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, de d 6 1`] = `
+{
+  "_cmd": "wa v 7, de d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de d 7 1`] = `
+{
+  "_cmd": "wa v 7, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, de d 8 1`] = `
+{
+  "_cmd": "wa v 7, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de d 9 1`] = `
+{
+  "_cmd": "wa v 7, de d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de d 10 1`] = `
+{
+  "_cmd": "wa v 7, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de d 11 1`] = `
+{
+  "_cmd": "wa v 7, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de d 12 1`] = `
+{
+  "_cmd": "wa v 7, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de d 13 1`] = `
+{
+  "_cmd": "wa v 7, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de d 14 1`] = `
+{
+  "_cmd": "wa v 7, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de d 15 1`] = `
+{
+  "_cmd": "wa v 7, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de d v 1 1`] = `
+{
+  "_cmd": "wa v 7, de d v 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 7, de d v 2 1`] = `
+{
+  "_cmd": "wa v 7, de d v 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, de d v 3 1`] = `
+{
+  "_cmd": "wa v 7, de d v 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, de d v 4 1`] = `
+{
+  "_cmd": "wa v 7, de d v 4",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, de d v 5 1`] = `
+{
+  "_cmd": "wa v 7, de d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, de d v 6 1`] = `
+{
+  "_cmd": "wa v 7, de d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, de d v 7 1`] = `
+{
+  "_cmd": "wa v 7, de d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, de d v 8 1`] = `
+{
+  "_cmd": "wa v 7, de d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de d v 9 1`] = `
+{
+  "_cmd": "wa v 7, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, de d v 10 1`] = `
+{
+  "_cmd": "wa v 7, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de d v 11 1`] = `
+{
+  "_cmd": "wa v 7, de d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de d v 12 1`] = `
+{
+  "_cmd": "wa v 7, de d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de d v 13 1`] = `
+{
+  "_cmd": "wa v 7, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de d v 14 1`] = `
+{
+  "_cmd": "wa v 7, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de d v 15 1`] = `
+{
+  "_cmd": "wa v 7, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de d v 16 1`] = `
+{
+  "_cmd": "wa v 7, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 7, de d v 17 1`] = `
+{
+  "_cmd": "wa v 7, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 7, de d v 18 1`] = `
+{
+  "_cmd": "wa v 7, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 7, de d v 19 1`] = `
+{
+  "_cmd": "wa v 7, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 7, de d v 20 1`] = `
+{
+  "_cmd": "wa v 7, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 7, de p 1 1`] = `
+{
+  "_cmd": "wa v 7, de p 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, de p 2 1`] = `
+{
+  "_cmd": "wa v 7, de p 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, de p 3 1`] = `
+{
+  "_cmd": "wa v 7, de p 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, de p 4 1`] = `
+{
+  "_cmd": "wa v 7, de p 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, de p 5 1`] = `
+{
+  "_cmd": "wa v 7, de p 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, de p 6 1`] = `
+{
+  "_cmd": "wa v 7, de p 6",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, de p 7 1`] = `
+{
+  "_cmd": "wa v 7, de p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de p 8 1`] = `
+{
+  "_cmd": "wa v 7, de p 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, de p 9 1`] = `
+{
+  "_cmd": "wa v 7, de p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de p 10 1`] = `
+{
+  "_cmd": "wa v 7, de p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, de p 11 1`] = `
+{
+  "_cmd": "wa v 7, de p 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de p 12 1`] = `
+{
+  "_cmd": "wa v 7, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de p 13 1`] = `
+{
+  "_cmd": "wa v 7, de p 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de p 14 1`] = `
+{
+  "_cmd": "wa v 7, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de p 15 1`] = `
+{
+  "_cmd": "wa v 7, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de p v 1 1`] = `
+{
+  "_cmd": "wa v 7, de p v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, de p v 2 1`] = `
+{
+  "_cmd": "wa v 7, de p v 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, de p v 3 1`] = `
+{
+  "_cmd": "wa v 7, de p v 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, de p v 4 1`] = `
+{
+  "_cmd": "wa v 7, de p v 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, de p v 5 1`] = `
+{
+  "_cmd": "wa v 7, de p v 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, de p v 6 1`] = `
+{
+  "_cmd": "wa v 7, de p v 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, de p v 7 1`] = `
+{
+  "_cmd": "wa v 7, de p v 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, de p v 8 1`] = `
+{
+  "_cmd": "wa v 7, de p v 8",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de p v 9 1`] = `
+{
+  "_cmd": "wa v 7, de p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de p v 10 1`] = `
+{
+  "_cmd": "wa v 7, de p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, de p v 11 1`] = `
+{
+  "_cmd": "wa v 7, de p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de p v 12 1`] = `
+{
+  "_cmd": "wa v 7, de p v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de p v 13 1`] = `
+{
+  "_cmd": "wa v 7, de p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de p v 14 1`] = `
+{
+  "_cmd": "wa v 7, de p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de p v 15 1`] = `
+{
+  "_cmd": "wa v 7, de p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de p v 16 1`] = `
+{
+  "_cmd": "wa v 7, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de p v 17 1`] = `
+{
+  "_cmd": "wa v 7, de p v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 7, de p v 18 1`] = `
+{
+  "_cmd": "wa v 7, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 7, de p v 19 1`] = `
+{
+  "_cmd": "wa v 7, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 7, de p v 20 1`] = `
+{
+  "_cmd": "wa v 7, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 7, de v 1 1`] = `
+{
+  "_cmd": "wa v 7, de v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, de v 2 1`] = `
+{
+  "_cmd": "wa v 7, de v 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, de v 3 1`] = `
+{
+  "_cmd": "wa v 7, de v 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, de v 4 1`] = `
+{
+  "_cmd": "wa v 7, de v 4",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, de v 5 1`] = `
+{
+  "_cmd": "wa v 7, de v 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, de v 6 1`] = `
+{
+  "_cmd": "wa v 7, de v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, de v 7 1`] = `
+{
+  "_cmd": "wa v 7, de v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de v 8 1`] = `
+{
+  "_cmd": "wa v 7, de v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, de v 9 1`] = `
+{
+  "_cmd": "wa v 7, de v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de v 10 1`] = `
+{
+  "_cmd": "wa v 7, de v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de v 11 1`] = `
+{
+  "_cmd": "wa v 7, de v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de v 12 1`] = `
+{
+  "_cmd": "wa v 7, de v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de v 13 1`] = `
+{
+  "_cmd": "wa v 7, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de v 14 1`] = `
+{
+  "_cmd": "wa v 7, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de v 15 1`] = `
+{
+  "_cmd": "wa v 7, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de v 16 1`] = `
+{
+  "_cmd": "wa v 7, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de v 17 1`] = `
+{
+  "_cmd": "wa v 7, de v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 7, de v 18 1`] = `
+{
+  "_cmd": "wa v 7, de v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 7, de v 19 1`] = `
+{
+  "_cmd": "wa v 7, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 7, de v 20 1`] = `
+{
+  "_cmd": "wa v 7, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 7, de w 1 1`] = `
+{
+  "_cmd": "wa v 7, de w 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, de w 2 1`] = `
+{
+  "_cmd": "wa v 7, de w 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, de w 3 1`] = `
+{
+  "_cmd": "wa v 7, de w 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, de w 4 1`] = `
+{
+  "_cmd": "wa v 7, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, de w 5 1`] = `
+{
+  "_cmd": "wa v 7, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de w 6 1`] = `
+{
+  "_cmd": "wa v 7, de w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de w 7 1`] = `
+{
+  "_cmd": "wa v 7, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, de w 8 1`] = `
+{
+  "_cmd": "wa v 7, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de w 9 1`] = `
+{
+  "_cmd": "wa v 7, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de w 10 1`] = `
+{
+  "_cmd": "wa v 7, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de w 11 1`] = `
+{
+  "_cmd": "wa v 7, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de w 12 1`] = `
+{
+  "_cmd": "wa v 7, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de w 13 1`] = `
+{
+  "_cmd": "wa v 7, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de w 14 1`] = `
+{
+  "_cmd": "wa v 7, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de w 15 1`] = `
+{
+  "_cmd": "wa v 7, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 7, de w v 1 1`] = `
+{
+  "_cmd": "wa v 7, de w v 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, de w v 2 1`] = `
+{
+  "_cmd": "wa v 7, de w v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, de w v 3 1`] = `
+{
+  "_cmd": "wa v 7, de w v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, de w v 4 1`] = `
+{
+  "_cmd": "wa v 7, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, de w v 5 1`] = `
+{
+  "_cmd": "wa v 7, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, de w v 6 1`] = `
+{
+  "_cmd": "wa v 7, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, de w v 7 1`] = `
+{
+  "_cmd": "wa v 7, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, de w v 8 1`] = `
+{
+  "_cmd": "wa v 7, de w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, de w v 9 1`] = `
+{
+  "_cmd": "wa v 7, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, de w v 10 1`] = `
+{
+  "_cmd": "wa v 7, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, de w v 11 1`] = `
+{
+  "_cmd": "wa v 7, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, de w v 12 1`] = `
+{
+  "_cmd": "wa v 7, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, de w v 13 1`] = `
+{
+  "_cmd": "wa v 7, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, de w v 14 1`] = `
+{
+  "_cmd": "wa v 7, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, de w v 15 1`] = `
+{
+  "_cmd": "wa v 7, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 7, de w v 16 1`] = `
+{
+  "_cmd": "wa v 7, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 7, de w v 17 1`] = `
+{
+  "_cmd": "wa v 7, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 7, de w v 18 1`] = `
+{
+  "_cmd": "wa v 7, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 7, de w v 19 1`] = `
+{
+  "_cmd": "wa v 7, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 7, de w v 20 1`] = `
+{
+  "_cmd": "wa v 7, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 8, de d 1 1`] = `
+{
+  "_cmd": "wa v 8, de d 1",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 8, de d 2 1`] = `
+{
+  "_cmd": "wa v 8, de d 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, de d 3 1`] = `
+{
+  "_cmd": "wa v 8, de d 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de d 4 1`] = `
+{
+  "_cmd": "wa v 8, de d 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de d 5 1`] = `
+{
+  "_cmd": "wa v 8, de d 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, de d 6 1`] = `
+{
+  "_cmd": "wa v 8, de d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, de d 7 1`] = `
+{
+  "_cmd": "wa v 8, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de d 8 1`] = `
+{
+  "_cmd": "wa v 8, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de d 9 1`] = `
+{
+  "_cmd": "wa v 8, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de d 10 1`] = `
+{
+  "_cmd": "wa v 8, de d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, de d 11 1`] = `
+{
+  "_cmd": "wa v 8, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de d 12 1`] = `
+{
+  "_cmd": "wa v 8, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de d 13 1`] = `
+{
+  "_cmd": "wa v 8, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de d 14 1`] = `
+{
+  "_cmd": "wa v 8, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de d 15 1`] = `
+{
+  "_cmd": "wa v 8, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de d v 1 1`] = `
+{
+  "_cmd": "wa v 8, de d v 1",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 8, de d v 2 1`] = `
+{
+  "_cmd": "wa v 8, de d v 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, de d v 3 1`] = `
+{
+  "_cmd": "wa v 8, de d v 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, de d v 4 1`] = `
+{
+  "_cmd": "wa v 8, de d v 4",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, de d v 5 1`] = `
+{
+  "_cmd": "wa v 8, de d v 5",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, de d v 6 1`] = `
+{
+  "_cmd": "wa v 8, de d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, de d v 7 1`] = `
+{
+  "_cmd": "wa v 8, de d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, de d v 8 1`] = `
+{
+  "_cmd": "wa v 8, de d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de d v 9 1`] = `
+{
+  "_cmd": "wa v 8, de d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de d v 10 1`] = `
+{
+  "_cmd": "wa v 8, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, de d v 11 1`] = `
+{
+  "_cmd": "wa v 8, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, de d v 12 1`] = `
+{
+  "_cmd": "wa v 8, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de d v 13 1`] = `
+{
+  "_cmd": "wa v 8, de d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de d v 14 1`] = `
+{
+  "_cmd": "wa v 8, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de d v 15 1`] = `
+{
+  "_cmd": "wa v 8, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de d v 16 1`] = `
+{
+  "_cmd": "wa v 8, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, de d v 17 1`] = `
+{
+  "_cmd": "wa v 8, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 8, de d v 18 1`] = `
+{
+  "_cmd": "wa v 8, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 8, de d v 19 1`] = `
+{
+  "_cmd": "wa v 8, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 8, de d v 20 1`] = `
+{
+  "_cmd": "wa v 8, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 8, de p 1 1`] = `
+{
+  "_cmd": "wa v 8, de p 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, de p 2 1`] = `
+{
+  "_cmd": "wa v 8, de p 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, de p 3 1`] = `
+{
+  "_cmd": "wa v 8, de p 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, de p 4 1`] = `
+{
+  "_cmd": "wa v 8, de p 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de p 5 1`] = `
+{
+  "_cmd": "wa v 8, de p 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de p 6 1`] = `
+{
+  "_cmd": "wa v 8, de p 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, de p 7 1`] = `
+{
+  "_cmd": "wa v 8, de p 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, de p 8 1`] = `
+{
+  "_cmd": "wa v 8, de p 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de p 9 1`] = `
+{
+  "_cmd": "wa v 8, de p 9",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de p 10 1`] = `
+{
+  "_cmd": "wa v 8, de p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de p 11 1`] = `
+{
+  "_cmd": "wa v 8, de p 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, de p 12 1`] = `
+{
+  "_cmd": "wa v 8, de p 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de p 13 1`] = `
+{
+  "_cmd": "wa v 8, de p 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de p 14 1`] = `
+{
+  "_cmd": "wa v 8, de p 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de p 15 1`] = `
+{
+  "_cmd": "wa v 8, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de p v 1 1`] = `
+{
+  "_cmd": "wa v 8, de p v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, de p v 2 1`] = `
+{
+  "_cmd": "wa v 8, de p v 2",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 8, de p v 3 1`] = `
+{
+  "_cmd": "wa v 8, de p v 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, de p v 4 1`] = `
+{
+  "_cmd": "wa v 8, de p v 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de p v 5 1`] = `
+{
+  "_cmd": "wa v 8, de p v 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, de p v 6 1`] = `
+{
+  "_cmd": "wa v 8, de p v 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de p v 7 1`] = `
+{
+  "_cmd": "wa v 8, de p v 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, de p v 8 1`] = `
+{
+  "_cmd": "wa v 8, de p v 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, de p v 9 1`] = `
+{
+  "_cmd": "wa v 8, de p v 9",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de p v 10 1`] = `
+{
+  "_cmd": "wa v 8, de p v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de p v 11 1`] = `
+{
+  "_cmd": "wa v 8, de p v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, de p v 12 1`] = `
+{
+  "_cmd": "wa v 8, de p v 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, de p v 13 1`] = `
+{
+  "_cmd": "wa v 8, de p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de p v 14 1`] = `
+{
+  "_cmd": "wa v 8, de p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de p v 15 1`] = `
+{
+  "_cmd": "wa v 8, de p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de p v 16 1`] = `
+{
+  "_cmd": "wa v 8, de p v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de p v 17 1`] = `
+{
+  "_cmd": "wa v 8, de p v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, de p v 18 1`] = `
+{
+  "_cmd": "wa v 8, de p v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 8, de p v 19 1`] = `
+{
+  "_cmd": "wa v 8, de p v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 8, de p v 20 1`] = `
+{
+  "_cmd": "wa v 8, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 8, de v 1 1`] = `
+{
+  "_cmd": "wa v 8, de v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, de v 2 1`] = `
+{
+  "_cmd": "wa v 8, de v 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, de v 3 1`] = `
+{
+  "_cmd": "wa v 8, de v 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, de v 4 1`] = `
+{
+  "_cmd": "wa v 8, de v 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de v 5 1`] = `
+{
+  "_cmd": "wa v 8, de v 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de v 6 1`] = `
+{
+  "_cmd": "wa v 8, de v 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, de v 7 1`] = `
+{
+  "_cmd": "wa v 8, de v 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, de v 8 1`] = `
+{
+  "_cmd": "wa v 8, de v 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de v 9 1`] = `
+{
+  "_cmd": "wa v 8, de v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de v 10 1`] = `
+{
+  "_cmd": "wa v 8, de v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de v 11 1`] = `
+{
+  "_cmd": "wa v 8, de v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, de v 12 1`] = `
+{
+  "_cmd": "wa v 8, de v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de v 13 1`] = `
+{
+  "_cmd": "wa v 8, de v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de v 14 1`] = `
+{
+  "_cmd": "wa v 8, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de v 15 1`] = `
+{
+  "_cmd": "wa v 8, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de v 16 1`] = `
+{
+  "_cmd": "wa v 8, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de v 17 1`] = `
+{
+  "_cmd": "wa v 8, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, de v 18 1`] = `
+{
+  "_cmd": "wa v 8, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 8, de v 19 1`] = `
+{
+  "_cmd": "wa v 8, de v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 8, de v 20 1`] = `
+{
+  "_cmd": "wa v 8, de v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 8, de w 1 1`] = `
+{
+  "_cmd": "wa v 8, de w 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, de w 2 1`] = `
+{
+  "_cmd": "wa v 8, de w 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de w 3 1`] = `
+{
+  "_cmd": "wa v 8, de w 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de w 4 1`] = `
+{
+  "_cmd": "wa v 8, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, de w 5 1`] = `
+{
+  "_cmd": "wa v 8, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, de w 6 1`] = `
+{
+  "_cmd": "wa v 8, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de w 7 1`] = `
+{
+  "_cmd": "wa v 8, de w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de w 8 1`] = `
+{
+  "_cmd": "wa v 8, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, de w 9 1`] = `
+{
+  "_cmd": "wa v 8, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, de w 10 1`] = `
+{
+  "_cmd": "wa v 8, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de w 11 1`] = `
+{
+  "_cmd": "wa v 8, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de w 12 1`] = `
+{
+  "_cmd": "wa v 8, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de w 13 1`] = `
+{
+  "_cmd": "wa v 8, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de w 14 1`] = `
+{
+  "_cmd": "wa v 8, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de w 15 1`] = `
+{
+  "_cmd": "wa v 8, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, de w v 1 1`] = `
+{
+  "_cmd": "wa v 8, de w v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, de w v 2 1`] = `
+{
+  "_cmd": "wa v 8, de w v 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, de w v 3 1`] = `
+{
+  "_cmd": "wa v 8, de w v 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, de w v 4 1`] = `
+{
+  "_cmd": "wa v 8, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, de w v 5 1`] = `
+{
+  "_cmd": "wa v 8, de w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, de w v 6 1`] = `
+{
+  "_cmd": "wa v 8, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, de w v 7 1`] = `
+{
+  "_cmd": "wa v 8, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, de w v 8 1`] = `
+{
+  "_cmd": "wa v 8, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, de w v 9 1`] = `
+{
+  "_cmd": "wa v 8, de w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, de w v 10 1`] = `
+{
+  "_cmd": "wa v 8, de w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, de w v 11 1`] = `
+{
+  "_cmd": "wa v 8, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, de w v 12 1`] = `
+{
+  "_cmd": "wa v 8, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, de w v 13 1`] = `
+{
+  "_cmd": "wa v 8, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, de w v 14 1`] = `
+{
+  "_cmd": "wa v 8, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, de w v 15 1`] = `
+{
+  "_cmd": "wa v 8, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, de w v 16 1`] = `
+{
+  "_cmd": "wa v 8, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 8, de w v 17 1`] = `
+{
+  "_cmd": "wa v 8, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 8, de w v 18 1`] = `
+{
+  "_cmd": "wa v 8, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 8, de w v 19 1`] = `
+{
+  "_cmd": "wa v 8, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 8, de w v 20 1`] = `
+{
+  "_cmd": "wa v 8, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 9, de d 1 1`] = `
+{
+  "_cmd": "wa v 9, de d 1",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 9, de d 2 1`] = `
+{
+  "_cmd": "wa v 9, de d 2",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, de d 3 1`] = `
+{
+  "_cmd": "wa v 9, de d 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, de d 4 1`] = `
+{
+  "_cmd": "wa v 9, de d 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de d 5 1`] = `
+{
+  "_cmd": "wa v 9, de d 5",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, de d 6 1`] = `
+{
+  "_cmd": "wa v 9, de d 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de d 7 1`] = `
+{
+  "_cmd": "wa v 9, de d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, de d 8 1`] = `
+{
+  "_cmd": "wa v 9, de d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de d 9 1`] = `
+{
+  "_cmd": "wa v 9, de d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de d 10 1`] = `
+{
+  "_cmd": "wa v 9, de d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de d 11 1`] = `
+{
+  "_cmd": "wa v 9, de d 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, de d 12 1`] = `
+{
+  "_cmd": "wa v 9, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de d 13 1`] = `
+{
+  "_cmd": "wa v 9, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de d 14 1`] = `
+{
+  "_cmd": "wa v 9, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de d 15 1`] = `
+{
+  "_cmd": "wa v 9, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de d v 1 1`] = `
+{
+  "_cmd": "wa v 9, de d v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, de d v 2 1`] = `
+{
+  "_cmd": "wa v 9, de d v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, de d v 3 1`] = `
+{
+  "_cmd": "wa v 9, de d v 3",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, de d v 4 1`] = `
+{
+  "_cmd": "wa v 9, de d v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de d v 5 1`] = `
+{
+  "_cmd": "wa v 9, de d v 5",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, de d v 6 1`] = `
+{
+  "_cmd": "wa v 9, de d v 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de d v 7 1`] = `
+{
+  "_cmd": "wa v 9, de d v 7",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, de d v 8 1`] = `
+{
+  "_cmd": "wa v 9, de d v 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, de d v 9 1`] = `
+{
+  "_cmd": "wa v 9, de d v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de d v 10 1`] = `
+{
+  "_cmd": "wa v 9, de d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de d v 11 1`] = `
+{
+  "_cmd": "wa v 9, de d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de d v 12 1`] = `
+{
+  "_cmd": "wa v 9, de d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, de d v 13 1`] = `
+{
+  "_cmd": "wa v 9, de d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de d v 14 1`] = `
+{
+  "_cmd": "wa v 9, de d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de d v 15 1`] = `
+{
+  "_cmd": "wa v 9, de d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de d v 16 1`] = `
+{
+  "_cmd": "wa v 9, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 9, de d v 17 1`] = `
+{
+  "_cmd": "wa v 9, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 9, de d v 18 1`] = `
+{
+  "_cmd": "wa v 9, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 9, de d v 19 1`] = `
+{
+  "_cmd": "wa v 9, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 9, de d v 20 1`] = `
+{
+  "_cmd": "wa v 9, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 9, de p 1 1`] = `
+{
+  "_cmd": "wa v 9, de p 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, de p 2 1`] = `
+{
+  "_cmd": "wa v 9, de p 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, de p 3 1`] = `
+{
+  "_cmd": "wa v 9, de p 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, de p 4 1`] = `
+{
+  "_cmd": "wa v 9, de p 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, de p 5 1`] = `
+{
+  "_cmd": "wa v 9, de p 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de p 6 1`] = `
+{
+  "_cmd": "wa v 9, de p 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, de p 7 1`] = `
+{
+  "_cmd": "wa v 9, de p 7",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de p 8 1`] = `
+{
+  "_cmd": "wa v 9, de p 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, de p 9 1`] = `
+{
+  "_cmd": "wa v 9, de p 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de p 10 1`] = `
+{
+  "_cmd": "wa v 9, de p 10",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de p 11 1`] = `
+{
+  "_cmd": "wa v 9, de p 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de p 12 1`] = `
+{
+  "_cmd": "wa v 9, de p 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de p 13 1`] = `
+{
+  "_cmd": "wa v 9, de p 13",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, de p 14 1`] = `
+{
+  "_cmd": "wa v 9, de p 14",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de p 15 1`] = `
+{
+  "_cmd": "wa v 9, de p 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de p v 1 1`] = `
+{
+  "_cmd": "wa v 9, de p v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, de p v 2 1`] = `
+{
+  "_cmd": "wa v 9, de p v 2",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 9, de p v 3 1`] = `
+{
+  "_cmd": "wa v 9, de p v 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, de p v 4 1`] = `
+{
+  "_cmd": "wa v 9, de p v 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, de p v 5 1`] = `
+{
+  "_cmd": "wa v 9, de p v 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de p v 6 1`] = `
+{
+  "_cmd": "wa v 9, de p v 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, de p v 7 1`] = `
+{
+  "_cmd": "wa v 9, de p v 7",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, de p v 8 1`] = `
+{
+  "_cmd": "wa v 9, de p v 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, de p v 9 1`] = `
+{
+  "_cmd": "wa v 9, de p v 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, de p v 10 1`] = `
+{
+  "_cmd": "wa v 9, de p v 10",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de p v 11 1`] = `
+{
+  "_cmd": "wa v 9, de p v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de p v 12 1`] = `
+{
+  "_cmd": "wa v 9, de p v 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de p v 13 1`] = `
+{
+  "_cmd": "wa v 9, de p v 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, de p v 14 1`] = `
+{
+  "_cmd": "wa v 9, de p v 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de p v 15 1`] = `
+{
+  "_cmd": "wa v 9, de p v 15",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de p v 16 1`] = `
+{
+  "_cmd": "wa v 9, de p v 16",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de p v 17 1`] = `
+{
+  "_cmd": "wa v 9, de p v 17",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de p v 18 1`] = `
+{
+  "_cmd": "wa v 9, de p v 18",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 9, de p v 19 1`] = `
+{
+  "_cmd": "wa v 9, de p v 19",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 9, de p v 20 1`] = `
+{
+  "_cmd": "wa v 9, de p v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 9, de v 1 1`] = `
+{
+  "_cmd": "wa v 9, de v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, de v 2 1`] = `
+{
+  "_cmd": "wa v 9, de v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, de v 3 1`] = `
+{
+  "_cmd": "wa v 9, de v 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, de v 4 1`] = `
+{
+  "_cmd": "wa v 9, de v 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, de v 5 1`] = `
+{
+  "_cmd": "wa v 9, de v 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de v 6 1`] = `
+{
+  "_cmd": "wa v 9, de v 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, de v 7 1`] = `
+{
+  "_cmd": "wa v 9, de v 7",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de v 8 1`] = `
+{
+  "_cmd": "wa v 9, de v 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, de v 9 1`] = `
+{
+  "_cmd": "wa v 9, de v 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de v 10 1`] = `
+{
+  "_cmd": "wa v 9, de v 10",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de v 11 1`] = `
+{
+  "_cmd": "wa v 9, de v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de v 12 1`] = `
+{
+  "_cmd": "wa v 9, de v 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de v 13 1`] = `
+{
+  "_cmd": "wa v 9, de v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de v 14 1`] = `
+{
+  "_cmd": "wa v 9, de v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de v 15 1`] = `
+{
+  "_cmd": "wa v 9, de v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de v 16 1`] = `
+{
+  "_cmd": "wa v 9, de v 16",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de v 17 1`] = `
+{
+  "_cmd": "wa v 9, de v 17",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 9, de v 18 1`] = `
+{
+  "_cmd": "wa v 9, de v 18",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 9, de v 19 1`] = `
+{
+  "_cmd": "wa v 9, de v 19",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 9, de v 20 1`] = `
+{
+  "_cmd": "wa v 9, de v 20",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 9, de w 1 1`] = `
+{
+  "_cmd": "wa v 9, de w 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, de w 2 1`] = `
+{
+  "_cmd": "wa v 9, de w 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, de w 3 1`] = `
+{
+  "_cmd": "wa v 9, de w 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, de w 4 1`] = `
+{
+  "_cmd": "wa v 9, de w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de w 5 1`] = `
+{
+  "_cmd": "wa v 9, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, de w 6 1`] = `
+{
+  "_cmd": "wa v 9, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, de w 7 1`] = `
+{
+  "_cmd": "wa v 9, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de w 8 1`] = `
+{
+  "_cmd": "wa v 9, de w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de w 9 1`] = `
+{
+  "_cmd": "wa v 9, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de w 10 1`] = `
+{
+  "_cmd": "wa v 9, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, de w 11 1`] = `
+{
+  "_cmd": "wa v 9, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de w 12 1`] = `
+{
+  "_cmd": "wa v 9, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de w 13 1`] = `
+{
+  "_cmd": "wa v 9, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de w 14 1`] = `
+{
+  "_cmd": "wa v 9, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de w 15 1`] = `
+{
+  "_cmd": "wa v 9, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 9, de w v 1 1`] = `
+{
+  "_cmd": "wa v 9, de w v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, de w v 2 1`] = `
+{
+  "_cmd": "wa v 9, de w v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, de w v 3 1`] = `
+{
+  "_cmd": "wa v 9, de w v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, de w v 4 1`] = `
+{
+  "_cmd": "wa v 9, de w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, de w v 5 1`] = `
+{
+  "_cmd": "wa v 9, de w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, de w v 6 1`] = `
+{
+  "_cmd": "wa v 9, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, de w v 7 1`] = `
+{
+  "_cmd": "wa v 9, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, de w v 8 1`] = `
+{
+  "_cmd": "wa v 9, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, de w v 9 1`] = `
+{
+  "_cmd": "wa v 9, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, de w v 10 1`] = `
+{
+  "_cmd": "wa v 9, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, de w v 11 1`] = `
+{
+  "_cmd": "wa v 9, de w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, de w v 12 1`] = `
+{
+  "_cmd": "wa v 9, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, de w v 13 1`] = `
+{
+  "_cmd": "wa v 9, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, de w v 14 1`] = `
+{
+  "_cmd": "wa v 9, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, de w v 15 1`] = `
+{
+  "_cmd": "wa v 9, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 9, de w v 16 1`] = `
+{
+  "_cmd": "wa v 9, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 9, de w v 17 1`] = `
+{
+  "_cmd": "wa v 9, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 9, de w v 18 1`] = `
+{
+  "_cmd": "wa v 9, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 9, de w v 19 1`] = `
+{
+  "_cmd": "wa v 9, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 9, de w v 20 1`] = `
+{
+  "_cmd": "wa v 9, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 10, de d 1 1`] = `
+{
+  "_cmd": "wa v 10, de d 1",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 10, de d 2 1`] = `
+{
+  "_cmd": "wa v 10, de d 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, de d 3 1`] = `
+{
+  "_cmd": "wa v 10, de d 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, de d 4 1`] = `
+{
+  "_cmd": "wa v 10, de d 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de d 5 1`] = `
+{
+  "_cmd": "wa v 10, de d 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, de d 6 1`] = `
+{
+  "_cmd": "wa v 10, de d 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de d 7 1`] = `
+{
+  "_cmd": "wa v 10, de d 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de d 8 1`] = `
+{
+  "_cmd": "wa v 10, de d 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de d 9 1`] = `
+{
+  "_cmd": "wa v 10, de d 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de d 10 1`] = `
+{
+  "_cmd": "wa v 10, de d 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de d 11 1`] = `
+{
+  "_cmd": "wa v 10, de d 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de d 12 1`] = `
+{
+  "_cmd": "wa v 10, de d 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, de d 13 1`] = `
+{
+  "_cmd": "wa v 10, de d 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de d 14 1`] = `
+{
+  "_cmd": "wa v 10, de d 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de d 15 1`] = `
+{
+  "_cmd": "wa v 10, de d 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, de d v 1 1`] = `
+{
+  "_cmd": "wa v 10, de d v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, de d v 2 1`] = `
+{
+  "_cmd": "wa v 10, de d v 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, de d v 3 1`] = `
+{
+  "_cmd": "wa v 10, de d v 3",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, de d v 4 1`] = `
+{
+  "_cmd": "wa v 10, de d v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de d v 5 1`] = `
+{
+  "_cmd": "wa v 10, de d v 5",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, de d v 6 1`] = `
+{
+  "_cmd": "wa v 10, de d v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de d v 7 1`] = `
+{
+  "_cmd": "wa v 10, de d v 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, de d v 8 1`] = `
+{
+  "_cmd": "wa v 10, de d v 8",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de d v 9 1`] = `
+{
+  "_cmd": "wa v 10, de d v 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de d v 10 1`] = `
+{
+  "_cmd": "wa v 10, de d v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de d v 11 1`] = `
+{
+  "_cmd": "wa v 10, de d v 11",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de d v 12 1`] = `
+{
+  "_cmd": "wa v 10, de d v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de d v 13 1`] = `
+{
+  "_cmd": "wa v 10, de d v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, de d v 14 1`] = `
+{
+  "_cmd": "wa v 10, de d v 14",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de d v 15 1`] = `
+{
+  "_cmd": "wa v 10, de d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de d v 16 1`] = `
+{
+  "_cmd": "wa v 10, de d v 16",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, de d v 17 1`] = `
+{
+  "_cmd": "wa v 10, de d v 17",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 10, de d v 18 1`] = `
+{
+  "_cmd": "wa v 10, de d v 18",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 10, de d v 19 1`] = `
+{
+  "_cmd": "wa v 10, de d v 19",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 10, de d v 20 1`] = `
+{
+  "_cmd": "wa v 10, de d v 20",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 10, de p 1 1`] = `
+{
+  "_cmd": "wa v 10, de p 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, de p 2 1`] = `
+{
+  "_cmd": "wa v 10, de p 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, de p 3 1`] = `
+{
+  "_cmd": "wa v 10, de p 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, de p 4 1`] = `
+{
+  "_cmd": "wa v 10, de p 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, de p 5 1`] = `
+{
+  "_cmd": "wa v 10, de p 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de p 6 1`] = `
+{
+  "_cmd": "wa v 10, de p 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, de p 7 1`] = `
+{
+  "_cmd": "wa v 10, de p 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de p 8 1`] = `
+{
+  "_cmd": "wa v 10, de p 8",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, de p 9 1`] = `
+{
+  "_cmd": "wa v 10, de p 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de p 10 1`] = `
+{
+  "_cmd": "wa v 10, de p 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de p 11 1`] = `
+{
+  "_cmd": "wa v 10, de p 11",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de p 12 1`] = `
+{
+  "_cmd": "wa v 10, de p 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de p 13 1`] = `
+{
+  "_cmd": "wa v 10, de p 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de p 14 1`] = `
+{
+  "_cmd": "wa v 10, de p 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, de p 15 1`] = `
+{
+  "_cmd": "wa v 10, de p 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de p v 1 1`] = `
+{
+  "_cmd": "wa v 10, de p v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, de p v 2 1`] = `
+{
+  "_cmd": "wa v 10, de p v 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 10, de p v 3 1`] = `
+{
+  "_cmd": "wa v 10, de p v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, de p v 4 1`] = `
+{
+  "_cmd": "wa v 10, de p v 4",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, de p v 5 1`] = `
+{
+  "_cmd": "wa v 10, de p v 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de p v 6 1`] = `
+{
+  "_cmd": "wa v 10, de p v 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, de p v 7 1`] = `
+{
+  "_cmd": "wa v 10, de p v 7",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, de p v 8 1`] = `
+{
+  "_cmd": "wa v 10, de p v 8",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de p v 9 1`] = `
+{
+  "_cmd": "wa v 10, de p v 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de p v 10 1`] = `
+{
+  "_cmd": "wa v 10, de p v 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de p v 11 1`] = `
+{
+  "_cmd": "wa v 10, de p v 11",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de p v 12 1`] = `
+{
+  "_cmd": "wa v 10, de p v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de p v 13 1`] = `
+{
+  "_cmd": "wa v 10, de p v 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de p v 14 1`] = `
+{
+  "_cmd": "wa v 10, de p v 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, de p v 15 1`] = `
+{
+  "_cmd": "wa v 10, de p v 15",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de p v 16 1`] = `
+{
+  "_cmd": "wa v 10, de p v 16",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de p v 17 1`] = `
+{
+  "_cmd": "wa v 10, de p v 17",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, de p v 18 1`] = `
+{
+  "_cmd": "wa v 10, de p v 18",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, de p v 19 1`] = `
+{
+  "_cmd": "wa v 10, de p v 19",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 10, de p v 20 1`] = `
+{
+  "_cmd": "wa v 10, de p v 20",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 10, de v 1 1`] = `
+{
+  "_cmd": "wa v 10, de v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, de v 2 1`] = `
+{
+  "_cmd": "wa v 10, de v 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, de v 3 1`] = `
+{
+  "_cmd": "wa v 10, de v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, de v 4 1`] = `
+{
+  "_cmd": "wa v 10, de v 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, de v 5 1`] = `
+{
+  "_cmd": "wa v 10, de v 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de v 6 1`] = `
+{
+  "_cmd": "wa v 10, de v 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, de v 7 1`] = `
+{
+  "_cmd": "wa v 10, de v 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de v 8 1`] = `
+{
+  "_cmd": "wa v 10, de v 8",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, de v 9 1`] = `
+{
+  "_cmd": "wa v 10, de v 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de v 10 1`] = `
+{
+  "_cmd": "wa v 10, de v 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de v 11 1`] = `
+{
+  "_cmd": "wa v 10, de v 11",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de v 12 1`] = `
+{
+  "_cmd": "wa v 10, de v 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de v 13 1`] = `
+{
+  "_cmd": "wa v 10, de v 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de v 14 1`] = `
+{
+  "_cmd": "wa v 10, de v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de v 15 1`] = `
+{
+  "_cmd": "wa v 10, de v 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de v 16 1`] = `
+{
+  "_cmd": "wa v 10, de v 16",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, de v 17 1`] = `
+{
+  "_cmd": "wa v 10, de v 17",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, de v 18 1`] = `
+{
+  "_cmd": "wa v 10, de v 18",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 10, de v 19 1`] = `
+{
+  "_cmd": "wa v 10, de v 19",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 10, de v 20 1`] = `
+{
+  "_cmd": "wa v 10, de v 20",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 10, de w 1 1`] = `
+{
+  "_cmd": "wa v 10, de w 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, de w 2 1`] = `
+{
+  "_cmd": "wa v 10, de w 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, de w 3 1`] = `
+{
+  "_cmd": "wa v 10, de w 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, de w 4 1`] = `
+{
+  "_cmd": "wa v 10, de w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, de w 5 1`] = `
+{
+  "_cmd": "wa v 10, de w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, de w 6 1`] = `
+{
+  "_cmd": "wa v 10, de w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de w 7 1`] = `
+{
+  "_cmd": "wa v 10, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de w 8 1`] = `
+{
+  "_cmd": "wa v 10, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de w 9 1`] = `
+{
+  "_cmd": "wa v 10, de w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de w 10 1`] = `
+{
+  "_cmd": "wa v 10, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de w 11 1`] = `
+{
+  "_cmd": "wa v 10, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, de w 12 1`] = `
+{
+  "_cmd": "wa v 10, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de w 13 1`] = `
+{
+  "_cmd": "wa v 10, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de w 14 1`] = `
+{
+  "_cmd": "wa v 10, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, de w 15 1`] = `
+{
+  "_cmd": "wa v 10, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, de w v 1 1`] = `
+{
+  "_cmd": "wa v 10, de w v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, de w v 2 1`] = `
+{
+  "_cmd": "wa v 10, de w v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, de w v 3 1`] = `
+{
+  "_cmd": "wa v 10, de w v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, de w v 4 1`] = `
+{
+  "_cmd": "wa v 10, de w v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, de w v 5 1`] = `
+{
+  "_cmd": "wa v 10, de w v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, de w v 6 1`] = `
+{
+  "_cmd": "wa v 10, de w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, de w v 7 1`] = `
+{
+  "_cmd": "wa v 10, de w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, de w v 8 1`] = `
+{
+  "_cmd": "wa v 10, de w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, de w v 9 1`] = `
+{
+  "_cmd": "wa v 10, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, de w v 10 1`] = `
+{
+  "_cmd": "wa v 10, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, de w v 11 1`] = `
+{
+  "_cmd": "wa v 10, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, de w v 12 1`] = `
+{
+  "_cmd": "wa v 10, de w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, de w v 13 1`] = `
+{
+  "_cmd": "wa v 10, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, de w v 14 1`] = `
+{
+  "_cmd": "wa v 10, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, de w v 15 1`] = `
+{
+  "_cmd": "wa v 10, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, de w v 16 1`] = `
+{
+  "_cmd": "wa v 10, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 10, de w v 17 1`] = `
+{
+  "_cmd": "wa v 10, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 10, de w v 18 1`] = `
+{
+  "_cmd": "wa v 10, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 10, de w v 19 1`] = `
+{
+  "_cmd": "wa v 10, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 10, de w v 20 1`] = `
+{
+  "_cmd": "wa v 10, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 11, de d 1 1`] = `
+{
+  "_cmd": "wa v 11, de d 1",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, de d 2 1`] = `
+{
+  "_cmd": "wa v 11, de d 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, de d 3 1`] = `
+{
+  "_cmd": "wa v 11, de d 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, de d 4 1`] = `
+{
+  "_cmd": "wa v 11, de d 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, de d 5 1`] = `
+{
+  "_cmd": "wa v 11, de d 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, de d 6 1`] = `
+{
+  "_cmd": "wa v 11, de d 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, de d 7 1`] = `
+{
+  "_cmd": "wa v 11, de d 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de d 8 1`] = `
+{
+  "_cmd": "wa v 11, de d 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de d 9 1`] = `
+{
+  "_cmd": "wa v 11, de d 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de d 10 1`] = `
+{
+  "_cmd": "wa v 11, de d 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de d 11 1`] = `
+{
+  "_cmd": "wa v 11, de d 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de d 12 1`] = `
+{
+  "_cmd": "wa v 11, de d 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de d 13 1`] = `
+{
+  "_cmd": "wa v 11, de d 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de d 14 1`] = `
+{
+  "_cmd": "wa v 11, de d 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, de d 15 1`] = `
+{
+  "_cmd": "wa v 11, de d 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de d v 1 1`] = `
+{
+  "_cmd": "wa v 11, de d v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, de d v 2 1`] = `
+{
+  "_cmd": "wa v 11, de d v 2",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, de d v 3 1`] = `
+{
+  "_cmd": "wa v 11, de d v 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, de d v 4 1`] = `
+{
+  "_cmd": "wa v 11, de d v 4",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, de d v 5 1`] = `
+{
+  "_cmd": "wa v 11, de d v 5",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, de d v 6 1`] = `
+{
+  "_cmd": "wa v 11, de d v 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, de d v 7 1`] = `
+{
+  "_cmd": "wa v 11, de d v 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de d v 8 1`] = `
+{
+  "_cmd": "wa v 11, de d v 8",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, de d v 9 1`] = `
+{
+  "_cmd": "wa v 11, de d v 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de d v 10 1`] = `
+{
+  "_cmd": "wa v 11, de d v 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de d v 11 1`] = `
+{
+  "_cmd": "wa v 11, de d v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de d v 12 1`] = `
+{
+  "_cmd": "wa v 11, de d v 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de d v 13 1`] = `
+{
+  "_cmd": "wa v 11, de d v 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de d v 14 1`] = `
+{
+  "_cmd": "wa v 11, de d v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de d v 15 1`] = `
+{
+  "_cmd": "wa v 11, de d v 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, de d v 16 1`] = `
+{
+  "_cmd": "wa v 11, de d v 16",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de d v 17 1`] = `
+{
+  "_cmd": "wa v 11, de d v 17",
+  "attacker": 1,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 11, de d v 18 1`] = `
+{
+  "_cmd": "wa v 11, de d v 18",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 11, de d v 19 1`] = `
+{
+  "_cmd": "wa v 11, de d v 19",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 11, de d v 20 1`] = `
+{
+  "_cmd": "wa v 11, de d v 20",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 11, de p 1 1`] = `
+{
+  "_cmd": "wa v 11, de p 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, de p 2 1`] = `
+{
+  "_cmd": "wa v 11, de p 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, de p 3 1`] = `
+{
+  "_cmd": "wa v 11, de p 3",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, de p 4 1`] = `
+{
+  "_cmd": "wa v 11, de p 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, de p 5 1`] = `
+{
+  "_cmd": "wa v 11, de p 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, de p 6 1`] = `
+{
+  "_cmd": "wa v 11, de p 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, de p 7 1`] = `
+{
+  "_cmd": "wa v 11, de p 7",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, de p 8 1`] = `
+{
+  "_cmd": "wa v 11, de p 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de p 9 1`] = `
+{
+  "_cmd": "wa v 11, de p 9",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, de p 10 1`] = `
+{
+  "_cmd": "wa v 11, de p 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de p 11 1`] = `
+{
+  "_cmd": "wa v 11, de p 11",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de p 12 1`] = `
+{
+  "_cmd": "wa v 11, de p 12",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de p 13 1`] = `
+{
+  "_cmd": "wa v 11, de p 13",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de p 14 1`] = `
+{
+  "_cmd": "wa v 11, de p 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de p 15 1`] = `
+{
+  "_cmd": "wa v 11, de p 15",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de p v 1 1`] = `
+{
+  "_cmd": "wa v 11, de p v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, de p v 2 1`] = `
+{
+  "_cmd": "wa v 11, de p v 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, de p v 3 1`] = `
+{
+  "_cmd": "wa v 11, de p v 3",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, de p v 4 1`] = `
+{
+  "_cmd": "wa v 11, de p v 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, de p v 5 1`] = `
+{
+  "_cmd": "wa v 11, de p v 5",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, de p v 6 1`] = `
+{
+  "_cmd": "wa v 11, de p v 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, de p v 7 1`] = `
+{
+  "_cmd": "wa v 11, de p v 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, de p v 8 1`] = `
+{
+  "_cmd": "wa v 11, de p v 8",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, de p v 9 1`] = `
+{
+  "_cmd": "wa v 11, de p v 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, de p v 10 1`] = `
+{
+  "_cmd": "wa v 11, de p v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de p v 11 1`] = `
+{
+  "_cmd": "wa v 11, de p v 11",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de p v 12 1`] = `
+{
+  "_cmd": "wa v 11, de p v 12",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de p v 13 1`] = `
+{
+  "_cmd": "wa v 11, de p v 13",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de p v 14 1`] = `
+{
+  "_cmd": "wa v 11, de p v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de p v 15 1`] = `
+{
+  "_cmd": "wa v 11, de p v 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de p v 16 1`] = `
+{
+  "_cmd": "wa v 11, de p v 16",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, de p v 17 1`] = `
+{
+  "_cmd": "wa v 11, de p v 17",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de p v 18 1`] = `
+{
+  "_cmd": "wa v 11, de p v 18",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 11, de p v 19 1`] = `
+{
+  "_cmd": "wa v 11, de p v 19",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 11, de p v 20 1`] = `
+{
+  "_cmd": "wa v 11, de p v 20",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 11, de v 1 1`] = `
+{
+  "_cmd": "wa v 11, de v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, de v 2 1`] = `
+{
+  "_cmd": "wa v 11, de v 2",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, de v 3 1`] = `
+{
+  "_cmd": "wa v 11, de v 3",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, de v 4 1`] = `
+{
+  "_cmd": "wa v 11, de v 4",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, de v 5 1`] = `
+{
+  "_cmd": "wa v 11, de v 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, de v 6 1`] = `
+{
+  "_cmd": "wa v 11, de v 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, de v 7 1`] = `
+{
+  "_cmd": "wa v 11, de v 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, de v 8 1`] = `
+{
+  "_cmd": "wa v 11, de v 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de v 9 1`] = `
+{
+  "_cmd": "wa v 11, de v 9",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, de v 10 1`] = `
+{
+  "_cmd": "wa v 11, de v 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de v 11 1`] = `
+{
+  "_cmd": "wa v 11, de v 11",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de v 12 1`] = `
+{
+  "_cmd": "wa v 11, de v 12",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de v 13 1`] = `
+{
+  "_cmd": "wa v 11, de v 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de v 14 1`] = `
+{
+  "_cmd": "wa v 11, de v 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de v 15 1`] = `
+{
+  "_cmd": "wa v 11, de v 15",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de v 16 1`] = `
+{
+  "_cmd": "wa v 11, de v 16",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de v 17 1`] = `
+{
+  "_cmd": "wa v 11, de v 17",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 11, de v 18 1`] = `
+{
+  "_cmd": "wa v 11, de v 18",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 11, de v 19 1`] = `
+{
+  "_cmd": "wa v 11, de v 19",
+  "attacker": 2,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 11, de v 20 1`] = `
+{
+  "_cmd": "wa v 11, de v 20",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 11, de w 1 1`] = `
+{
+  "_cmd": "wa v 11, de w 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, de w 2 1`] = `
+{
+  "_cmd": "wa v 11, de w 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, de w 3 1`] = `
+{
+  "_cmd": "wa v 11, de w 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, de w 4 1`] = `
+{
+  "_cmd": "wa v 11, de w 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, de w 5 1`] = `
+{
+  "_cmd": "wa v 11, de w 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de w 6 1`] = `
+{
+  "_cmd": "wa v 11, de w 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, de w 7 1`] = `
+{
+  "_cmd": "wa v 11, de w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de w 8 1`] = `
+{
+  "_cmd": "wa v 11, de w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de w 9 1`] = `
+{
+  "_cmd": "wa v 11, de w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de w 10 1`] = `
+{
+  "_cmd": "wa v 11, de w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de w 11 1`] = `
+{
+  "_cmd": "wa v 11, de w 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de w 12 1`] = `
+{
+  "_cmd": "wa v 11, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, de w 13 1`] = `
+{
+  "_cmd": "wa v 11, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, de w 14 1`] = `
+{
+  "_cmd": "wa v 11, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de w 15 1`] = `
+{
+  "_cmd": "wa v 11, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 11, de w v 1 1`] = `
+{
+  "_cmd": "wa v 11, de w v 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, de w v 2 1`] = `
+{
+  "_cmd": "wa v 11, de w v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, de w v 3 1`] = `
+{
+  "_cmd": "wa v 11, de w v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, de w v 4 1`] = `
+{
+  "_cmd": "wa v 11, de w v 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, de w v 5 1`] = `
+{
+  "_cmd": "wa v 11, de w v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, de w v 6 1`] = `
+{
+  "_cmd": "wa v 11, de w v 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, de w v 7 1`] = `
+{
+  "_cmd": "wa v 11, de w v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, de w v 8 1`] = `
+{
+  "_cmd": "wa v 11, de w v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, de w v 9 1`] = `
+{
+  "_cmd": "wa v 11, de w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, de w v 10 1`] = `
+{
+  "_cmd": "wa v 11, de w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, de w v 11 1`] = `
+{
+  "_cmd": "wa v 11, de w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, de w v 12 1`] = `
+{
+  "_cmd": "wa v 11, de w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, de w v 13 1`] = `
+{
+  "_cmd": "wa v 11, de w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, de w v 14 1`] = `
+{
+  "_cmd": "wa v 11, de w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, de w v 15 1`] = `
+{
+  "_cmd": "wa v 11, de w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 11, de w v 16 1`] = `
+{
+  "_cmd": "wa v 11, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 11, de w v 17 1`] = `
+{
+  "_cmd": "wa v 11, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 11, de w v 18 1`] = `
+{
+  "_cmd": "wa v 11, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 11, de w v 19 1`] = `
+{
+  "_cmd": "wa v 11, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 11, de w v 20 1`] = `
+{
+  "_cmd": "wa v 11, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 12, de d 1 1`] = `
+{
+  "_cmd": "wa v 12, de d 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, de d 2 1`] = `
+{
+  "_cmd": "wa v 12, de d 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, de d 3 1`] = `
+{
+  "_cmd": "wa v 12, de d 3",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de d 4 1`] = `
+{
+  "_cmd": "wa v 12, de d 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, de d 5 1`] = `
+{
+  "_cmd": "wa v 12, de d 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de d 6 1`] = `
+{
+  "_cmd": "wa v 12, de d 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de d 7 1`] = `
+{
+  "_cmd": "wa v 12, de d 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, de d 8 1`] = `
+{
+  "_cmd": "wa v 12, de d 8",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, de d 9 1`] = `
+{
+  "_cmd": "wa v 12, de d 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de d 10 1`] = `
+{
+  "_cmd": "wa v 12, de d 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de d 11 1`] = `
+{
+  "_cmd": "wa v 12, de d 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de d 12 1`] = `
+{
+  "_cmd": "wa v 12, de d 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de d 13 1`] = `
+{
+  "_cmd": "wa v 12, de d 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de d 14 1`] = `
+{
+  "_cmd": "wa v 12, de d 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, de d 15 1`] = `
+{
+  "_cmd": "wa v 12, de d 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 12, de d v 1 1`] = `
+{
+  "_cmd": "wa v 12, de d v 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, de d v 2 1`] = `
+{
+  "_cmd": "wa v 12, de d v 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, de d v 3 1`] = `
+{
+  "_cmd": "wa v 12, de d v 3",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de d v 4 1`] = `
+{
+  "_cmd": "wa v 12, de d v 4",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 12, de d v 5 1`] = `
+{
+  "_cmd": "wa v 12, de d v 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de d v 6 1`] = `
+{
+  "_cmd": "wa v 12, de d v 6",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, de d v 7 1`] = `
+{
+  "_cmd": "wa v 12, de d v 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de d v 8 1`] = `
+{
+  "_cmd": "wa v 12, de d v 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, de d v 9 1`] = `
+{
+  "_cmd": "wa v 12, de d v 9",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de d v 10 1`] = `
+{
+  "_cmd": "wa v 12, de d v 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de d v 11 1`] = `
+{
+  "_cmd": "wa v 12, de d v 11",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de d v 12 1`] = `
+{
+  "_cmd": "wa v 12, de d v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de d v 13 1`] = `
+{
+  "_cmd": "wa v 12, de d v 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de d v 14 1`] = `
+{
+  "_cmd": "wa v 12, de d v 14",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, de d v 15 1`] = `
+{
+  "_cmd": "wa v 12, de d v 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, de d v 16 1`] = `
+{
+  "_cmd": "wa v 12, de d v 16",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 12, de d v 17 1`] = `
+{
+  "_cmd": "wa v 12, de d v 17",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, de d v 18 1`] = `
+{
+  "_cmd": "wa v 12, de d v 18",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 12, de d v 19 1`] = `
+{
+  "_cmd": "wa v 12, de d v 19",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 12, de d v 20 1`] = `
+{
+  "_cmd": "wa v 12, de d v 20",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 12, de p 1 1`] = `
+{
+  "_cmd": "wa v 12, de p 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, de p 2 1`] = `
+{
+  "_cmd": "wa v 12, de p 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, de p 3 1`] = `
+{
+  "_cmd": "wa v 12, de p 3",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 12, de p 4 1`] = `
+{
+  "_cmd": "wa v 12, de p 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de p 5 1`] = `
+{
+  "_cmd": "wa v 12, de p 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, de p 6 1`] = `
+{
+  "_cmd": "wa v 12, de p 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de p 7 1`] = `
+{
+  "_cmd": "wa v 12, de p 7",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, de p 8 1`] = `
+{
+  "_cmd": "wa v 12, de p 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, de p 9 1`] = `
+{
+  "_cmd": "wa v 12, de p 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, de p 10 1`] = `
+{
+  "_cmd": "wa v 12, de p 10",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de p 11 1`] = `
+{
+  "_cmd": "wa v 12, de p 11",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de p 12 1`] = `
+{
+  "_cmd": "wa v 12, de p 12",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de p 13 1`] = `
+{
+  "_cmd": "wa v 12, de p 13",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de p 14 1`] = `
+{
+  "_cmd": "wa v 12, de p 14",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de p 15 1`] = `
+{
+  "_cmd": "wa v 12, de p 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, de p v 1 1`] = `
+{
+  "_cmd": "wa v 12, de p v 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, de p v 2 1`] = `
+{
+  "_cmd": "wa v 12, de p v 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, de p v 3 1`] = `
+{
+  "_cmd": "wa v 12, de p v 3",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, de p v 4 1`] = `
+{
+  "_cmd": "wa v 12, de p v 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de p v 5 1`] = `
+{
+  "_cmd": "wa v 12, de p v 5",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 12, de p v 6 1`] = `
+{
+  "_cmd": "wa v 12, de p v 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de p v 7 1`] = `
+{
+  "_cmd": "wa v 12, de p v 7",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, de p v 8 1`] = `
+{
+  "_cmd": "wa v 12, de p v 8",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de p v 9 1`] = `
+{
+  "_cmd": "wa v 12, de p v 9",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, de p v 10 1`] = `
+{
+  "_cmd": "wa v 12, de p v 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de p v 11 1`] = `
+{
+  "_cmd": "wa v 12, de p v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de p v 12 1`] = `
+{
+  "_cmd": "wa v 12, de p v 12",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de p v 13 1`] = `
+{
+  "_cmd": "wa v 12, de p v 13",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de p v 14 1`] = `
+{
+  "_cmd": "wa v 12, de p v 14",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de p v 15 1`] = `
+{
+  "_cmd": "wa v 12, de p v 15",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de p v 16 1`] = `
+{
+  "_cmd": "wa v 12, de p v 16",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, de p v 17 1`] = `
+{
+  "_cmd": "wa v 12, de p v 17",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 12, de p v 18 1`] = `
+{
+  "_cmd": "wa v 12, de p v 18",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, de p v 19 1`] = `
+{
+  "_cmd": "wa v 12, de p v 19",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 12, de p v 20 1`] = `
+{
+  "_cmd": "wa v 12, de p v 20",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 12, de v 1 1`] = `
+{
+  "_cmd": "wa v 12, de v 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, de v 2 1`] = `
+{
+  "_cmd": "wa v 12, de v 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, de v 3 1`] = `
+{
+  "_cmd": "wa v 12, de v 3",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 12, de v 4 1`] = `
+{
+  "_cmd": "wa v 12, de v 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de v 5 1`] = `
+{
+  "_cmd": "wa v 12, de v 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, de v 6 1`] = `
+{
+  "_cmd": "wa v 12, de v 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de v 7 1`] = `
+{
+  "_cmd": "wa v 12, de v 7",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de v 8 1`] = `
+{
+  "_cmd": "wa v 12, de v 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, de v 9 1`] = `
+{
+  "_cmd": "wa v 12, de v 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, de v 10 1`] = `
+{
+  "_cmd": "wa v 12, de v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de v 11 1`] = `
+{
+  "_cmd": "wa v 12, de v 11",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de v 12 1`] = `
+{
+  "_cmd": "wa v 12, de v 12",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de v 13 1`] = `
+{
+  "_cmd": "wa v 12, de v 13",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de v 14 1`] = `
+{
+  "_cmd": "wa v 12, de v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de v 15 1`] = `
+{
+  "_cmd": "wa v 12, de v 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, de v 16 1`] = `
+{
+  "_cmd": "wa v 12, de v 16",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, de v 17 1`] = `
+{
+  "_cmd": "wa v 12, de v 17",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, de v 18 1`] = `
+{
+  "_cmd": "wa v 12, de v 18",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 12, de v 19 1`] = `
+{
+  "_cmd": "wa v 12, de v 19",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 12, de v 20 1`] = `
+{
+  "_cmd": "wa v 12, de v 20",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 12, de w 1 1`] = `
+{
+  "_cmd": "wa v 12, de w 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, de w 2 1`] = `
+{
+  "_cmd": "wa v 12, de w 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de w 3 1`] = `
+{
+  "_cmd": "wa v 12, de w 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, de w 4 1`] = `
+{
+  "_cmd": "wa v 12, de w 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, de w 5 1`] = `
+{
+  "_cmd": "wa v 12, de w 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de w 6 1`] = `
+{
+  "_cmd": "wa v 12, de w 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, de w 7 1`] = `
+{
+  "_cmd": "wa v 12, de w 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de w 8 1`] = `
+{
+  "_cmd": "wa v 12, de w 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de w 9 1`] = `
+{
+  "_cmd": "wa v 12, de w 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de w 10 1`] = `
+{
+  "_cmd": "wa v 12, de w 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de w 11 1`] = `
+{
+  "_cmd": "wa v 12, de w 11",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de w 12 1`] = `
+{
+  "_cmd": "wa v 12, de w 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, de w 13 1`] = `
+{
+  "_cmd": "wa v 12, de w 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, de w 14 1`] = `
+{
+  "_cmd": "wa v 12, de w 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 12, de w 15 1`] = `
+{
+  "_cmd": "wa v 12, de w 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, de w v 1 1`] = `
+{
+  "_cmd": "wa v 12, de w v 1",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, de w v 2 1`] = `
+{
+  "_cmd": "wa v 12, de w v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, de w v 3 1`] = `
+{
+  "_cmd": "wa v 12, de w v 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, de w v 4 1`] = `
+{
+  "_cmd": "wa v 12, de w v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, de w v 5 1`] = `
+{
+  "_cmd": "wa v 12, de w v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, de w v 6 1`] = `
+{
+  "_cmd": "wa v 12, de w v 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, de w v 7 1`] = `
+{
+  "_cmd": "wa v 12, de w v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, de w v 8 1`] = `
+{
+  "_cmd": "wa v 12, de w v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, de w v 9 1`] = `
+{
+  "_cmd": "wa v 12, de w v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, de w v 10 1`] = `
+{
+  "_cmd": "wa v 12, de w v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, de w v 11 1`] = `
+{
+  "_cmd": "wa v 12, de w v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, de w v 12 1`] = `
+{
+  "_cmd": "wa v 12, de w v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, de w v 13 1`] = `
+{
+  "_cmd": "wa v 12, de w v 13",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, de w v 14 1`] = `
+{
+  "_cmd": "wa v 12, de w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 12, de w v 15 1`] = `
+{
+  "_cmd": "wa v 12, de w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, de w v 16 1`] = `
+{
+  "_cmd": "wa v 12, de w v 16",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 12, de w v 17 1`] = `
+{
+  "_cmd": "wa v 12, de w v 17",
+  "attacker": 0,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 12, de w v 18 1`] = `
+{
+  "_cmd": "wa v 12, de w v 18",
+  "attacker": 0,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 12, de w v 19 1`] = `
+{
+  "_cmd": "wa v 12, de w v 19",
+  "attacker": 0,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 12, de w v 20 1`] = `
+{
+  "_cmd": "wa v 12, de w v 20",
+  "attacker": 0,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 13, de d 1 1`] = `
+{
+  "_cmd": "wa v 13, de d 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, de d 2 1`] = `
+{
+  "_cmd": "wa v 13, de d 2",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, de d 3 1`] = `
+{
+  "_cmd": "wa v 13, de d 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de d 4 1`] = `
+{
+  "_cmd": "wa v 13, de d 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de d 5 1`] = `
+{
+  "_cmd": "wa v 13, de d 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, de d 6 1`] = `
+{
+  "_cmd": "wa v 13, de d 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, de d 7 1`] = `
+{
+  "_cmd": "wa v 13, de d 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, de d 8 1`] = `
+{
+  "_cmd": "wa v 13, de d 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de d 9 1`] = `
+{
+  "_cmd": "wa v 13, de d 9",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, de d 10 1`] = `
+{
+  "_cmd": "wa v 13, de d 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de d 11 1`] = `
+{
+  "_cmd": "wa v 13, de d 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de d 12 1`] = `
+{
+  "_cmd": "wa v 13, de d 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, de d 13 1`] = `
+{
+  "_cmd": "wa v 13, de d 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de d 14 1`] = `
+{
+  "_cmd": "wa v 13, de d 14",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de d 15 1`] = `
+{
+  "_cmd": "wa v 13, de d 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, de d v 1 1`] = `
+{
+  "_cmd": "wa v 13, de d v 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, de d v 2 1`] = `
+{
+  "_cmd": "wa v 13, de d v 2",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, de d v 3 1`] = `
+{
+  "_cmd": "wa v 13, de d v 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de d v 4 1`] = `
+{
+  "_cmd": "wa v 13, de d v 4",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, de d v 5 1`] = `
+{
+  "_cmd": "wa v 13, de d v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, de d v 6 1`] = `
+{
+  "_cmd": "wa v 13, de d v 6",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, de d v 7 1`] = `
+{
+  "_cmd": "wa v 13, de d v 7",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, de d v 8 1`] = `
+{
+  "_cmd": "wa v 13, de d v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de d v 9 1`] = `
+{
+  "_cmd": "wa v 13, de d v 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, de d v 10 1`] = `
+{
+  "_cmd": "wa v 13, de d v 10",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de d v 11 1`] = `
+{
+  "_cmd": "wa v 13, de d v 11",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de d v 12 1`] = `
+{
+  "_cmd": "wa v 13, de d v 12",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de d v 13 1`] = `
+{
+  "_cmd": "wa v 13, de d v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de d v 14 1`] = `
+{
+  "_cmd": "wa v 13, de d v 14",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de d v 15 1`] = `
+{
+  "_cmd": "wa v 13, de d v 15",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, de d v 16 1`] = `
+{
+  "_cmd": "wa v 13, de d v 16",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 13, de d v 17 1`] = `
+{
+  "_cmd": "wa v 13, de d v 17",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 13, de d v 18 1`] = `
+{
+  "_cmd": "wa v 13, de d v 18",
+  "attacker": 4,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 13, de d v 19 1`] = `
+{
+  "_cmd": "wa v 13, de d v 19",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 13, de d v 20 1`] = `
+{
+  "_cmd": "wa v 13, de d v 20",
+  "attacker": 3,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 13, de p 1 1`] = `
+{
+  "_cmd": "wa v 13, de p 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, de p 2 1`] = `
+{
+  "_cmd": "wa v 13, de p 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, de p 3 1`] = `
+{
+  "_cmd": "wa v 13, de p 3",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, de p 4 1`] = `
+{
+  "_cmd": "wa v 13, de p 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de p 5 1`] = `
+{
+  "_cmd": "wa v 13, de p 5",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de p 6 1`] = `
+{
+  "_cmd": "wa v 13, de p 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, de p 7 1`] = `
+{
+  "_cmd": "wa v 13, de p 7",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, de p 8 1`] = `
+{
+  "_cmd": "wa v 13, de p 8",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, de p 9 1`] = `
+{
+  "_cmd": "wa v 13, de p 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de p 10 1`] = `
+{
+  "_cmd": "wa v 13, de p 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, de p 11 1`] = `
+{
+  "_cmd": "wa v 13, de p 11",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de p 12 1`] = `
+{
+  "_cmd": "wa v 13, de p 12",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de p 13 1`] = `
+{
+  "_cmd": "wa v 13, de p 13",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, de p 14 1`] = `
+{
+  "_cmd": "wa v 13, de p 14",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de p 15 1`] = `
+{
+  "_cmd": "wa v 13, de p 15",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de p v 1 1`] = `
+{
+  "_cmd": "wa v 13, de p v 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, de p v 2 1`] = `
+{
+  "_cmd": "wa v 13, de p v 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, de p v 3 1`] = `
+{
+  "_cmd": "wa v 13, de p v 3",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, de p v 4 1`] = `
+{
+  "_cmd": "wa v 13, de p v 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de p v 5 1`] = `
+{
+  "_cmd": "wa v 13, de p v 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, de p v 6 1`] = `
+{
+  "_cmd": "wa v 13, de p v 6",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de p v 7 1`] = `
+{
+  "_cmd": "wa v 13, de p v 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, de p v 8 1`] = `
+{
+  "_cmd": "wa v 13, de p v 8",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, de p v 9 1`] = `
+{
+  "_cmd": "wa v 13, de p v 9",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, de p v 10 1`] = `
+{
+  "_cmd": "wa v 13, de p v 10",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de p v 11 1`] = `
+{
+  "_cmd": "wa v 13, de p v 11",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de p v 12 1`] = `
+{
+  "_cmd": "wa v 13, de p v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de p v 13 1`] = `
+{
+  "_cmd": "wa v 13, de p v 13",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de p v 14 1`] = `
+{
+  "_cmd": "wa v 13, de p v 14",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, de p v 15 1`] = `
+{
+  "_cmd": "wa v 13, de p v 15",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de p v 16 1`] = `
+{
+  "_cmd": "wa v 13, de p v 16",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de p v 17 1`] = `
+{
+  "_cmd": "wa v 13, de p v 17",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 13, de p v 18 1`] = `
+{
+  "_cmd": "wa v 13, de p v 18",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 13, de p v 19 1`] = `
+{
+  "_cmd": "wa v 13, de p v 19",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 13, de p v 20 1`] = `
+{
+  "_cmd": "wa v 13, de p v 20",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 13, de v 1 1`] = `
+{
+  "_cmd": "wa v 13, de v 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, de v 2 1`] = `
+{
+  "_cmd": "wa v 13, de v 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, de v 3 1`] = `
+{
+  "_cmd": "wa v 13, de v 3",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, de v 4 1`] = `
+{
+  "_cmd": "wa v 13, de v 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de v 5 1`] = `
+{
+  "_cmd": "wa v 13, de v 5",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de v 6 1`] = `
+{
+  "_cmd": "wa v 13, de v 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, de v 7 1`] = `
+{
+  "_cmd": "wa v 13, de v 7",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, de v 8 1`] = `
+{
+  "_cmd": "wa v 13, de v 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, de v 9 1`] = `
+{
+  "_cmd": "wa v 13, de v 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de v 10 1`] = `
+{
+  "_cmd": "wa v 13, de v 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, de v 11 1`] = `
+{
+  "_cmd": "wa v 13, de v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de v 12 1`] = `
+{
+  "_cmd": "wa v 13, de v 12",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de v 13 1`] = `
+{
+  "_cmd": "wa v 13, de v 13",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, de v 14 1`] = `
+{
+  "_cmd": "wa v 13, de v 14",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de v 15 1`] = `
+{
+  "_cmd": "wa v 13, de v 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de v 16 1`] = `
+{
+  "_cmd": "wa v 13, de v 16",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, de v 17 1`] = `
+{
+  "_cmd": "wa v 13, de v 17",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 13, de v 18 1`] = `
+{
+  "_cmd": "wa v 13, de v 18",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 13, de v 19 1`] = `
+{
+  "_cmd": "wa v 13, de v 19",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 13, de v 20 1`] = `
+{
+  "_cmd": "wa v 13, de v 20",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 13, de w 1 1`] = `
+{
+  "_cmd": "wa v 13, de w 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, de w 2 1`] = `
+{
+  "_cmd": "wa v 13, de w 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de w 3 1`] = `
+{
+  "_cmd": "wa v 13, de w 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de w 4 1`] = `
+{
+  "_cmd": "wa v 13, de w 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, de w 5 1`] = `
+{
+  "_cmd": "wa v 13, de w 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, de w 6 1`] = `
+{
+  "_cmd": "wa v 13, de w 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de w 7 1`] = `
+{
+  "_cmd": "wa v 13, de w 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, de w 8 1`] = `
+{
+  "_cmd": "wa v 13, de w 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de w 9 1`] = `
+{
+  "_cmd": "wa v 13, de w 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de w 10 1`] = `
+{
+  "_cmd": "wa v 13, de w 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de w 11 1`] = `
+{
+  "_cmd": "wa v 13, de w 11",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de w 12 1`] = `
+{
+  "_cmd": "wa v 13, de w 12",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de w 13 1`] = `
+{
+  "_cmd": "wa v 13, de w 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, de w 14 1`] = `
+{
+  "_cmd": "wa v 13, de w 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 13, de w 15 1`] = `
+{
+  "_cmd": "wa v 13, de w 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 13, de w v 1 1`] = `
+{
+  "_cmd": "wa v 13, de w v 1",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, de w v 2 1`] = `
+{
+  "_cmd": "wa v 13, de w v 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, de w v 3 1`] = `
+{
+  "_cmd": "wa v 13, de w v 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, de w v 4 1`] = `
+{
+  "_cmd": "wa v 13, de w v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, de w v 5 1`] = `
+{
+  "_cmd": "wa v 13, de w v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, de w v 6 1`] = `
+{
+  "_cmd": "wa v 13, de w v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, de w v 7 1`] = `
+{
+  "_cmd": "wa v 13, de w v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, de w v 8 1`] = `
+{
+  "_cmd": "wa v 13, de w v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, de w v 9 1`] = `
+{
+  "_cmd": "wa v 13, de w v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, de w v 10 1`] = `
+{
+  "_cmd": "wa v 13, de w v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, de w v 11 1`] = `
+{
+  "_cmd": "wa v 13, de w v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, de w v 12 1`] = `
+{
+  "_cmd": "wa v 13, de w v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, de w v 13 1`] = `
+{
+  "_cmd": "wa v 13, de w v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, de w v 14 1`] = `
+{
+  "_cmd": "wa v 13, de w v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, de w v 15 1`] = `
+{
+  "_cmd": "wa v 13, de w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 13, de w v 16 1`] = `
+{
+  "_cmd": "wa v 13, de w v 16",
+  "attacker": 2,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 13, de w v 17 1`] = `
+{
+  "_cmd": "wa v 13, de w v 17",
+  "attacker": 1,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 13, de w v 18 1`] = `
+{
+  "_cmd": "wa v 13, de w v 18",
+  "attacker": 1,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 13, de w v 19 1`] = `
+{
+  "_cmd": "wa v 13, de w v 19",
+  "attacker": 1,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 13, de w v 20 1`] = `
+{
+  "_cmd": "wa v 13, de w v 20",
+  "attacker": 1,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 14, de d 1 1`] = `
+{
+  "_cmd": "wa v 14, de d 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, de d 2 1`] = `
+{
+  "_cmd": "wa v 14, de d 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, de d 3 1`] = `
+{
+  "_cmd": "wa v 14, de d 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de d 4 1`] = `
+{
+  "_cmd": "wa v 14, de d 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, de d 5 1`] = `
+{
+  "_cmd": "wa v 14, de d 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, de d 6 1`] = `
+{
+  "_cmd": "wa v 14, de d 6",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de d 7 1`] = `
+{
+  "_cmd": "wa v 14, de d 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de d 8 1`] = `
+{
+  "_cmd": "wa v 14, de d 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, de d 9 1`] = `
+{
+  "_cmd": "wa v 14, de d 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de d 10 1`] = `
+{
+  "_cmd": "wa v 14, de d 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de d 11 1`] = `
+{
+  "_cmd": "wa v 14, de d 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de d 12 1`] = `
+{
+  "_cmd": "wa v 14, de d 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de d 13 1`] = `
+{
+  "_cmd": "wa v 14, de d 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, de d 14 1`] = `
+{
+  "_cmd": "wa v 14, de d 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de d 15 1`] = `
+{
+  "_cmd": "wa v 14, de d 15",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de d v 1 1`] = `
+{
+  "_cmd": "wa v 14, de d v 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, de d v 2 1`] = `
+{
+  "_cmd": "wa v 14, de d v 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, de d v 3 1`] = `
+{
+  "_cmd": "wa v 14, de d v 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, de d v 4 1`] = `
+{
+  "_cmd": "wa v 14, de d v 4",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, de d v 5 1`] = `
+{
+  "_cmd": "wa v 14, de d v 5",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, de d v 6 1`] = `
+{
+  "_cmd": "wa v 14, de d v 6",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de d v 7 1`] = `
+{
+  "_cmd": "wa v 14, de d v 7",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, de d v 8 1`] = `
+{
+  "_cmd": "wa v 14, de d v 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de d v 9 1`] = `
+{
+  "_cmd": "wa v 14, de d v 9",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de d v 10 1`] = `
+{
+  "_cmd": "wa v 14, de d v 10",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, de d v 11 1`] = `
+{
+  "_cmd": "wa v 14, de d v 11",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de d v 12 1`] = `
+{
+  "_cmd": "wa v 14, de d v 12",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de d v 13 1`] = `
+{
+  "_cmd": "wa v 14, de d v 13",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de d v 14 1`] = `
+{
+  "_cmd": "wa v 14, de d v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de d v 15 1`] = `
+{
+  "_cmd": "wa v 14, de d v 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de d v 16 1`] = `
+{
+  "_cmd": "wa v 14, de d v 16",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 14, de d v 17 1`] = `
+{
+  "_cmd": "wa v 14, de d v 17",
+  "attacker": 5,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 14, de d v 18 1`] = `
+{
+  "_cmd": "wa v 14, de d v 18",
+  "attacker": 5,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 14, de d v 19 1`] = `
+{
+  "_cmd": "wa v 14, de d v 19",
+  "attacker": 5,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 14, de d v 20 1`] = `
+{
+  "_cmd": "wa v 14, de d v 20",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 14, de p 1 1`] = `
+{
+  "_cmd": "wa v 14, de p 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, de p 2 1`] = `
+{
+  "_cmd": "wa v 14, de p 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, de p 3 1`] = `
+{
+  "_cmd": "wa v 14, de p 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, de p 4 1`] = `
+{
+  "_cmd": "wa v 14, de p 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de p 5 1`] = `
+{
+  "_cmd": "wa v 14, de p 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, de p 6 1`] = `
+{
+  "_cmd": "wa v 14, de p 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, de p 7 1`] = `
+{
+  "_cmd": "wa v 14, de p 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de p 8 1`] = `
+{
+  "_cmd": "wa v 14, de p 8",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, de p 9 1`] = `
+{
+  "_cmd": "wa v 14, de p 9",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, de p 10 1`] = `
+{
+  "_cmd": "wa v 14, de p 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de p 11 1`] = `
+{
+  "_cmd": "wa v 14, de p 11",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, de p 12 1`] = `
+{
+  "_cmd": "wa v 14, de p 12",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de p 13 1`] = `
+{
+  "_cmd": "wa v 14, de p 13",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de p 14 1`] = `
+{
+  "_cmd": "wa v 14, de p 14",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, de p 15 1`] = `
+{
+  "_cmd": "wa v 14, de p 15",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de p v 1 1`] = `
+{
+  "_cmd": "wa v 14, de p v 1",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 14, de p v 2 1`] = `
+{
+  "_cmd": "wa v 14, de p v 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, de p v 3 1`] = `
+{
+  "_cmd": "wa v 14, de p v 3",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, de p v 4 1`] = `
+{
+  "_cmd": "wa v 14, de p v 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de p v 5 1`] = `
+{
+  "_cmd": "wa v 14, de p v 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, de p v 6 1`] = `
+{
+  "_cmd": "wa v 14, de p v 6",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, de p v 7 1`] = `
+{
+  "_cmd": "wa v 14, de p v 7",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de p v 8 1`] = `
+{
+  "_cmd": "wa v 14, de p v 8",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, de p v 9 1`] = `
+{
+  "_cmd": "wa v 14, de p v 9",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de p v 10 1`] = `
+{
+  "_cmd": "wa v 14, de p v 10",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, de p v 11 1`] = `
+{
+  "_cmd": "wa v 14, de p v 11",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de p v 12 1`] = `
+{
+  "_cmd": "wa v 14, de p v 12",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de p v 13 1`] = `
+{
+  "_cmd": "wa v 14, de p v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de p v 14 1`] = `
+{
+  "_cmd": "wa v 14, de p v 14",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de p v 15 1`] = `
+{
+  "_cmd": "wa v 14, de p v 15",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, de p v 16 1`] = `
+{
+  "_cmd": "wa v 14, de p v 16",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de p v 17 1`] = `
+{
+  "_cmd": "wa v 14, de p v 17",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de p v 18 1`] = `
+{
+  "_cmd": "wa v 14, de p v 18",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 14, de p v 19 1`] = `
+{
+  "_cmd": "wa v 14, de p v 19",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 14, de p v 20 1`] = `
+{
+  "_cmd": "wa v 14, de p v 20",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 14, de v 1 1`] = `
+{
+  "_cmd": "wa v 14, de v 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, de v 2 1`] = `
+{
+  "_cmd": "wa v 14, de v 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, de v 3 1`] = `
+{
+  "_cmd": "wa v 14, de v 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, de v 4 1`] = `
+{
+  "_cmd": "wa v 14, de v 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de v 5 1`] = `
+{
+  "_cmd": "wa v 14, de v 5",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, de v 6 1`] = `
+{
+  "_cmd": "wa v 14, de v 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, de v 7 1`] = `
+{
+  "_cmd": "wa v 14, de v 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de v 8 1`] = `
+{
+  "_cmd": "wa v 14, de v 8",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de v 9 1`] = `
+{
+  "_cmd": "wa v 14, de v 9",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, de v 10 1`] = `
+{
+  "_cmd": "wa v 14, de v 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de v 11 1`] = `
+{
+  "_cmd": "wa v 14, de v 11",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, de v 12 1`] = `
+{
+  "_cmd": "wa v 14, de v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de v 13 1`] = `
+{
+  "_cmd": "wa v 14, de v 13",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de v 14 1`] = `
+{
+  "_cmd": "wa v 14, de v 14",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, de v 15 1`] = `
+{
+  "_cmd": "wa v 14, de v 15",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de v 16 1`] = `
+{
+  "_cmd": "wa v 14, de v 16",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de v 17 1`] = `
+{
+  "_cmd": "wa v 14, de v 17",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 14, de v 18 1`] = `
+{
+  "_cmd": "wa v 14, de v 18",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 14, de v 19 1`] = `
+{
+  "_cmd": "wa v 14, de v 19",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 14, de v 20 1`] = `
+{
+  "_cmd": "wa v 14, de v 20",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 14, de w 1 1`] = `
+{
+  "_cmd": "wa v 14, de w 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, de w 2 1`] = `
+{
+  "_cmd": "wa v 14, de w 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de w 3 1`] = `
+{
+  "_cmd": "wa v 14, de w 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, de w 4 1`] = `
+{
+  "_cmd": "wa v 14, de w 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, de w 5 1`] = `
+{
+  "_cmd": "wa v 14, de w 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, de w 6 1`] = `
+{
+  "_cmd": "wa v 14, de w 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de w 7 1`] = `
+{
+  "_cmd": "wa v 14, de w 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de w 8 1`] = `
+{
+  "_cmd": "wa v 14, de w 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, de w 9 1`] = `
+{
+  "_cmd": "wa v 14, de w 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de w 10 1`] = `
+{
+  "_cmd": "wa v 14, de w 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de w 11 1`] = `
+{
+  "_cmd": "wa v 14, de w 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de w 12 1`] = `
+{
+  "_cmd": "wa v 14, de w 12",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de w 13 1`] = `
+{
+  "_cmd": "wa v 14, de w 13",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de w 14 1`] = `
+{
+  "_cmd": "wa v 14, de w 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 14, de w 15 1`] = `
+{
+  "_cmd": "wa v 14, de w 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 14, de w v 1 1`] = `
+{
+  "_cmd": "wa v 14, de w v 1",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, de w v 2 1`] = `
+{
+  "_cmd": "wa v 14, de w v 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, de w v 3 1`] = `
+{
+  "_cmd": "wa v 14, de w v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, de w v 4 1`] = `
+{
+  "_cmd": "wa v 14, de w v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, de w v 5 1`] = `
+{
+  "_cmd": "wa v 14, de w v 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, de w v 6 1`] = `
+{
+  "_cmd": "wa v 14, de w v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, de w v 7 1`] = `
+{
+  "_cmd": "wa v 14, de w v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, de w v 8 1`] = `
+{
+  "_cmd": "wa v 14, de w v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, de w v 9 1`] = `
+{
+  "_cmd": "wa v 14, de w v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, de w v 10 1`] = `
+{
+  "_cmd": "wa v 14, de w v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, de w v 11 1`] = `
+{
+  "_cmd": "wa v 14, de w v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, de w v 12 1`] = `
+{
+  "_cmd": "wa v 14, de w v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, de w v 13 1`] = `
+{
+  "_cmd": "wa v 14, de w v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, de w v 14 1`] = `
+{
+  "_cmd": "wa v 14, de w v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, de w v 15 1`] = `
+{
+  "_cmd": "wa v 14, de w v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 14, de w v 16 1`] = `
+{
+  "_cmd": "wa v 14, de w v 16",
+  "attacker": 3,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 14, de w v 17 1`] = `
+{
+  "_cmd": "wa v 14, de w v 17",
+  "attacker": 3,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 14, de w v 18 1`] = `
+{
+  "_cmd": "wa v 14, de w v 18",
+  "attacker": 2,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 14, de w v 19 1`] = `
+{
+  "_cmd": "wa v 14, de w v 19",
+  "attacker": 2,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 14, de w v 20 1`] = `
+{
+  "_cmd": "wa v 14, de w v 20",
+  "attacker": 2,
+  "defender": 19,
+}
+`;
+
+exports[`wa v 15, de d 1 1`] = `
+{
+  "_cmd": "wa v 15, de d 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, de d 2 1`] = `
+{
+  "_cmd": "wa v 15, de d 2",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, de d 3 1`] = `
+{
+  "_cmd": "wa v 15, de d 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, de d 4 1`] = `
+{
+  "_cmd": "wa v 15, de d 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de d 5 1`] = `
+{
+  "_cmd": "wa v 15, de d 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, de d 6 1`] = `
+{
+  "_cmd": "wa v 15, de d 6",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de d 7 1`] = `
+{
+  "_cmd": "wa v 15, de d 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de d 8 1`] = `
+{
+  "_cmd": "wa v 15, de d 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, de d 9 1`] = `
+{
+  "_cmd": "wa v 15, de d 9",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de d 10 1`] = `
+{
+  "_cmd": "wa v 15, de d 10",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de d 11 1`] = `
+{
+  "_cmd": "wa v 15, de d 11",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de d 12 1`] = `
+{
+  "_cmd": "wa v 15, de d 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de d 13 1`] = `
+{
+  "_cmd": "wa v 15, de d 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, de d 14 1`] = `
+{
+  "_cmd": "wa v 15, de d 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de d 15 1`] = `
+{
+  "_cmd": "wa v 15, de d 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de d v 1 1`] = `
+{
+  "_cmd": "wa v 15, de d v 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, de d v 2 1`] = `
+{
+  "_cmd": "wa v 15, de d v 2",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, de d v 3 1`] = `
+{
+  "_cmd": "wa v 15, de d v 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, de d v 4 1`] = `
+{
+  "_cmd": "wa v 15, de d v 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de d v 5 1`] = `
+{
+  "_cmd": "wa v 15, de d v 5",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, de d v 6 1`] = `
+{
+  "_cmd": "wa v 15, de d v 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de d v 7 1`] = `
+{
+  "_cmd": "wa v 15, de d v 7",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, de d v 8 1`] = `
+{
+  "_cmd": "wa v 15, de d v 8",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de d v 9 1`] = `
+{
+  "_cmd": "wa v 15, de d v 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de d v 10 1`] = `
+{
+  "_cmd": "wa v 15, de d v 10",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de d v 11 1`] = `
+{
+  "_cmd": "wa v 15, de d v 11",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, de d v 12 1`] = `
+{
+  "_cmd": "wa v 15, de d v 12",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de d v 13 1`] = `
+{
+  "_cmd": "wa v 15, de d v 13",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de d v 14 1`] = `
+{
+  "_cmd": "wa v 15, de d v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de d v 15 1`] = `
+{
+  "_cmd": "wa v 15, de d v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de d v 16 1`] = `
+{
+  "_cmd": "wa v 15, de d v 16",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, de d v 17 1`] = `
+{
+  "_cmd": "wa v 15, de d v 17",
+  "attacker": 6,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 15, de d v 18 1`] = `
+{
+  "_cmd": "wa v 15, de d v 18",
+  "attacker": 6,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 15, de d v 19 1`] = `
+{
+  "_cmd": "wa v 15, de d v 19",
+  "attacker": 6,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 15, de d v 20 1`] = `
+{
+  "_cmd": "wa v 15, de d v 20",
+  "attacker": 6,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 15, de p 1 1`] = `
+{
+  "_cmd": "wa v 15, de p 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, de p 2 1`] = `
+{
+  "_cmd": "wa v 15, de p 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, de p 3 1`] = `
+{
+  "_cmd": "wa v 15, de p 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, de p 4 1`] = `
+{
+  "_cmd": "wa v 15, de p 4",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, de p 5 1`] = `
+{
+  "_cmd": "wa v 15, de p 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de p 6 1`] = `
+{
+  "_cmd": "wa v 15, de p 6",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, de p 7 1`] = `
+{
+  "_cmd": "wa v 15, de p 7",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de p 8 1`] = `
+{
+  "_cmd": "wa v 15, de p 8",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, de p 9 1`] = `
+{
+  "_cmd": "wa v 15, de p 9",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de p 10 1`] = `
+{
+  "_cmd": "wa v 15, de p 10",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de p 11 1`] = `
+{
+  "_cmd": "wa v 15, de p 11",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de p 12 1`] = `
+{
+  "_cmd": "wa v 15, de p 12",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, de p 13 1`] = `
+{
+  "_cmd": "wa v 15, de p 13",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de p 14 1`] = `
+{
+  "_cmd": "wa v 15, de p 14",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de p 15 1`] = `
+{
+  "_cmd": "wa v 15, de p 15",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de p v 1 1`] = `
+{
+  "_cmd": "wa v 15, de p v 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 15, de p v 2 1`] = `
+{
+  "_cmd": "wa v 15, de p v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, de p v 3 1`] = `
+{
+  "_cmd": "wa v 15, de p v 3",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, de p v 4 1`] = `
+{
+  "_cmd": "wa v 15, de p v 4",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, de p v 5 1`] = `
+{
+  "_cmd": "wa v 15, de p v 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de p v 6 1`] = `
+{
+  "_cmd": "wa v 15, de p v 6",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, de p v 7 1`] = `
+{
+  "_cmd": "wa v 15, de p v 7",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, de p v 8 1`] = `
+{
+  "_cmd": "wa v 15, de p v 8",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, de p v 9 1`] = `
+{
+  "_cmd": "wa v 15, de p v 9",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de p v 10 1`] = `
+{
+  "_cmd": "wa v 15, de p v 10",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, de p v 11 1`] = `
+{
+  "_cmd": "wa v 15, de p v 11",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de p v 12 1`] = `
+{
+  "_cmd": "wa v 15, de p v 12",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de p v 13 1`] = `
+{
+  "_cmd": "wa v 15, de p v 13",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de p v 14 1`] = `
+{
+  "_cmd": "wa v 15, de p v 14",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de p v 15 1`] = `
+{
+  "_cmd": "wa v 15, de p v 15",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, de p v 16 1`] = `
+{
+  "_cmd": "wa v 15, de p v 16",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de p v 17 1`] = `
+{
+  "_cmd": "wa v 15, de p v 17",
+  "attacker": 9,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de p v 18 1`] = `
+{
+  "_cmd": "wa v 15, de p v 18",
+  "attacker": 8,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, de p v 19 1`] = `
+{
+  "_cmd": "wa v 15, de p v 19",
+  "attacker": 8,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 15, de p v 20 1`] = `
+{
+  "_cmd": "wa v 15, de p v 20",
+  "attacker": 8,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 15, de v 1 1`] = `
+{
+  "_cmd": "wa v 15, de v 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, de v 2 1`] = `
+{
+  "_cmd": "wa v 15, de v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, de v 3 1`] = `
+{
+  "_cmd": "wa v 15, de v 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, de v 4 1`] = `
+{
+  "_cmd": "wa v 15, de v 4",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, de v 5 1`] = `
+{
+  "_cmd": "wa v 15, de v 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de v 6 1`] = `
+{
+  "_cmd": "wa v 15, de v 6",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, de v 7 1`] = `
+{
+  "_cmd": "wa v 15, de v 7",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de v 8 1`] = `
+{
+  "_cmd": "wa v 15, de v 8",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, de v 9 1`] = `
+{
+  "_cmd": "wa v 15, de v 9",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, de v 10 1`] = `
+{
+  "_cmd": "wa v 15, de v 10",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de v 11 1`] = `
+{
+  "_cmd": "wa v 15, de v 11",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de v 12 1`] = `
+{
+  "_cmd": "wa v 15, de v 12",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, de v 13 1`] = `
+{
+  "_cmd": "wa v 15, de v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de v 14 1`] = `
+{
+  "_cmd": "wa v 15, de v 14",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, de v 15 1`] = `
+{
+  "_cmd": "wa v 15, de v 15",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de v 16 1`] = `
+{
+  "_cmd": "wa v 15, de v 16",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de v 17 1`] = `
+{
+  "_cmd": "wa v 15, de v 17",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, de v 18 1`] = `
+{
+  "_cmd": "wa v 15, de v 18",
+  "attacker": 7,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 15, de v 19 1`] = `
+{
+  "_cmd": "wa v 15, de v 19",
+  "attacker": 7,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 15, de v 20 1`] = `
+{
+  "_cmd": "wa v 15, de v 20",
+  "attacker": 7,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 15, de w 1 1`] = `
+{
+  "_cmd": "wa v 15, de w 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, de w 2 1`] = `
+{
+  "_cmd": "wa v 15, de w 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, de w 3 1`] = `
+{
+  "_cmd": "wa v 15, de w 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, de w 4 1`] = `
+{
+  "_cmd": "wa v 15, de w 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de w 5 1`] = `
+{
+  "_cmd": "wa v 15, de w 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, de w 6 1`] = `
+{
+  "_cmd": "wa v 15, de w 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de w 7 1`] = `
+{
+  "_cmd": "wa v 15, de w 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de w 8 1`] = `
+{
+  "_cmd": "wa v 15, de w 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, de w 9 1`] = `
+{
+  "_cmd": "wa v 15, de w 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, de w 10 1`] = `
+{
+  "_cmd": "wa v 15, de w 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de w 11 1`] = `
+{
+  "_cmd": "wa v 15, de w 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de w 12 1`] = `
+{
+  "_cmd": "wa v 15, de w 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, de w 13 1`] = `
+{
+  "_cmd": "wa v 15, de w 13",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de w 14 1`] = `
+{
+  "_cmd": "wa v 15, de w 14",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, de w 15 1`] = `
+{
+  "_cmd": "wa v 15, de w 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 15, de w v 1 1`] = `
+{
+  "_cmd": "wa v 15, de w v 1",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, de w v 2 1`] = `
+{
+  "_cmd": "wa v 15, de w v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, de w v 3 1`] = `
+{
+  "_cmd": "wa v 15, de w v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, de w v 4 1`] = `
+{
+  "_cmd": "wa v 15, de w v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, de w v 5 1`] = `
+{
+  "_cmd": "wa v 15, de w v 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, de w v 6 1`] = `
+{
+  "_cmd": "wa v 15, de w v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, de w v 7 1`] = `
+{
+  "_cmd": "wa v 15, de w v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, de w v 8 1`] = `
+{
+  "_cmd": "wa v 15, de w v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, de w v 9 1`] = `
+{
+  "_cmd": "wa v 15, de w v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, de w v 10 1`] = `
+{
+  "_cmd": "wa v 15, de w v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, de w v 11 1`] = `
+{
+  "_cmd": "wa v 15, de w v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, de w v 12 1`] = `
+{
+  "_cmd": "wa v 15, de w v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, de w v 13 1`] = `
+{
+  "_cmd": "wa v 15, de w v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, de w v 14 1`] = `
+{
+  "_cmd": "wa v 15, de w v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, de w v 15 1`] = `
+{
+  "_cmd": "wa v 15, de w v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, de w v 16 1`] = `
+{
+  "_cmd": "wa v 15, de w v 16",
+  "attacker": 4,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 15, de w v 17 1`] = `
+{
+  "_cmd": "wa v 15, de w v 17",
+  "attacker": 4,
+  "defender": 16,
+}
+`;
+
+exports[`wa v 15, de w v 18 1`] = `
+{
+  "_cmd": "wa v 15, de w v 18",
+  "attacker": 4,
+  "defender": 17,
+}
+`;
+
+exports[`wa v 15, de w v 19 1`] = `
+{
+  "_cmd": "wa v 15, de w v 19",
+  "attacker": 4,
+  "defender": 18,
+}
+`;
+
+exports[`wa v 15, de w v 20 1`] = `
+{
+  "_cmd": "wa v 15, de w v 20",
+  "attacker": 3,
+  "defender": 19,
+}
+`;

--- a/bot/tests/simpleCalc/__snapshots__/wa-vs-wa.test.js.snap
+++ b/bot/tests/simpleCalc/__snapshots__/wa-vs-wa.test.js.snap
@@ -1,0 +1,28801 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`wa b 1, wa d 1 1`] = `
+{
+  "_cmd": "wa b 1, wa d 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 1, wa d 2 1`] = `
+{
+  "_cmd": "wa b 1, wa d 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, wa d 3 1`] = `
+{
+  "_cmd": "wa b 1, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, wa d 4 1`] = `
+{
+  "_cmd": "wa b 1, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, wa d 5 1`] = `
+{
+  "_cmd": "wa b 1, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa d 6 1`] = `
+{
+  "_cmd": "wa b 1, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa d 7 1`] = `
+{
+  "_cmd": "wa b 1, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa d 8 1`] = `
+{
+  "_cmd": "wa b 1, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, wa d 9 1`] = `
+{
+  "_cmd": "wa b 1, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa d 10 1`] = `
+{
+  "_cmd": "wa b 1, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 1, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 1, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, wa p 1 1`] = `
+{
+  "_cmd": "wa b 1, wa p 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 1, wa p 2 1`] = `
+{
+  "_cmd": "wa b 1, wa p 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 1, wa p 3 1`] = `
+{
+  "_cmd": "wa b 1, wa p 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, wa p 4 1`] = `
+{
+  "_cmd": "wa b 1, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, wa p 5 1`] = `
+{
+  "_cmd": "wa b 1, wa p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, wa p 6 1`] = `
+{
+  "_cmd": "wa b 1, wa p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa p 7 1`] = `
+{
+  "_cmd": "wa b 1, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa p 8 1`] = `
+{
+  "_cmd": "wa b 1, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa p 9 1`] = `
+{
+  "_cmd": "wa b 1, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, wa p 10 1`] = `
+{
+  "_cmd": "wa b 1, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 1",
+  "attacker": 1,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 1, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 2",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 1, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 3",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 4",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 1, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, wa v 1 1`] = `
+{
+  "_cmd": "wa b 1, wa v 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 1, wa v 2 1`] = `
+{
+  "_cmd": "wa b 1, wa v 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 1, wa v 3 1`] = `
+{
+  "_cmd": "wa b 1, wa v 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 1, wa v 4 1`] = `
+{
+  "_cmd": "wa b 1, wa v 4",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, wa v 5 1`] = `
+{
+  "_cmd": "wa b 1, wa v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, wa v 6 1`] = `
+{
+  "_cmd": "wa b 1, wa v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa v 7 1`] = `
+{
+  "_cmd": "wa b 1, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa v 8 1`] = `
+{
+  "_cmd": "wa b 1, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa v 9 1`] = `
+{
+  "_cmd": "wa b 1, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, wa v 10 1`] = `
+{
+  "_cmd": "wa b 1, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa v 11 1`] = `
+{
+  "_cmd": "wa b 1, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa v 12 1`] = `
+{
+  "_cmd": "wa b 1, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, wa v 13 1`] = `
+{
+  "_cmd": "wa b 1, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, wa v 14 1`] = `
+{
+  "_cmd": "wa b 1, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, wa v 15 1`] = `
+{
+  "_cmd": "wa b 1, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, wa w 1 1`] = `
+{
+  "_cmd": "wa b 1, wa w 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 1, wa w 2 1`] = `
+{
+  "_cmd": "wa b 1, wa w 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, wa w 3 1`] = `
+{
+  "_cmd": "wa b 1, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 1, wa w 4 1`] = `
+{
+  "_cmd": "wa b 1, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa w 5 1`] = `
+{
+  "_cmd": "wa b 1, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, wa w 6 1`] = `
+{
+  "_cmd": "wa b 1, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa w 7 1`] = `
+{
+  "_cmd": "wa b 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, wa w 8 1`] = `
+{
+  "_cmd": "wa b 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa w 9 1`] = `
+{
+  "_cmd": "wa b 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa w 10 1`] = `
+{
+  "_cmd": "wa b 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 1, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 1, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 1, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 1, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 1, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 1, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 1, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 1, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 1, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 1, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 1, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 1, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 1, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 1, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 1, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b 2, wa d 1 1`] = `
+{
+  "_cmd": "wa b 2, wa d 1",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 2, wa d 2 1`] = `
+{
+  "_cmd": "wa b 2, wa d 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, wa d 3 1`] = `
+{
+  "_cmd": "wa b 2, wa d 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, wa d 4 1`] = `
+{
+  "_cmd": "wa b 2, wa d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, wa d 5 1`] = `
+{
+  "_cmd": "wa b 2, wa d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa d 6 1`] = `
+{
+  "_cmd": "wa b 2, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, wa d 7 1`] = `
+{
+  "_cmd": "wa b 2, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, wa d 8 1`] = `
+{
+  "_cmd": "wa b 2, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa d 9 1`] = `
+{
+  "_cmd": "wa b 2, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa d 10 1`] = `
+{
+  "_cmd": "wa b 2, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 2, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 2, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 2, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, wa p 1 1`] = `
+{
+  "_cmd": "wa b 2, wa p 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, wa p 2 1`] = `
+{
+  "_cmd": "wa b 2, wa p 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 2, wa p 3 1`] = `
+{
+  "_cmd": "wa b 2, wa p 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, wa p 4 1`] = `
+{
+  "_cmd": "wa b 2, wa p 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, wa p 5 1`] = `
+{
+  "_cmd": "wa b 2, wa p 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, wa p 6 1`] = `
+{
+  "_cmd": "wa b 2, wa p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa p 7 1`] = `
+{
+  "_cmd": "wa b 2, wa p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, wa p 8 1`] = `
+{
+  "_cmd": "wa b 2, wa p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, wa p 9 1`] = `
+{
+  "_cmd": "wa b 2, wa p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa p 10 1`] = `
+{
+  "_cmd": "wa b 2, wa p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 2",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 2, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 3",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 4",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 2, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 5",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 2, wa p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, wa v 1 1`] = `
+{
+  "_cmd": "wa b 2, wa v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 2, wa v 2 1`] = `
+{
+  "_cmd": "wa b 2, wa v 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 2, wa v 3 1`] = `
+{
+  "_cmd": "wa b 2, wa v 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, wa v 4 1`] = `
+{
+  "_cmd": "wa b 2, wa v 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, wa v 5 1`] = `
+{
+  "_cmd": "wa b 2, wa v 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, wa v 6 1`] = `
+{
+  "_cmd": "wa b 2, wa v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa v 7 1`] = `
+{
+  "_cmd": "wa b 2, wa v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, wa v 8 1`] = `
+{
+  "_cmd": "wa b 2, wa v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, wa v 9 1`] = `
+{
+  "_cmd": "wa b 2, wa v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa v 10 1`] = `
+{
+  "_cmd": "wa b 2, wa v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa v 11 1`] = `
+{
+  "_cmd": "wa b 2, wa v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, wa v 12 1`] = `
+{
+  "_cmd": "wa b 2, wa v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, wa v 13 1`] = `
+{
+  "_cmd": "wa b 2, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, wa v 14 1`] = `
+{
+  "_cmd": "wa b 2, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, wa v 15 1`] = `
+{
+  "_cmd": "wa b 2, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, wa w 1 1`] = `
+{
+  "_cmd": "wa b 2, wa w 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 2, wa w 2 1`] = `
+{
+  "_cmd": "wa b 2, wa w 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 2, wa w 3 1`] = `
+{
+  "_cmd": "wa b 2, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 2, wa w 4 1`] = `
+{
+  "_cmd": "wa b 2, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa w 5 1`] = `
+{
+  "_cmd": "wa b 2, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, wa w 6 1`] = `
+{
+  "_cmd": "wa b 2, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 2, wa w 7 1`] = `
+{
+  "_cmd": "wa b 2, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa w 8 1`] = `
+{
+  "_cmd": "wa b 2, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa w 9 1`] = `
+{
+  "_cmd": "wa b 2, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, wa w 10 1`] = `
+{
+  "_cmd": "wa b 2, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 1",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 2, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 2, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 2, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 2, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 2, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 2, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 2, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 2, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 2, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 2, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 2, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 2, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 2, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 2, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 2, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 3, wa d 1 1`] = `
+{
+  "_cmd": "wa b 3, wa d 1",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 3, wa d 2 1`] = `
+{
+  "_cmd": "wa b 3, wa d 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, wa d 3 1`] = `
+{
+  "_cmd": "wa b 3, wa d 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, wa d 4 1`] = `
+{
+  "_cmd": "wa b 3, wa d 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, wa d 5 1`] = `
+{
+  "_cmd": "wa b 3, wa d 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, wa d 6 1`] = `
+{
+  "_cmd": "wa b 3, wa d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa d 7 1`] = `
+{
+  "_cmd": "wa b 3, wa d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, wa d 8 1`] = `
+{
+  "_cmd": "wa b 3, wa d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, wa d 9 1`] = `
+{
+  "_cmd": "wa b 3, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa d 10 1`] = `
+{
+  "_cmd": "wa b 3, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 3, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 3, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 3, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 3, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, wa p 1 1`] = `
+{
+  "_cmd": "wa b 3, wa p 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 3, wa p 2 1`] = `
+{
+  "_cmd": "wa b 3, wa p 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 3, wa p 3 1`] = `
+{
+  "_cmd": "wa b 3, wa p 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, wa p 4 1`] = `
+{
+  "_cmd": "wa b 3, wa p 4",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, wa p 5 1`] = `
+{
+  "_cmd": "wa b 3, wa p 5",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, wa p 6 1`] = `
+{
+  "_cmd": "wa b 3, wa p 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, wa p 7 1`] = `
+{
+  "_cmd": "wa b 3, wa p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, wa p 8 1`] = `
+{
+  "_cmd": "wa b 3, wa p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa p 9 1`] = `
+{
+  "_cmd": "wa b 3, wa p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, wa p 10 1`] = `
+{
+  "_cmd": "wa b 3, wa p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 1",
+  "attacker": 3,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 3, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 2",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 3, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 3",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 3, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 4",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 5",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 6",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 3, wa p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, wa v 1 1`] = `
+{
+  "_cmd": "wa b 3, wa v 1",
+  "attacker": 3,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 3, wa v 2 1`] = `
+{
+  "_cmd": "wa b 3, wa v 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 3, wa v 3 1`] = `
+{
+  "_cmd": "wa b 3, wa v 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, wa v 4 1`] = `
+{
+  "_cmd": "wa b 3, wa v 4",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 3, wa v 5 1`] = `
+{
+  "_cmd": "wa b 3, wa v 5",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, wa v 6 1`] = `
+{
+  "_cmd": "wa b 3, wa v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, wa v 7 1`] = `
+{
+  "_cmd": "wa b 3, wa v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, wa v 8 1`] = `
+{
+  "_cmd": "wa b 3, wa v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa v 9 1`] = `
+{
+  "_cmd": "wa b 3, wa v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, wa v 10 1`] = `
+{
+  "_cmd": "wa b 3, wa v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa v 11 1`] = `
+{
+  "_cmd": "wa b 3, wa v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa v 12 1`] = `
+{
+  "_cmd": "wa b 3, wa v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, wa v 13 1`] = `
+{
+  "_cmd": "wa b 3, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, wa v 14 1`] = `
+{
+  "_cmd": "wa b 3, wa v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, wa v 15 1`] = `
+{
+  "_cmd": "wa b 3, wa v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, wa w 1 1`] = `
+{
+  "_cmd": "wa b 3, wa w 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 3, wa w 2 1`] = `
+{
+  "_cmd": "wa b 3, wa w 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 3, wa w 3 1`] = `
+{
+  "_cmd": "wa b 3, wa w 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 3, wa w 4 1`] = `
+{
+  "_cmd": "wa b 3, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 3, wa w 5 1`] = `
+{
+  "_cmd": "wa b 3, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa w 6 1`] = `
+{
+  "_cmd": "wa b 3, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, wa w 7 1`] = `
+{
+  "_cmd": "wa b 3, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa w 8 1`] = `
+{
+  "_cmd": "wa b 3, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa w 9 1`] = `
+{
+  "_cmd": "wa b 3, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 3, wa w 10 1`] = `
+{
+  "_cmd": "wa b 3, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 3, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 3, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 3, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 3, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 3, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 3, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 3, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 3, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 3, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 3, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 3, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 3, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 3, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 3, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 3, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 4, wa d 1 1`] = `
+{
+  "_cmd": "wa b 4, wa d 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 4, wa d 2 1`] = `
+{
+  "_cmd": "wa b 4, wa d 2",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, wa d 3 1`] = `
+{
+  "_cmd": "wa b 4, wa d 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, wa d 4 1`] = `
+{
+  "_cmd": "wa b 4, wa d 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, wa d 5 1`] = `
+{
+  "_cmd": "wa b 4, wa d 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa d 6 1`] = `
+{
+  "_cmd": "wa b 4, wa d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, wa d 7 1`] = `
+{
+  "_cmd": "wa b 4, wa d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa d 8 1`] = `
+{
+  "_cmd": "wa b 4, wa d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa d 9 1`] = `
+{
+  "_cmd": "wa b 4, wa d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, wa d 10 1`] = `
+{
+  "_cmd": "wa b 4, wa d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 4, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 4, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 5",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 4, wa d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, wa p 1 1`] = `
+{
+  "_cmd": "wa b 4, wa p 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, wa p 2 1`] = `
+{
+  "_cmd": "wa b 4, wa p 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, wa p 3 1`] = `
+{
+  "_cmd": "wa b 4, wa p 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, wa p 4 1`] = `
+{
+  "_cmd": "wa b 4, wa p 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, wa p 5 1`] = `
+{
+  "_cmd": "wa b 4, wa p 5",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, wa p 6 1`] = `
+{
+  "_cmd": "wa b 4, wa p 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa p 7 1`] = `
+{
+  "_cmd": "wa b 4, wa p 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, wa p 8 1`] = `
+{
+  "_cmd": "wa b 4, wa p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa p 9 1`] = `
+{
+  "_cmd": "wa b 4, wa p 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, wa p 10 1`] = `
+{
+  "_cmd": "wa b 4, wa p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 3",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 4",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 4, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 5",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 6",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 7",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 8",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 10",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 11",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 4, wa p v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, wa v 1 1`] = `
+{
+  "_cmd": "wa b 4, wa v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 4, wa v 2 1`] = `
+{
+  "_cmd": "wa b 4, wa v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 4, wa v 3 1`] = `
+{
+  "_cmd": "wa b 4, wa v 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, wa v 4 1`] = `
+{
+  "_cmd": "wa b 4, wa v 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, wa v 5 1`] = `
+{
+  "_cmd": "wa b 4, wa v 5",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, wa v 6 1`] = `
+{
+  "_cmd": "wa b 4, wa v 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa v 7 1`] = `
+{
+  "_cmd": "wa b 4, wa v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, wa v 8 1`] = `
+{
+  "_cmd": "wa b 4, wa v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa v 9 1`] = `
+{
+  "_cmd": "wa b 4, wa v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, wa v 10 1`] = `
+{
+  "_cmd": "wa b 4, wa v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa v 11 1`] = `
+{
+  "_cmd": "wa b 4, wa v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, wa v 12 1`] = `
+{
+  "_cmd": "wa b 4, wa v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, wa v 13 1`] = `
+{
+  "_cmd": "wa b 4, wa v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, wa v 14 1`] = `
+{
+  "_cmd": "wa b 4, wa v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, wa v 15 1`] = `
+{
+  "_cmd": "wa b 4, wa v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 4, wa w 1 1`] = `
+{
+  "_cmd": "wa b 4, wa w 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 4, wa w 2 1`] = `
+{
+  "_cmd": "wa b 4, wa w 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 4, wa w 3 1`] = `
+{
+  "_cmd": "wa b 4, wa w 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa w 4 1`] = `
+{
+  "_cmd": "wa b 4, wa w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 4, wa w 5 1`] = `
+{
+  "_cmd": "wa b 4, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa w 6 1`] = `
+{
+  "_cmd": "wa b 4, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 4, wa w 7 1`] = `
+{
+  "_cmd": "wa b 4, wa w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa w 8 1`] = `
+{
+  "_cmd": "wa b 4, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, wa w 9 1`] = `
+{
+  "_cmd": "wa b 4, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, wa w 10 1`] = `
+{
+  "_cmd": "wa b 4, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 4, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 2",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 4, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 4, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 4, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 4, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 4, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 4, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 4, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 4, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 4, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 4, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 4, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 4, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 4, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 4, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b 5, wa d 1 1`] = `
+{
+  "_cmd": "wa b 5, wa d 1",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 5, wa d 2 1`] = `
+{
+  "_cmd": "wa b 5, wa d 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, wa d 3 1`] = `
+{
+  "_cmd": "wa b 5, wa d 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, wa d 4 1`] = `
+{
+  "_cmd": "wa b 5, wa d 4",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, wa d 5 1`] = `
+{
+  "_cmd": "wa b 5, wa d 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, wa d 6 1`] = `
+{
+  "_cmd": "wa b 5, wa d 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa d 7 1`] = `
+{
+  "_cmd": "wa b 5, wa d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, wa d 8 1`] = `
+{
+  "_cmd": "wa b 5, wa d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, wa d 9 1`] = `
+{
+  "_cmd": "wa b 5, wa d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa d 10 1`] = `
+{
+  "_cmd": "wa b 5, wa d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 5, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 6",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 5, wa d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, wa p 1 1`] = `
+{
+  "_cmd": "wa b 5, wa p 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, wa p 2 1`] = `
+{
+  "_cmd": "wa b 5, wa p 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, wa p 3 1`] = `
+{
+  "_cmd": "wa b 5, wa p 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 5, wa p 4 1`] = `
+{
+  "_cmd": "wa b 5, wa p 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, wa p 5 1`] = `
+{
+  "_cmd": "wa b 5, wa p 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, wa p 6 1`] = `
+{
+  "_cmd": "wa b 5, wa p 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, wa p 7 1`] = `
+{
+  "_cmd": "wa b 5, wa p 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa p 8 1`] = `
+{
+  "_cmd": "wa b 5, wa p 8",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, wa p 9 1`] = `
+{
+  "_cmd": "wa b 5, wa p 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, wa p 10 1`] = `
+{
+  "_cmd": "wa b 5, wa p 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 2",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 5, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 3",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 4",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 5, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 5",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 6",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 7",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 8",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 9",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 10",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 11",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 12",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 13",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 14",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 5, wa p v 15",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, wa v 1 1`] = `
+{
+  "_cmd": "wa b 5, wa v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 5, wa v 2 1`] = `
+{
+  "_cmd": "wa b 5, wa v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, wa v 3 1`] = `
+{
+  "_cmd": "wa b 5, wa v 3",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, wa v 4 1`] = `
+{
+  "_cmd": "wa b 5, wa v 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, wa v 5 1`] = `
+{
+  "_cmd": "wa b 5, wa v 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, wa v 6 1`] = `
+{
+  "_cmd": "wa b 5, wa v 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, wa v 7 1`] = `
+{
+  "_cmd": "wa b 5, wa v 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa v 8 1`] = `
+{
+  "_cmd": "wa b 5, wa v 8",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, wa v 9 1`] = `
+{
+  "_cmd": "wa b 5, wa v 9",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, wa v 10 1`] = `
+{
+  "_cmd": "wa b 5, wa v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa v 11 1`] = `
+{
+  "_cmd": "wa b 5, wa v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, wa v 12 1`] = `
+{
+  "_cmd": "wa b 5, wa v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa v 13 1`] = `
+{
+  "_cmd": "wa b 5, wa v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, wa v 14 1`] = `
+{
+  "_cmd": "wa b 5, wa v 14",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, wa v 15 1`] = `
+{
+  "_cmd": "wa b 5, wa v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, wa w 1 1`] = `
+{
+  "_cmd": "wa b 5, wa w 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 5, wa w 2 1`] = `
+{
+  "_cmd": "wa b 5, wa w 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 5, wa w 3 1`] = `
+{
+  "_cmd": "wa b 5, wa w 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 5, wa w 4 1`] = `
+{
+  "_cmd": "wa b 5, wa w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa w 5 1`] = `
+{
+  "_cmd": "wa b 5, wa w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 5, wa w 6 1`] = `
+{
+  "_cmd": "wa b 5, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, wa w 7 1`] = `
+{
+  "_cmd": "wa b 5, wa w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa w 8 1`] = `
+{
+  "_cmd": "wa b 5, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 5, wa w 9 1`] = `
+{
+  "_cmd": "wa b 5, wa w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa w 10 1`] = `
+{
+  "_cmd": "wa b 5, wa w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 5, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 5, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 5, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 5, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 5, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 5, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 5, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 5, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 5, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 5, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 5, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 5, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 5, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 5, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 5, wa w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 6, wa d 1 1`] = `
+{
+  "_cmd": "wa b 6, wa d 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 6, wa d 2 1`] = `
+{
+  "_cmd": "wa b 6, wa d 2",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, wa d 3 1`] = `
+{
+  "_cmd": "wa b 6, wa d 3",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, wa d 4 1`] = `
+{
+  "_cmd": "wa b 6, wa d 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, wa d 5 1`] = `
+{
+  "_cmd": "wa b 6, wa d 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa d 6 1`] = `
+{
+  "_cmd": "wa b 6, wa d 6",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, wa d 7 1`] = `
+{
+  "_cmd": "wa b 6, wa d 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, wa d 8 1`] = `
+{
+  "_cmd": "wa b 6, wa d 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa d 9 1`] = `
+{
+  "_cmd": "wa b 6, wa d 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, wa d 10 1`] = `
+{
+  "_cmd": "wa b 6, wa d 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 6, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 5",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 8",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 9",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 6, wa d v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 6, wa p 1 1`] = `
+{
+  "_cmd": "wa b 6, wa p 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, wa p 2 1`] = `
+{
+  "_cmd": "wa b 6, wa p 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, wa p 3 1`] = `
+{
+  "_cmd": "wa b 6, wa p 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, wa p 4 1`] = `
+{
+  "_cmd": "wa b 6, wa p 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, wa p 5 1`] = `
+{
+  "_cmd": "wa b 6, wa p 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, wa p 6 1`] = `
+{
+  "_cmd": "wa b 6, wa p 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa p 7 1`] = `
+{
+  "_cmd": "wa b 6, wa p 7",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, wa p 8 1`] = `
+{
+  "_cmd": "wa b 6, wa p 8",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, wa p 9 1`] = `
+{
+  "_cmd": "wa b 6, wa p 9",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, wa p 10 1`] = `
+{
+  "_cmd": "wa b 6, wa p 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 1",
+  "attacker": 6,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 6, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 2",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 6, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 4",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 6, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 5",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 6",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 7",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 8",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 10",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 11",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 12",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 13",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 14",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 6, wa p v 15",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, wa v 1 1`] = `
+{
+  "_cmd": "wa b 6, wa v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 6, wa v 2 1`] = `
+{
+  "_cmd": "wa b 6, wa v 2",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 6, wa v 3 1`] = `
+{
+  "_cmd": "wa b 6, wa v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, wa v 4 1`] = `
+{
+  "_cmd": "wa b 6, wa v 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 6, wa v 5 1`] = `
+{
+  "_cmd": "wa b 6, wa v 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, wa v 6 1`] = `
+{
+  "_cmd": "wa b 6, wa v 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa v 7 1`] = `
+{
+  "_cmd": "wa b 6, wa v 7",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, wa v 8 1`] = `
+{
+  "_cmd": "wa b 6, wa v 8",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, wa v 9 1`] = `
+{
+  "_cmd": "wa b 6, wa v 9",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, wa v 10 1`] = `
+{
+  "_cmd": "wa b 6, wa v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa v 11 1`] = `
+{
+  "_cmd": "wa b 6, wa v 11",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, wa v 12 1`] = `
+{
+  "_cmd": "wa b 6, wa v 12",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, wa v 13 1`] = `
+{
+  "_cmd": "wa b 6, wa v 13",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, wa v 14 1`] = `
+{
+  "_cmd": "wa b 6, wa v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, wa v 15 1`] = `
+{
+  "_cmd": "wa b 6, wa v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, wa w 1 1`] = `
+{
+  "_cmd": "wa b 6, wa w 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 6, wa w 2 1`] = `
+{
+  "_cmd": "wa b 6, wa w 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 6, wa w 3 1`] = `
+{
+  "_cmd": "wa b 6, wa w 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa w 4 1`] = `
+{
+  "_cmd": "wa b 6, wa w 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 6, wa w 5 1`] = `
+{
+  "_cmd": "wa b 6, wa w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, wa w 6 1`] = `
+{
+  "_cmd": "wa b 6, wa w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 6, wa w 7 1`] = `
+{
+  "_cmd": "wa b 6, wa w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, wa w 8 1`] = `
+{
+  "_cmd": "wa b 6, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, wa w 9 1`] = `
+{
+  "_cmd": "wa b 6, wa w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 6, wa w 10 1`] = `
+{
+  "_cmd": "wa b 6, wa w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 6, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 6, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 3",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 6, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 6, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 6, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 6, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 6, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 6, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 6, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 6, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 6, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 6, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 6, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 6, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 6, wa w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 7, wa d 1 1`] = `
+{
+  "_cmd": "wa b 7, wa d 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, wa d 2 1`] = `
+{
+  "_cmd": "wa b 7, wa d 2",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, wa d 3 1`] = `
+{
+  "_cmd": "wa b 7, wa d 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, wa d 4 1`] = `
+{
+  "_cmd": "wa b 7, wa d 4",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, wa d 5 1`] = `
+{
+  "_cmd": "wa b 7, wa d 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, wa d 6 1`] = `
+{
+  "_cmd": "wa b 7, wa d 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, wa d 7 1`] = `
+{
+  "_cmd": "wa b 7, wa d 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa d 8 1`] = `
+{
+  "_cmd": "wa b 7, wa d 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, wa d 9 1`] = `
+{
+  "_cmd": "wa b 7, wa d 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, wa d 10 1`] = `
+{
+  "_cmd": "wa b 7, wa d 10",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 7",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 9",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 10",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 13",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 14",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 7, wa d v 15",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, wa p 1 1`] = `
+{
+  "_cmd": "wa b 7, wa p 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, wa p 2 1`] = `
+{
+  "_cmd": "wa b 7, wa p 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, wa p 3 1`] = `
+{
+  "_cmd": "wa b 7, wa p 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, wa p 4 1`] = `
+{
+  "_cmd": "wa b 7, wa p 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, wa p 5 1`] = `
+{
+  "_cmd": "wa b 7, wa p 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, wa p 6 1`] = `
+{
+  "_cmd": "wa b 7, wa p 6",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, wa p 7 1`] = `
+{
+  "_cmd": "wa b 7, wa p 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, wa p 8 1`] = `
+{
+  "_cmd": "wa b 7, wa p 8",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, wa p 9 1`] = `
+{
+  "_cmd": "wa b 7, wa p 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa p 10 1`] = `
+{
+  "_cmd": "wa b 7, wa p 10",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 1",
+  "attacker": 7,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 7, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 3",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 5",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 6",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 7",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 8",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 9",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 11",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 12",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 13",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 14",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 7, wa p v 15",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, wa v 1 1`] = `
+{
+  "_cmd": "wa b 7, wa v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 7, wa v 2 1`] = `
+{
+  "_cmd": "wa b 7, wa v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, wa v 3 1`] = `
+{
+  "_cmd": "wa b 7, wa v 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 7, wa v 4 1`] = `
+{
+  "_cmd": "wa b 7, wa v 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, wa v 5 1`] = `
+{
+  "_cmd": "wa b 7, wa v 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, wa v 6 1`] = `
+{
+  "_cmd": "wa b 7, wa v 6",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, wa v 7 1`] = `
+{
+  "_cmd": "wa b 7, wa v 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, wa v 8 1`] = `
+{
+  "_cmd": "wa b 7, wa v 8",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, wa v 9 1`] = `
+{
+  "_cmd": "wa b 7, wa v 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa v 10 1`] = `
+{
+  "_cmd": "wa b 7, wa v 10",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, wa v 11 1`] = `
+{
+  "_cmd": "wa b 7, wa v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, wa v 12 1`] = `
+{
+  "_cmd": "wa b 7, wa v 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa v 13 1`] = `
+{
+  "_cmd": "wa b 7, wa v 13",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, wa v 14 1`] = `
+{
+  "_cmd": "wa b 7, wa v 14",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 7, wa v 15 1`] = `
+{
+  "_cmd": "wa b 7, wa v 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, wa w 1 1`] = `
+{
+  "_cmd": "wa b 7, wa w 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 7, wa w 2 1`] = `
+{
+  "_cmd": "wa b 7, wa w 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 7, wa w 3 1`] = `
+{
+  "_cmd": "wa b 7, wa w 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 7, wa w 4 1`] = `
+{
+  "_cmd": "wa b 7, wa w 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 7, wa w 5 1`] = `
+{
+  "_cmd": "wa b 7, wa w 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa w 6 1`] = `
+{
+  "_cmd": "wa b 7, wa w 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, wa w 7 1`] = `
+{
+  "_cmd": "wa b 7, wa w 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 7, wa w 8 1`] = `
+{
+  "_cmd": "wa b 7, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa w 9 1`] = `
+{
+  "_cmd": "wa b 7, wa w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, wa w 10 1`] = `
+{
+  "_cmd": "wa b 7, wa w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 1",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 7, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 7, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 7, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 4",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 7, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 7, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 7, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 7",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 7, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 7, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 7, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 7, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 7, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 7, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 7, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 7, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 7, wa w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 8, wa d 1 1`] = `
+{
+  "_cmd": "wa b 8, wa d 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 8, wa d 2 1`] = `
+{
+  "_cmd": "wa b 8, wa d 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, wa d 3 1`] = `
+{
+  "_cmd": "wa b 8, wa d 3",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, wa d 4 1`] = `
+{
+  "_cmd": "wa b 8, wa d 4",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa d 5 1`] = `
+{
+  "_cmd": "wa b 8, wa d 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa d 6 1`] = `
+{
+  "_cmd": "wa b 8, wa d 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, wa d 7 1`] = `
+{
+  "_cmd": "wa b 8, wa d 7",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa d 8 1`] = `
+{
+  "_cmd": "wa b 8, wa d 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa d 9 1`] = `
+{
+  "_cmd": "wa b 8, wa d 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, wa d 10 1`] = `
+{
+  "_cmd": "wa b 8, wa d 10",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 8, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 8, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 7",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 8",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 10",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 11",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 13",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 14",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 8, wa d v 15",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, wa p 1 1`] = `
+{
+  "_cmd": "wa b 8, wa p 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 8, wa p 2 1`] = `
+{
+  "_cmd": "wa b 8, wa p 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, wa p 3 1`] = `
+{
+  "_cmd": "wa b 8, wa p 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 8, wa p 4 1`] = `
+{
+  "_cmd": "wa b 8, wa p 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, wa p 5 1`] = `
+{
+  "_cmd": "wa b 8, wa p 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa p 6 1`] = `
+{
+  "_cmd": "wa b 8, wa p 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, wa p 7 1`] = `
+{
+  "_cmd": "wa b 8, wa p 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa p 8 1`] = `
+{
+  "_cmd": "wa b 8, wa p 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, wa p 9 1`] = `
+{
+  "_cmd": "wa b 8, wa p 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa p 10 1`] = `
+{
+  "_cmd": "wa b 8, wa p 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 8, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 3",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 5",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 6",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 8",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 9",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 10",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 11",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 12",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 13",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 14",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 8, wa p v 15",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, wa v 1 1`] = `
+{
+  "_cmd": "wa b 8, wa v 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 8, wa v 2 1`] = `
+{
+  "_cmd": "wa b 8, wa v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, wa v 3 1`] = `
+{
+  "_cmd": "wa b 8, wa v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 8, wa v 4 1`] = `
+{
+  "_cmd": "wa b 8, wa v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, wa v 5 1`] = `
+{
+  "_cmd": "wa b 8, wa v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa v 6 1`] = `
+{
+  "_cmd": "wa b 8, wa v 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, wa v 7 1`] = `
+{
+  "_cmd": "wa b 8, wa v 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa v 8 1`] = `
+{
+  "_cmd": "wa b 8, wa v 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, wa v 9 1`] = `
+{
+  "_cmd": "wa b 8, wa v 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa v 10 1`] = `
+{
+  "_cmd": "wa b 8, wa v 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa v 11 1`] = `
+{
+  "_cmd": "wa b 8, wa v 11",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, wa v 12 1`] = `
+{
+  "_cmd": "wa b 8, wa v 12",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, wa v 13 1`] = `
+{
+  "_cmd": "wa b 8, wa v 13",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, wa v 14 1`] = `
+{
+  "_cmd": "wa b 8, wa v 14",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, wa v 15 1`] = `
+{
+  "_cmd": "wa b 8, wa v 15",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, wa w 1 1`] = `
+{
+  "_cmd": "wa b 8, wa w 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 8, wa w 2 1`] = `
+{
+  "_cmd": "wa b 8, wa w 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 8, wa w 3 1`] = `
+{
+  "_cmd": "wa b 8, wa w 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 8, wa w 4 1`] = `
+{
+  "_cmd": "wa b 8, wa w 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, wa w 5 1`] = `
+{
+  "_cmd": "wa b 8, wa w 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 8, wa w 6 1`] = `
+{
+  "_cmd": "wa b 8, wa w 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa w 7 1`] = `
+{
+  "_cmd": "wa b 8, wa w 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, wa w 8 1`] = `
+{
+  "_cmd": "wa b 8, wa w 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 8, wa w 9 1`] = `
+{
+  "_cmd": "wa b 8, wa w 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, wa w 10 1`] = `
+{
+  "_cmd": "wa b 8, wa w 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 1",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 8, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 8, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 8, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 4",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 8, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 8, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 8, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 8, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 8",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 8, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 8, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 8, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 11",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 8, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 8, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 8, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b 8, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 8, wa w v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 9, wa d 1 1`] = `
+{
+  "_cmd": "wa b 9, wa d 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 9, wa d 2 1`] = `
+{
+  "_cmd": "wa b 9, wa d 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, wa d 3 1`] = `
+{
+  "_cmd": "wa b 9, wa d 3",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, wa d 4 1`] = `
+{
+  "_cmd": "wa b 9, wa d 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, wa d 5 1`] = `
+{
+  "_cmd": "wa b 9, wa d 5",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa d 6 1`] = `
+{
+  "_cmd": "wa b 9, wa d 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa d 7 1`] = `
+{
+  "_cmd": "wa b 9, wa d 7",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, wa d 8 1`] = `
+{
+  "_cmd": "wa b 9, wa d 8",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa d 9 1`] = `
+{
+  "_cmd": "wa b 9, wa d 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa d 10 1`] = `
+{
+  "_cmd": "wa b 9, wa d 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 9, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 9",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 10",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 11",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 12",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 13",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 14",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 9, wa d v 15",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, wa p 1 1`] = `
+{
+  "_cmd": "wa b 9, wa p 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, wa p 2 1`] = `
+{
+  "_cmd": "wa b 9, wa p 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, wa p 3 1`] = `
+{
+  "_cmd": "wa b 9, wa p 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, wa p 4 1`] = `
+{
+  "_cmd": "wa b 9, wa p 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, wa p 5 1`] = `
+{
+  "_cmd": "wa b 9, wa p 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, wa p 6 1`] = `
+{
+  "_cmd": "wa b 9, wa p 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa p 7 1`] = `
+{
+  "_cmd": "wa b 9, wa p 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, wa p 8 1`] = `
+{
+  "_cmd": "wa b 9, wa p 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa p 9 1`] = `
+{
+  "_cmd": "wa b 9, wa p 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, wa p 10 1`] = `
+{
+  "_cmd": "wa b 9, wa p 10",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 3",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 4",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 6",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 9, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 7",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 9",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 10",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 11",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 12",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 13",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 14",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 9, wa p v 15",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, wa v 1 1`] = `
+{
+  "_cmd": "wa b 9, wa v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 9, wa v 2 1`] = `
+{
+  "_cmd": "wa b 9, wa v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, wa v 3 1`] = `
+{
+  "_cmd": "wa b 9, wa v 3",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, wa v 4 1`] = `
+{
+  "_cmd": "wa b 9, wa v 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, wa v 5 1`] = `
+{
+  "_cmd": "wa b 9, wa v 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, wa v 6 1`] = `
+{
+  "_cmd": "wa b 9, wa v 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa v 7 1`] = `
+{
+  "_cmd": "wa b 9, wa v 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, wa v 8 1`] = `
+{
+  "_cmd": "wa b 9, wa v 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa v 9 1`] = `
+{
+  "_cmd": "wa b 9, wa v 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, wa v 10 1`] = `
+{
+  "_cmd": "wa b 9, wa v 10",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa v 11 1`] = `
+{
+  "_cmd": "wa b 9, wa v 11",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa v 12 1`] = `
+{
+  "_cmd": "wa b 9, wa v 12",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, wa v 13 1`] = `
+{
+  "_cmd": "wa b 9, wa v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, wa v 14 1`] = `
+{
+  "_cmd": "wa b 9, wa v 14",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, wa v 15 1`] = `
+{
+  "_cmd": "wa b 9, wa v 15",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, wa w 1 1`] = `
+{
+  "_cmd": "wa b 9, wa w 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 9, wa w 2 1`] = `
+{
+  "_cmd": "wa b 9, wa w 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 9, wa w 3 1`] = `
+{
+  "_cmd": "wa b 9, wa w 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa w 4 1`] = `
+{
+  "_cmd": "wa b 9, wa w 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 9, wa w 5 1`] = `
+{
+  "_cmd": "wa b 9, wa w 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, wa w 6 1`] = `
+{
+  "_cmd": "wa b 9, wa w 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 9, wa w 7 1`] = `
+{
+  "_cmd": "wa b 9, wa w 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa w 8 1`] = `
+{
+  "_cmd": "wa b 9, wa w 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, wa w 9 1`] = `
+{
+  "_cmd": "wa b 9, wa w 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 9, wa w 10 1`] = `
+{
+  "_cmd": "wa b 9, wa w 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 1",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 9, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 2",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 9, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 9, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 9, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 5",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 9, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 6",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 9, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 9, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 8",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 9, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 9, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 9, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 9, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 9, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 9, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 9, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 9, wa w v 15",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa b 10, wa d 1 1`] = `
+{
+  "_cmd": "wa b 10, wa d 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 10, wa d 2 1`] = `
+{
+  "_cmd": "wa b 10, wa d 2",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, wa d 3 1`] = `
+{
+  "_cmd": "wa b 10, wa d 3",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, wa d 4 1`] = `
+{
+  "_cmd": "wa b 10, wa d 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, wa d 5 1`] = `
+{
+  "_cmd": "wa b 10, wa d 5",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, wa d 6 1`] = `
+{
+  "_cmd": "wa b 10, wa d 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, wa d 7 1`] = `
+{
+  "_cmd": "wa b 10, wa d 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa d 8 1`] = `
+{
+  "_cmd": "wa b 10, wa d 8",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa d 9 1`] = `
+{
+  "_cmd": "wa b 10, wa d 9",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa d 10 1`] = `
+{
+  "_cmd": "wa b 10, wa d 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa d v 1 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b 10, wa d v 2 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa d v 3 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, wa d v 4 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, wa d v 5 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, wa d v 6 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, wa d v 7 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, wa d v 8 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 8",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa d v 9 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa d v 10 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 10",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa d v 11 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 11",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa d v 12 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 12",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, wa d v 13 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, wa d v 14 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 14",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, wa d v 15 1`] = `
+{
+  "_cmd": "wa b 10, wa d v 15",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, wa p 1 1`] = `
+{
+  "_cmd": "wa b 10, wa p 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, wa p 2 1`] = `
+{
+  "_cmd": "wa b 10, wa p 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa p 3 1`] = `
+{
+  "_cmd": "wa b 10, wa p 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, wa p 4 1`] = `
+{
+  "_cmd": "wa b 10, wa p 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, wa p 5 1`] = `
+{
+  "_cmd": "wa b 10, wa p 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, wa p 6 1`] = `
+{
+  "_cmd": "wa b 10, wa p 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, wa p 7 1`] = `
+{
+  "_cmd": "wa b 10, wa p 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, wa p 8 1`] = `
+{
+  "_cmd": "wa b 10, wa p 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, wa p 9 1`] = `
+{
+  "_cmd": "wa b 10, wa p 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa p 10 1`] = `
+{
+  "_cmd": "wa b 10, wa p 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, wa p v 1 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, wa p v 2 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa p v 3 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, wa p v 4 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 4",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, wa p v 5 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, wa p v 6 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 6",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, wa p v 7 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 7",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, wa p v 8 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 8",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, wa p v 9 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 9",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa p v 10 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 10",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa p v 11 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 11",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, wa p v 12 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 12",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa p v 13 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 13",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa p v 14 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 14",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, wa p v 15 1`] = `
+{
+  "_cmd": "wa b 10, wa p v 15",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, wa v 1 1`] = `
+{
+  "_cmd": "wa b 10, wa v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b 10, wa v 2 1`] = `
+{
+  "_cmd": "wa b 10, wa v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa v 3 1`] = `
+{
+  "_cmd": "wa b 10, wa v 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b 10, wa v 4 1`] = `
+{
+  "_cmd": "wa b 10, wa v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, wa v 5 1`] = `
+{
+  "_cmd": "wa b 10, wa v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, wa v 6 1`] = `
+{
+  "_cmd": "wa b 10, wa v 6",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, wa v 7 1`] = `
+{
+  "_cmd": "wa b 10, wa v 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, wa v 8 1`] = `
+{
+  "_cmd": "wa b 10, wa v 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, wa v 9 1`] = `
+{
+  "_cmd": "wa b 10, wa v 9",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa v 10 1`] = `
+{
+  "_cmd": "wa b 10, wa v 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b 10, wa v 11 1`] = `
+{
+  "_cmd": "wa b 10, wa v 11",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa v 12 1`] = `
+{
+  "_cmd": "wa b 10, wa v 12",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa v 13 1`] = `
+{
+  "_cmd": "wa b 10, wa v 13",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, wa v 14 1`] = `
+{
+  "_cmd": "wa b 10, wa v 14",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, wa v 15 1`] = `
+{
+  "_cmd": "wa b 10, wa v 15",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, wa w 1 1`] = `
+{
+  "_cmd": "wa b 10, wa w 1",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa w 2 1`] = `
+{
+  "_cmd": "wa b 10, wa w 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b 10, wa w 3 1`] = `
+{
+  "_cmd": "wa b 10, wa w 3",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b 10, wa w 4 1`] = `
+{
+  "_cmd": "wa b 10, wa w 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b 10, wa w 5 1`] = `
+{
+  "_cmd": "wa b 10, wa w 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa w 6 1`] = `
+{
+  "_cmd": "wa b 10, wa w 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa w 7 1`] = `
+{
+  "_cmd": "wa b 10, wa w 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa w 8 1`] = `
+{
+  "_cmd": "wa b 10, wa w 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa w 9 1`] = `
+{
+  "_cmd": "wa b 10, wa w 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, wa w 10 1`] = `
+{
+  "_cmd": "wa b 10, wa w 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b 10, wa w v 1 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 1",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b 10, wa w v 2 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b 10, wa w v 3 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b 10, wa w v 4 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b 10, wa w v 5 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 5",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b 10, wa w v 6 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b 10, wa w v 7 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b 10, wa w v 8 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 8",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b 10, wa w v 9 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 9",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b 10, wa w v 10 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b 10, wa w v 11 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b 10, wa w v 12 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b 10, wa w v 13 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b 10, wa w v 14 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 14",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b 10, wa w v 15 1`] = `
+{
+  "_cmd": "wa b 10, wa w v 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 1, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 1, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 1, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 1, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 1, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 1",
+  "attacker": 1,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 1, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 2",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 1, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 3",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 1, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 1",
+  "attacker": 1,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 1, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 1, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 1, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 1, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 1, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 1, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 1, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 1, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 1, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 1, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 1, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 1, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 1, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 1, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 1, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 1, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 1, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 1, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 1, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 1, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 2, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 2, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 1",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 2, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 2, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 2, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 2, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 2, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 1",
+  "attacker": 2,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 2, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 2",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 2, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 3",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 4",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 2, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 5",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 2, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 1",
+  "attacker": 2,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 2, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 2",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 2, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 3",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 2, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 2, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 2, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 2, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 2, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 2, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 2, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 2, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 2, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 2, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 2, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 2, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 2, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 2, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 2, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 2, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 2, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 2, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 2, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 2, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa b v 3, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 3, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 1",
+  "attacker": 3,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 3, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 3, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 3, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 3, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 2",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 3, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 3",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 4",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 3, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 5",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 3, wa p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 1",
+  "attacker": 3,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 3, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 2",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 3, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 3",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 5",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 3, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 3, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 2",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 3, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 3, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 3, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 3, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 3, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 3, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 3, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 3, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 3, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 3, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 3, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 3, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 3, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 3, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 3, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 3, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 3, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 3, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 4, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 1",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 4, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 4, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 2",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 4, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 4, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 4, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 4, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 1",
+  "attacker": 4,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 4, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 2",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 4, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 3",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 4",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 4, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 5",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 6",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 7",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 4, wa p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 1",
+  "attacker": 4,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 4, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 2",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 4, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 3",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 4",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 5",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 4, wa v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 4, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 4, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 4, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 4, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 4, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 4, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 4, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 4, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 4, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 4, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 4, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 4, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 4, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 4, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 4, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 4, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 4, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 4, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 4, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 5, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 5, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 2",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 1",
+  "attacker": 5,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 5, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 5, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 4",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 6",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 5, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 2",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 3",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 5, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 6",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa p 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 5, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 4",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 5, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 5",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 6",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 7",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 8",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 9",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 10",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 11",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 12",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 13",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 5, wa p v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 1",
+  "attacker": 5,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 5, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 2",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 5, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 3",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 4",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 5",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 6",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 7",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 8",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 9",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 5, wa v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 5, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 2",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 5, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 5, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 5, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 5, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 5, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 5, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 5, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 5, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 5, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 5, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 5, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 5, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 5, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 5, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 5, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 5, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 5, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 5, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 5, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 6, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 6, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa d 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 1",
+  "attacker": 6,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 6, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 2",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 3",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 6, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 6",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 6, wa d v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 5",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 8",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 9",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa p 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 3",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 4",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 6, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 5",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 6",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 7",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 8",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 9",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 10",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 11",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 12",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 13",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 14",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 6, wa p v 15",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 1",
+  "attacker": 6,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 6, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 2",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 6, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 3",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 4",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 5",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 6",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 7",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 8",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 9",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 10",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 11",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 12",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 13",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 14",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 6, wa v 15",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 6, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 1",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 6, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 6, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 6, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 6, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 6, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 6, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 6, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 6, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 6, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 6, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 6, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 6, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 6, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 6, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 6, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 6, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 6, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 6, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 6, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 7, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 1",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 7, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 7",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa d 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 2",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 4",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 10",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 14",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 7, wa d v 15",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 7, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 7",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 9",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa p 10",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 2",
+  "attacker": 7,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 7, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 3",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 4",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 5",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 6",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 7",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 8",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 9",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 10",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 11",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 12",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 13",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 14",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 7, wa p v 15",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 1",
+  "attacker": 7,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 7, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 2",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 7, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 3",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 7, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 4",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 5",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 6",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 7",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 8",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 9",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 10",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 11",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 12",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 13",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 14",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 7, wa v 15",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 7, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 7, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 3",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 7, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 7, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 7, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 7, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 7, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 7, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 7, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 7, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 7, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 7, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 7, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 7, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 7, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 7, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 7, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 7, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 7, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 7, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa b v 8, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 1",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 8, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 2",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 8",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa d 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 3",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 8, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 4",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 7",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 10",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 11",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 8, wa d v 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 5",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 7",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 8",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa p 10",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 1",
+  "attacker": 8,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 8, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 2",
+  "attacker": 8,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 8, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 4",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 8, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 6",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 7",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 9",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 10",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 11",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 12",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 13",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 14",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 8, wa p v 15",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 1",
+  "attacker": 8,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 8, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 2",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 3",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 4",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 5",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 6",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 7",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 8",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 9",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 10",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 11",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 12",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 13",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 14",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 8, wa v 15",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 1",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 8, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 8, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 8, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 8, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 8, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa w 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 8, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 8, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 8, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 8, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 8, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 8, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 8, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 8, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 8, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 8, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 11",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 8, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 12",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 8, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 8, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 8, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 8, wa w v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 9, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 1",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 9, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 2",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 6",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 8",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa d 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 3",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 9, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 5",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 7",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 8",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 11",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 12",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 9, wa d v 15",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 9, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 2",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 8",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 9",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa p 10",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 1",
+  "attacker": 9,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 9, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 9, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 4",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 9, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 5",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 6",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 7",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 8",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 10",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 11",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 12",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 14",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 9, wa p v 15",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 1",
+  "attacker": 9,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 9, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 2",
+  "attacker": 9,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 9, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 3",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 4",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 9, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 5",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 6",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 7",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 8",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 9",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 10",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 11",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 12",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 13",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 14",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 9, wa v 15",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 1",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 9, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 9, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 4",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 9, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 9, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 9, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa w 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 9, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 9, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 9, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 9, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 9, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 9, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 9, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 9, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 9, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 9, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 9, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 12",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 9, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 13",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 9, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 14",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 9, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 9, wa w v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 10, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 4",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 9",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa d 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 2",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 3",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 5",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 8",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 9",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 11",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 12",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 13",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 10, wa d v 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 4",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 6",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 8",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 9",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa p 10",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 1",
+  "attacker": 10,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 10, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 3",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 5",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 7",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 8",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 11",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 12",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 13",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 14",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 10, wa p v 15",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 1",
+  "attacker": 10,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 10, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 2",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 3",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 10, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 4",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 5",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 6",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 7",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 8",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 9",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 10",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 11",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 12",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 13",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 14",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 10, wa v 15",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 10, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 10, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 10, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 4",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 10, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 6",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 10, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa w 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 10, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 1",
+  "attacker": 10,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 10, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 10, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 3",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 10, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 10, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 10, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 10, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 10, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 10, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 10, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 10, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 10, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 10, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 13",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 10, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 14",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 10, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 10, wa w v 15",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 11, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 3",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 7",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa d 10",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 2",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 3",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 4",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 5",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 6",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 7",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 8",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 9",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 10",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 12",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 13",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 14",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 11, wa d v 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 3",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 4",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 5",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 6",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 7",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 8",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa p 10",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 1",
+  "attacker": 11,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 11, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 3",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 4",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 5",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 6",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 7",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 8",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 9",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 10",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 11",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 12",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 13",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 14",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 11, wa p v 15",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 1",
+  "attacker": 11,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 11, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 2",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 3",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 11, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 4",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 5",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 6",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 7",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 8",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 9",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 10",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 11",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 12",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 13",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 14",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 11, wa v 15",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 11, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 11, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 11, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 3",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 11, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 11, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 11, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa w 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 1",
+  "attacker": 11,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 11, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 2",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 11, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 11, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 11, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 5",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 11, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 11, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 11, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 11, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 11, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 11, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 11, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 11, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 11, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 14",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 11, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 11, wa w v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 12, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 1",
+  "attacker": 12,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 12, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 2",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 3",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 7",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa d 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 1",
+  "attacker": 12,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 12, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 2",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 3",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 12, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 4",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 5",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 6",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 7",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 8",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 9",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 10",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 11",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 13",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 14",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 12, wa d v 15",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 1",
+  "attacker": 12,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 12, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 3",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 12, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 5",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 6",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 7",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 8",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 9",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa p 10",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 1",
+  "attacker": 12,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 12, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 3",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 5",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 6",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 7",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 8",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 9",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 10",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 11",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 12",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 13",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 14",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 12, wa p v 15",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 1",
+  "attacker": 12,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 12, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 2",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 3",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 12, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 4",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 5",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 6",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 7",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 8",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 9",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 10",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 11",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 12",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 13",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 14",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 12, wa v 15",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 12, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 2",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 12, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 12, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 12, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 12, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa w 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 1",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 12, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 12, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 3",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 12, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 12, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 12, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 12, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 12, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 12, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 12, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 12, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 11",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 12, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 12, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 12, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 12, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 12, wa w v 15",
+  "attacker": 5,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 13, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 1",
+  "attacker": 13,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 13, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 2",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 3",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 8",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 9",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa d 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 1",
+  "attacker": 13,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 13, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 2",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 4",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 5",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 6",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 7",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 8",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 9",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 10",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 11",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 12",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 14",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 13, wa d v 15",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 13, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 4",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 5",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 6",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 7",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 8",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 9",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa p 10",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 3",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 4",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 5",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 6",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 7",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 8",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 9",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 10",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 11",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 12",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 13",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 14",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 13, wa p v 15",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 1",
+  "attacker": 13,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 13, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 2",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 3",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 4",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 13, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 5",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 6",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 7",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 8",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 9",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 13, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 10",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 11",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 12",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 13",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 14",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 13, wa v 15",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 13, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 13, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 13, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 5",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 8",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 13, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa w 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 1",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 13, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 13, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 13, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 4",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 13, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 13, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 6",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 13, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 13, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 13, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 13, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 13, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 11",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 13, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 12",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 13, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 13, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 13, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 13, wa w v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa b v 14, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 1",
+  "attacker": 14,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 14, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 2",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 3",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 7",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 8",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 9",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa d 10",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 1",
+  "attacker": 14,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 14, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 3",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 4",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 5",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 6",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 7",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 8",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 9",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 10",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 11",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 12",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 13",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 14",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 14, wa d v 15",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 3",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 4",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 6",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 7",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 8",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 9",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa p 10",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 3",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 4",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 6",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 7",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 8",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 9",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 10",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 11",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 12",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 13",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 14",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 14, wa p v 15",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 1",
+  "attacker": 14,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 14, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 2",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 3",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 4",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 5",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 6",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 7",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 8",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 9",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 10",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 11",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 12",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 13",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 14",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 14, wa v 15",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 14, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 14, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 14, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 14, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 14, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 9",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 14, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa w 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 1",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 14, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 14, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 14, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 4",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 14, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 14, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 6",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 14, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 14, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 14, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 14, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 14, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 11",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 14, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 12",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 14, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 13",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 14, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 14, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 14, wa w v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa b v 15, wa d 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 1",
+  "attacker": 15,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 15, wa d 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 2",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, wa d 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 3",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, wa d 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 4",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, wa d 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, wa d 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 6",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, wa d 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 7",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa d 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 8",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa d 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 9",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa d 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa d 10",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa d v 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 1",
+  "attacker": 15,
+  "defender": -9,
+}
+`;
+
+exports[`wa b v 15, wa d v 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa d v 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 3",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, wa d v 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 4",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, wa d v 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 5",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, wa d v 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 6",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, wa d v 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 7",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, wa d v 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 8",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa d v 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 9",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa d v 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 10",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa d v 11 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 11",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa d v 12 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 12",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, wa d v 13 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 13",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, wa d v 14 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 14",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, wa d v 15 1`] = `
+{
+  "_cmd": "wa b v 15, wa d v 15",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, wa p 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, wa p 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa p 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, wa p 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 4",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, wa p 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, wa p 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 6",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, wa p 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 7",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, wa p 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 8",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, wa p 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 9",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa p 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa p 10",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, wa p v 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, wa p v 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa p v 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, wa p v 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 4",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, wa p v 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, wa p v 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 6",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, wa p v 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 7",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, wa p v 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 8",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, wa p v 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 9",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa p v 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 10",
+  "attacker": 13,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa p v 11 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 11",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, wa p v 12 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 12",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa p v 13 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 13",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa p v 14 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 14",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, wa p v 15 1`] = `
+{
+  "_cmd": "wa b v 15, wa p v 15",
+  "attacker": 12,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, wa v 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 1",
+  "attacker": 15,
+  "defender": -10,
+}
+`;
+
+exports[`wa b v 15, wa v 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 2",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa v 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 3",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa b v 15, wa v 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 4",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, wa v 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 5",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, wa v 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 6",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, wa v 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 7",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, wa v 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 8",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, wa v 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 9",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa v 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 10",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa b v 15, wa v 11 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 11",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa v 12 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 12",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa v 13 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 13",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, wa v 14 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 14",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, wa v 15 1`] = `
+{
+  "_cmd": "wa b v 15, wa v 15",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, wa w 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa w 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 2",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa b v 15, wa w 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa b v 15, wa w 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 4",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa b v 15, wa w 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa w 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 6",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa w 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa w 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa w 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, wa w 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa w 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa b v 15, wa w v 1 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa b v 15, wa w v 2 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa b v 15, wa w v 3 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa b v 15, wa w v 4 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa b v 15, wa w v 5 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa b v 15, wa w v 6 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa b v 15, wa w v 7 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 7",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa b v 15, wa w v 8 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa b v 15, wa w v 9 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa b v 15, wa w v 10 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 10",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa b v 15, wa w v 11 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 11",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa b v 15, wa w v 12 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 12",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa b v 15, wa w v 13 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 13",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa b v 15, wa w v 14 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 14",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa b v 15, wa w v 15 1`] = `
+{
+  "_cmd": "wa b v 15, wa w v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, wa d 1 1`] = `
+{
+  "_cmd": "wa v 1, wa d 1",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 1, wa d 2 1`] = `
+{
+  "_cmd": "wa v 1, wa d 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, wa d 3 1`] = `
+{
+  "_cmd": "wa v 1, wa d 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, wa d 4 1`] = `
+{
+  "_cmd": "wa v 1, wa d 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa d 5 1`] = `
+{
+  "_cmd": "wa v 1, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, wa d 6 1`] = `
+{
+  "_cmd": "wa v 1, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa d 7 1`] = `
+{
+  "_cmd": "wa v 1, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa d 8 1`] = `
+{
+  "_cmd": "wa v 1, wa d 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa d 9 1`] = `
+{
+  "_cmd": "wa v 1, wa d 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa d 10 1`] = `
+{
+  "_cmd": "wa v 1, wa d 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 1, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 2",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 1, wa d v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 1, wa p 1 1`] = `
+{
+  "_cmd": "wa v 1, wa p 1",
+  "attacker": 1,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 1, wa p 2 1`] = `
+{
+  "_cmd": "wa v 1, wa p 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, wa p 3 1`] = `
+{
+  "_cmd": "wa v 1, wa p 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, wa p 4 1`] = `
+{
+  "_cmd": "wa v 1, wa p 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, wa p 5 1`] = `
+{
+  "_cmd": "wa v 1, wa p 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, wa p 6 1`] = `
+{
+  "_cmd": "wa v 1, wa p 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa p 7 1`] = `
+{
+  "_cmd": "wa v 1, wa p 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa p 8 1`] = `
+{
+  "_cmd": "wa v 1, wa p 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa p 9 1`] = `
+{
+  "_cmd": "wa v 1, wa p 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa p 10 1`] = `
+{
+  "_cmd": "wa v 1, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 1, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 2",
+  "attacker": 1,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 1, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 3",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 1, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, wa v 1 1`] = `
+{
+  "_cmd": "wa v 1, wa v 1",
+  "attacker": 1,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 1, wa v 2 1`] = `
+{
+  "_cmd": "wa v 1, wa v 2",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, wa v 3 1`] = `
+{
+  "_cmd": "wa v 1, wa v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, wa v 4 1`] = `
+{
+  "_cmd": "wa v 1, wa v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, wa v 5 1`] = `
+{
+  "_cmd": "wa v 1, wa v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa v 6 1`] = `
+{
+  "_cmd": "wa v 1, wa v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa v 7 1`] = `
+{
+  "_cmd": "wa v 1, wa v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa v 8 1`] = `
+{
+  "_cmd": "wa v 1, wa v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa v 9 1`] = `
+{
+  "_cmd": "wa v 1, wa v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa v 10 1`] = `
+{
+  "_cmd": "wa v 1, wa v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa v 11 1`] = `
+{
+  "_cmd": "wa v 1, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa v 12 1`] = `
+{
+  "_cmd": "wa v 1, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, wa v 13 1`] = `
+{
+  "_cmd": "wa v 1, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, wa v 14 1`] = `
+{
+  "_cmd": "wa v 1, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, wa v 15 1`] = `
+{
+  "_cmd": "wa v 1, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, wa w 1 1`] = `
+{
+  "_cmd": "wa v 1, wa w 1",
+  "attacker": 1,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 1, wa w 2 1`] = `
+{
+  "_cmd": "wa v 1, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, wa w 3 1`] = `
+{
+  "_cmd": "wa v 1, wa w 3",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa w 4 1`] = `
+{
+  "_cmd": "wa v 1, wa w 4",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 1, wa w 5 1`] = `
+{
+  "_cmd": "wa v 1, wa w 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa w 6 1`] = `
+{
+  "_cmd": "wa v 1, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa w 7 1`] = `
+{
+  "_cmd": "wa v 1, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa w 8 1`] = `
+{
+  "_cmd": "wa v 1, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa w 9 1`] = `
+{
+  "_cmd": "wa v 1, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa w 10 1`] = `
+{
+  "_cmd": "wa v 1, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 1",
+  "attacker": 1,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 1, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 1, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 1, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 1, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 5",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 1, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 1, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 1, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 1, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 1, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 1, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 1, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 1, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 1, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 1, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 1, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 2, wa d 1 1`] = `
+{
+  "_cmd": "wa v 2, wa d 1",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 2, wa d 2 1`] = `
+{
+  "_cmd": "wa v 2, wa d 2",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, wa d 3 1`] = `
+{
+  "_cmd": "wa v 2, wa d 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, wa d 4 1`] = `
+{
+  "_cmd": "wa v 2, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa d 5 1`] = `
+{
+  "_cmd": "wa v 2, wa d 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa d 6 1`] = `
+{
+  "_cmd": "wa v 2, wa d 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, wa d 7 1`] = `
+{
+  "_cmd": "wa v 2, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa d 8 1`] = `
+{
+  "_cmd": "wa v 2, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa d 9 1`] = `
+{
+  "_cmd": "wa v 2, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, wa d 10 1`] = `
+{
+  "_cmd": "wa v 2, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 1",
+  "attacker": 2,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 2, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 2, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, wa p 1 1`] = `
+{
+  "_cmd": "wa v 2, wa p 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 2, wa p 2 1`] = `
+{
+  "_cmd": "wa v 2, wa p 2",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, wa p 3 1`] = `
+{
+  "_cmd": "wa v 2, wa p 3",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, wa p 4 1`] = `
+{
+  "_cmd": "wa v 2, wa p 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, wa p 5 1`] = `
+{
+  "_cmd": "wa v 2, wa p 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, wa p 6 1`] = `
+{
+  "_cmd": "wa v 2, wa p 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa p 7 1`] = `
+{
+  "_cmd": "wa v 2, wa p 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, wa p 8 1`] = `
+{
+  "_cmd": "wa v 2, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa p 9 1`] = `
+{
+  "_cmd": "wa v 2, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa p 10 1`] = `
+{
+  "_cmd": "wa v 2, wa p 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 1",
+  "attacker": 2,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 2, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 2, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 4",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 2, wa p v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, wa v 1 1`] = `
+{
+  "_cmd": "wa v 2, wa v 1",
+  "attacker": 2,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 2, wa v 2 1`] = `
+{
+  "_cmd": "wa v 2, wa v 2",
+  "attacker": 2,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 2, wa v 3 1`] = `
+{
+  "_cmd": "wa v 2, wa v 3",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, wa v 4 1`] = `
+{
+  "_cmd": "wa v 2, wa v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, wa v 5 1`] = `
+{
+  "_cmd": "wa v 2, wa v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa v 6 1`] = `
+{
+  "_cmd": "wa v 2, wa v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa v 7 1`] = `
+{
+  "_cmd": "wa v 2, wa v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, wa v 8 1`] = `
+{
+  "_cmd": "wa v 2, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa v 9 1`] = `
+{
+  "_cmd": "wa v 2, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa v 10 1`] = `
+{
+  "_cmd": "wa v 2, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, wa v 11 1`] = `
+{
+  "_cmd": "wa v 2, wa v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, wa v 12 1`] = `
+{
+  "_cmd": "wa v 2, wa v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, wa v 13 1`] = `
+{
+  "_cmd": "wa v 2, wa v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, wa v 14 1`] = `
+{
+  "_cmd": "wa v 2, wa v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, wa v 15 1`] = `
+{
+  "_cmd": "wa v 2, wa v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, wa w 1 1`] = `
+{
+  "_cmd": "wa v 2, wa w 1",
+  "attacker": 2,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 2, wa w 2 1`] = `
+{
+  "_cmd": "wa v 2, wa w 2",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 2, wa w 3 1`] = `
+{
+  "_cmd": "wa v 2, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa w 4 1`] = `
+{
+  "_cmd": "wa v 2, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, wa w 5 1`] = `
+{
+  "_cmd": "wa v 2, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa w 6 1`] = `
+{
+  "_cmd": "wa v 2, wa w 6",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa w 7 1`] = `
+{
+  "_cmd": "wa v 2, wa w 7",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa w 8 1`] = `
+{
+  "_cmd": "wa v 2, wa w 8",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 2, wa w 9 1`] = `
+{
+  "_cmd": "wa v 2, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa w 10 1`] = `
+{
+  "_cmd": "wa v 2, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 1",
+  "attacker": 2,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 2, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 2",
+  "attacker": 2,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 2, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 2, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 2, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 2, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 2, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 2, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 2, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 2, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 2, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 11",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 2, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 12",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 2, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 2, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 2, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 2, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 3, wa d 1 1`] = `
+{
+  "_cmd": "wa v 3, wa d 1",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 3, wa d 2 1`] = `
+{
+  "_cmd": "wa v 3, wa d 2",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, wa d 3 1`] = `
+{
+  "_cmd": "wa v 3, wa d 3",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, wa d 4 1`] = `
+{
+  "_cmd": "wa v 3, wa d 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa d 5 1`] = `
+{
+  "_cmd": "wa v 3, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, wa d 6 1`] = `
+{
+  "_cmd": "wa v 3, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa d 7 1`] = `
+{
+  "_cmd": "wa v 3, wa d 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa d 8 1`] = `
+{
+  "_cmd": "wa v 3, wa d 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa d 9 1`] = `
+{
+  "_cmd": "wa v 3, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa d 10 1`] = `
+{
+  "_cmd": "wa v 3, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 1",
+  "attacker": 3,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 3, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 3, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 3, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, wa p 1 1`] = `
+{
+  "_cmd": "wa v 3, wa p 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, wa p 2 1`] = `
+{
+  "_cmd": "wa v 3, wa p 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, wa p 3 1`] = `
+{
+  "_cmd": "wa v 3, wa p 3",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 3, wa p 4 1`] = `
+{
+  "_cmd": "wa v 3, wa p 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, wa p 5 1`] = `
+{
+  "_cmd": "wa v 3, wa p 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa p 6 1`] = `
+{
+  "_cmd": "wa v 3, wa p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, wa p 7 1`] = `
+{
+  "_cmd": "wa v 3, wa p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa p 8 1`] = `
+{
+  "_cmd": "wa v 3, wa p 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa p 9 1`] = `
+{
+  "_cmd": "wa v 3, wa p 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa p 10 1`] = `
+{
+  "_cmd": "wa v 3, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 2",
+  "attacker": 3,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 3, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 4",
+  "attacker": 3,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 3, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 3, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, wa v 1 1`] = `
+{
+  "_cmd": "wa v 3, wa v 1",
+  "attacker": 3,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 3, wa v 2 1`] = `
+{
+  "_cmd": "wa v 3, wa v 2",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, wa v 3 1`] = `
+{
+  "_cmd": "wa v 3, wa v 3",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, wa v 4 1`] = `
+{
+  "_cmd": "wa v 3, wa v 4",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, wa v 5 1`] = `
+{
+  "_cmd": "wa v 3, wa v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa v 6 1`] = `
+{
+  "_cmd": "wa v 3, wa v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, wa v 7 1`] = `
+{
+  "_cmd": "wa v 3, wa v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa v 8 1`] = `
+{
+  "_cmd": "wa v 3, wa v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa v 9 1`] = `
+{
+  "_cmd": "wa v 3, wa v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa v 10 1`] = `
+{
+  "_cmd": "wa v 3, wa v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa v 11 1`] = `
+{
+  "_cmd": "wa v 3, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, wa v 12 1`] = `
+{
+  "_cmd": "wa v 3, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, wa v 13 1`] = `
+{
+  "_cmd": "wa v 3, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, wa v 14 1`] = `
+{
+  "_cmd": "wa v 3, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 3, wa v 15 1`] = `
+{
+  "_cmd": "wa v 3, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, wa w 1 1`] = `
+{
+  "_cmd": "wa v 3, wa w 1",
+  "attacker": 3,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 3, wa w 2 1`] = `
+{
+  "_cmd": "wa v 3, wa w 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, wa w 3 1`] = `
+{
+  "_cmd": "wa v 3, wa w 3",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 3, wa w 4 1`] = `
+{
+  "_cmd": "wa v 3, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, wa w 5 1`] = `
+{
+  "_cmd": "wa v 3, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa w 6 1`] = `
+{
+  "_cmd": "wa v 3, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, wa w 7 1`] = `
+{
+  "_cmd": "wa v 3, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa w 8 1`] = `
+{
+  "_cmd": "wa v 3, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa w 9 1`] = `
+{
+  "_cmd": "wa v 3, wa w 9",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, wa w 10 1`] = `
+{
+  "_cmd": "wa v 3, wa w 10",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 1",
+  "attacker": 3,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 3, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 2",
+  "attacker": 3,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 3, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 3, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 3, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 3, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 3, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 3, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 3, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 3, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 3, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 3, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 3, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 13",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 3, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 14",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 3, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 3, wa w v 15",
+  "attacker": 0,
+  "defender": 15,
+}
+`;
+
+exports[`wa v 4, wa d 1 1`] = `
+{
+  "_cmd": "wa v 4, wa d 1",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 4, wa d 2 1`] = `
+{
+  "_cmd": "wa v 4, wa d 2",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, wa d 3 1`] = `
+{
+  "_cmd": "wa v 4, wa d 3",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, wa d 4 1`] = `
+{
+  "_cmd": "wa v 4, wa d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, wa d 5 1`] = `
+{
+  "_cmd": "wa v 4, wa d 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa d 6 1`] = `
+{
+  "_cmd": "wa v 4, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, wa d 7 1`] = `
+{
+  "_cmd": "wa v 4, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa d 8 1`] = `
+{
+  "_cmd": "wa v 4, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa d 9 1`] = `
+{
+  "_cmd": "wa v 4, wa d 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa d 10 1`] = `
+{
+  "_cmd": "wa v 4, wa d 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 4, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 2",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 3",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 4, wa d v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 4, wa p 1 1`] = `
+{
+  "_cmd": "wa v 4, wa p 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 4, wa p 2 1`] = `
+{
+  "_cmd": "wa v 4, wa p 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, wa p 3 1`] = `
+{
+  "_cmd": "wa v 4, wa p 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, wa p 4 1`] = `
+{
+  "_cmd": "wa v 4, wa p 4",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, wa p 5 1`] = `
+{
+  "_cmd": "wa v 4, wa p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, wa p 6 1`] = `
+{
+  "_cmd": "wa v 4, wa p 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa p 7 1`] = `
+{
+  "_cmd": "wa v 4, wa p 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, wa p 8 1`] = `
+{
+  "_cmd": "wa v 4, wa p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa p 9 1`] = `
+{
+  "_cmd": "wa v 4, wa p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa p 10 1`] = `
+{
+  "_cmd": "wa v 4, wa p 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 1",
+  "attacker": 4,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 4, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 2",
+  "attacker": 4,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 4, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 3",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 5",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 4, wa p v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, wa v 1 1`] = `
+{
+  "_cmd": "wa v 4, wa v 1",
+  "attacker": 4,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 4, wa v 2 1`] = `
+{
+  "_cmd": "wa v 4, wa v 2",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, wa v 3 1`] = `
+{
+  "_cmd": "wa v 4, wa v 3",
+  "attacker": 4,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 4, wa v 4 1`] = `
+{
+  "_cmd": "wa v 4, wa v 4",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, wa v 5 1`] = `
+{
+  "_cmd": "wa v 4, wa v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, wa v 6 1`] = `
+{
+  "_cmd": "wa v 4, wa v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, wa v 7 1`] = `
+{
+  "_cmd": "wa v 4, wa v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, wa v 8 1`] = `
+{
+  "_cmd": "wa v 4, wa v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa v 9 1`] = `
+{
+  "_cmd": "wa v 4, wa v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa v 10 1`] = `
+{
+  "_cmd": "wa v 4, wa v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, wa v 11 1`] = `
+{
+  "_cmd": "wa v 4, wa v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa v 12 1`] = `
+{
+  "_cmd": "wa v 4, wa v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, wa v 13 1`] = `
+{
+  "_cmd": "wa v 4, wa v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, wa v 14 1`] = `
+{
+  "_cmd": "wa v 4, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, wa v 15 1`] = `
+{
+  "_cmd": "wa v 4, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, wa w 1 1`] = `
+{
+  "_cmd": "wa v 4, wa w 1",
+  "attacker": 4,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 4, wa w 2 1`] = `
+{
+  "_cmd": "wa v 4, wa w 2",
+  "attacker": 4,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 4, wa w 3 1`] = `
+{
+  "_cmd": "wa v 4, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, wa w 4 1`] = `
+{
+  "_cmd": "wa v 4, wa w 4",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa w 5 1`] = `
+{
+  "_cmd": "wa v 4, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 4, wa w 6 1`] = `
+{
+  "_cmd": "wa v 4, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa w 7 1`] = `
+{
+  "_cmd": "wa v 4, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa w 8 1`] = `
+{
+  "_cmd": "wa v 4, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, wa w 9 1`] = `
+{
+  "_cmd": "wa v 4, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa w 10 1`] = `
+{
+  "_cmd": "wa v 4, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 1",
+  "attacker": 4,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 4, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 2",
+  "attacker": 4,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 4, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 4, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 4, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 4, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 4, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 4, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 4, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 4, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 4, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 4, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 4, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 4, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 4, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 4, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 5, wa d 1 1`] = `
+{
+  "_cmd": "wa v 5, wa d 1",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 5, wa d 2 1`] = `
+{
+  "_cmd": "wa v 5, wa d 2",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, wa d 3 1`] = `
+{
+  "_cmd": "wa v 5, wa d 3",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, wa d 4 1`] = `
+{
+  "_cmd": "wa v 5, wa d 4",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, wa d 5 1`] = `
+{
+  "_cmd": "wa v 5, wa d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa d 6 1`] = `
+{
+  "_cmd": "wa v 5, wa d 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, wa d 7 1`] = `
+{
+  "_cmd": "wa v 5, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa d 8 1`] = `
+{
+  "_cmd": "wa v 5, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa d 9 1`] = `
+{
+  "_cmd": "wa v 5, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa d 10 1`] = `
+{
+  "_cmd": "wa v 5, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 5, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 3",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 5, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 4",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 5, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, wa p 1 1`] = `
+{
+  "_cmd": "wa v 5, wa p 1",
+  "attacker": 5,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 5, wa p 2 1`] = `
+{
+  "_cmd": "wa v 5, wa p 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, wa p 3 1`] = `
+{
+  "_cmd": "wa v 5, wa p 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, wa p 4 1`] = `
+{
+  "_cmd": "wa v 5, wa p 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, wa p 5 1`] = `
+{
+  "_cmd": "wa v 5, wa p 5",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, wa p 6 1`] = `
+{
+  "_cmd": "wa v 5, wa p 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa p 7 1`] = `
+{
+  "_cmd": "wa v 5, wa p 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, wa p 8 1`] = `
+{
+  "_cmd": "wa v 5, wa p 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa p 9 1`] = `
+{
+  "_cmd": "wa v 5, wa p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa p 10 1`] = `
+{
+  "_cmd": "wa v 5, wa p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 5, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 2",
+  "attacker": 5,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 5, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 4",
+  "attacker": 5,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 5, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 6",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 7",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 8",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 9",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 10",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 11",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 5, wa p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, wa v 1 1`] = `
+{
+  "_cmd": "wa v 5, wa v 1",
+  "attacker": 5,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 5, wa v 2 1`] = `
+{
+  "_cmd": "wa v 5, wa v 2",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, wa v 3 1`] = `
+{
+  "_cmd": "wa v 5, wa v 3",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, wa v 4 1`] = `
+{
+  "_cmd": "wa v 5, wa v 4",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, wa v 5 1`] = `
+{
+  "_cmd": "wa v 5, wa v 5",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, wa v 6 1`] = `
+{
+  "_cmd": "wa v 5, wa v 6",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa v 7 1`] = `
+{
+  "_cmd": "wa v 5, wa v 7",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, wa v 8 1`] = `
+{
+  "_cmd": "wa v 5, wa v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa v 9 1`] = `
+{
+  "_cmd": "wa v 5, wa v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa v 10 1`] = `
+{
+  "_cmd": "wa v 5, wa v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa v 11 1`] = `
+{
+  "_cmd": "wa v 5, wa v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, wa v 12 1`] = `
+{
+  "_cmd": "wa v 5, wa v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, wa v 13 1`] = `
+{
+  "_cmd": "wa v 5, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, wa v 14 1`] = `
+{
+  "_cmd": "wa v 5, wa v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, wa v 15 1`] = `
+{
+  "_cmd": "wa v 5, wa v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, wa w 1 1`] = `
+{
+  "_cmd": "wa v 5, wa w 1",
+  "attacker": 5,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 5, wa w 2 1`] = `
+{
+  "_cmd": "wa v 5, wa w 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, wa w 3 1`] = `
+{
+  "_cmd": "wa v 5, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 5, wa w 4 1`] = `
+{
+  "_cmd": "wa v 5, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa w 5 1`] = `
+{
+  "_cmd": "wa v 5, wa w 5",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, wa w 6 1`] = `
+{
+  "_cmd": "wa v 5, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 5, wa w 7 1`] = `
+{
+  "_cmd": "wa v 5, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa w 8 1`] = `
+{
+  "_cmd": "wa v 5, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa w 9 1`] = `
+{
+  "_cmd": "wa v 5, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, wa w 10 1`] = `
+{
+  "_cmd": "wa v 5, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 1",
+  "attacker": 5,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 5, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 2",
+  "attacker": 5,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 5, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 3",
+  "attacker": 5,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 5, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 5, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 5, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 5, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 5, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 5, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 5, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 5, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 5, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 5, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 5, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 5, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 5, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 6, wa d 1 1`] = `
+{
+  "_cmd": "wa v 6, wa d 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 6, wa d 2 1`] = `
+{
+  "_cmd": "wa v 6, wa d 2",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, wa d 3 1`] = `
+{
+  "_cmd": "wa v 6, wa d 3",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa d 4 1`] = `
+{
+  "_cmd": "wa v 6, wa d 4",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, wa d 5 1`] = `
+{
+  "_cmd": "wa v 6, wa d 5",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa d 6 1`] = `
+{
+  "_cmd": "wa v 6, wa d 6",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa d 7 1`] = `
+{
+  "_cmd": "wa v 6, wa d 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa d 8 1`] = `
+{
+  "_cmd": "wa v 6, wa d 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, wa d 9 1`] = `
+{
+  "_cmd": "wa v 6, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa d 10 1`] = `
+{
+  "_cmd": "wa v 6, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 1",
+  "attacker": 6,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 6, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 2",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 3",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 5",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 7",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 8",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 11",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 12",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 6, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, wa p 1 1`] = `
+{
+  "_cmd": "wa v 6, wa p 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, wa p 2 1`] = `
+{
+  "_cmd": "wa v 6, wa p 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, wa p 3 1`] = `
+{
+  "_cmd": "wa v 6, wa p 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, wa p 4 1`] = `
+{
+  "_cmd": "wa v 6, wa p 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa p 5 1`] = `
+{
+  "_cmd": "wa v 6, wa p 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, wa p 6 1`] = `
+{
+  "_cmd": "wa v 6, wa p 6",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa p 7 1`] = `
+{
+  "_cmd": "wa v 6, wa p 7",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa p 8 1`] = `
+{
+  "_cmd": "wa v 6, wa p 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, wa p 9 1`] = `
+{
+  "_cmd": "wa v 6, wa p 9",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, wa p 10 1`] = `
+{
+  "_cmd": "wa v 6, wa p 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 3",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 4",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 5",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 6",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 8",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 9",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 10",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 12",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 13",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 6, wa p v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, wa v 1 1`] = `
+{
+  "_cmd": "wa v 6, wa v 1",
+  "attacker": 6,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 6, wa v 2 1`] = `
+{
+  "_cmd": "wa v 6, wa v 2",
+  "attacker": 6,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 6, wa v 3 1`] = `
+{
+  "_cmd": "wa v 6, wa v 3",
+  "attacker": 6,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 6, wa v 4 1`] = `
+{
+  "_cmd": "wa v 6, wa v 4",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa v 5 1`] = `
+{
+  "_cmd": "wa v 6, wa v 5",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, wa v 6 1`] = `
+{
+  "_cmd": "wa v 6, wa v 6",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, wa v 7 1`] = `
+{
+  "_cmd": "wa v 6, wa v 7",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa v 8 1`] = `
+{
+  "_cmd": "wa v 6, wa v 8",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, wa v 9 1`] = `
+{
+  "_cmd": "wa v 6, wa v 9",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa v 10 1`] = `
+{
+  "_cmd": "wa v 6, wa v 10",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa v 11 1`] = `
+{
+  "_cmd": "wa v 6, wa v 11",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, wa v 12 1`] = `
+{
+  "_cmd": "wa v 6, wa v 12",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, wa v 13 1`] = `
+{
+  "_cmd": "wa v 6, wa v 13",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, wa v 14 1`] = `
+{
+  "_cmd": "wa v 6, wa v 14",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, wa v 15 1`] = `
+{
+  "_cmd": "wa v 6, wa v 15",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, wa w 1 1`] = `
+{
+  "_cmd": "wa v 6, wa w 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, wa w 2 1`] = `
+{
+  "_cmd": "wa v 6, wa w 2",
+  "attacker": 6,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 6, wa w 3 1`] = `
+{
+  "_cmd": "wa v 6, wa w 3",
+  "attacker": 0,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 6, wa w 4 1`] = `
+{
+  "_cmd": "wa v 6, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa w 5 1`] = `
+{
+  "_cmd": "wa v 6, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa w 6 1`] = `
+{
+  "_cmd": "wa v 6, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa w 7 1`] = `
+{
+  "_cmd": "wa v 6, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 6, wa w 8 1`] = `
+{
+  "_cmd": "wa v 6, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa w 9 1`] = `
+{
+  "_cmd": "wa v 6, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, wa w 10 1`] = `
+{
+  "_cmd": "wa v 6, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 1",
+  "attacker": 6,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 6, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 2",
+  "attacker": 6,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 6, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 3",
+  "attacker": 6,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 6, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 6, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 6, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 6, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 6, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 6, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 6, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 6, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 6, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 6, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 6, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 6, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 6, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 7, wa d 1 1`] = `
+{
+  "_cmd": "wa v 7, wa d 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 7, wa d 2 1`] = `
+{
+  "_cmd": "wa v 7, wa d 2",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, wa d 3 1`] = `
+{
+  "_cmd": "wa v 7, wa d 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa d 4 1`] = `
+{
+  "_cmd": "wa v 7, wa d 4",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa d 5 1`] = `
+{
+  "_cmd": "wa v 7, wa d 5",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, wa d 6 1`] = `
+{
+  "_cmd": "wa v 7, wa d 6",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa d 7 1`] = `
+{
+  "_cmd": "wa v 7, wa d 7",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, wa d 8 1`] = `
+{
+  "_cmd": "wa v 7, wa d 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa d 9 1`] = `
+{
+  "_cmd": "wa v 7, wa d 9",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, wa d 10 1`] = `
+{
+  "_cmd": "wa v 7, wa d 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 1",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 7, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 2",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 3",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 4",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 5",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 6",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 8",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 9",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 10",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 11",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 13",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 14",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 7, wa d v 15",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, wa p 1 1`] = `
+{
+  "_cmd": "wa v 7, wa p 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, wa p 2 1`] = `
+{
+  "_cmd": "wa v 7, wa p 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, wa p 3 1`] = `
+{
+  "_cmd": "wa v 7, wa p 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, wa p 4 1`] = `
+{
+  "_cmd": "wa v 7, wa p 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa p 5 1`] = `
+{
+  "_cmd": "wa v 7, wa p 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa p 6 1`] = `
+{
+  "_cmd": "wa v 7, wa p 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, wa p 7 1`] = `
+{
+  "_cmd": "wa v 7, wa p 7",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa p 8 1`] = `
+{
+  "_cmd": "wa v 7, wa p 8",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, wa p 9 1`] = `
+{
+  "_cmd": "wa v 7, wa p 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa p 10 1`] = `
+{
+  "_cmd": "wa v 7, wa p 10",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 2",
+  "attacker": 7,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 7, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 3",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 5",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 6",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 7",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 9",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 10",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 11",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 12",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 13",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 14",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 7, wa p v 15",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, wa v 1 1`] = `
+{
+  "_cmd": "wa v 7, wa v 1",
+  "attacker": 7,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 7, wa v 2 1`] = `
+{
+  "_cmd": "wa v 7, wa v 2",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, wa v 3 1`] = `
+{
+  "_cmd": "wa v 7, wa v 3",
+  "attacker": 7,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 7, wa v 4 1`] = `
+{
+  "_cmd": "wa v 7, wa v 4",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa v 5 1`] = `
+{
+  "_cmd": "wa v 7, wa v 5",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa v 6 1`] = `
+{
+  "_cmd": "wa v 7, wa v 6",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, wa v 7 1`] = `
+{
+  "_cmd": "wa v 7, wa v 7",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, wa v 8 1`] = `
+{
+  "_cmd": "wa v 7, wa v 8",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, wa v 9 1`] = `
+{
+  "_cmd": "wa v 7, wa v 9",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa v 10 1`] = `
+{
+  "_cmd": "wa v 7, wa v 10",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, wa v 11 1`] = `
+{
+  "_cmd": "wa v 7, wa v 11",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, wa v 12 1`] = `
+{
+  "_cmd": "wa v 7, wa v 12",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, wa v 13 1`] = `
+{
+  "_cmd": "wa v 7, wa v 13",
+  "attacker": 1,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, wa v 14 1`] = `
+{
+  "_cmd": "wa v 7, wa v 14",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, wa v 15 1`] = `
+{
+  "_cmd": "wa v 7, wa v 15",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, wa w 1 1`] = `
+{
+  "_cmd": "wa v 7, wa w 1",
+  "attacker": 7,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 7, wa w 2 1`] = `
+{
+  "_cmd": "wa v 7, wa w 2",
+  "attacker": 7,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 7, wa w 3 1`] = `
+{
+  "_cmd": "wa v 7, wa w 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa w 4 1`] = `
+{
+  "_cmd": "wa v 7, wa w 4",
+  "attacker": 0,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 7, wa w 5 1`] = `
+{
+  "_cmd": "wa v 7, wa w 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa w 6 1`] = `
+{
+  "_cmd": "wa v 7, wa w 6",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa w 7 1`] = `
+{
+  "_cmd": "wa v 7, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, wa w 8 1`] = `
+{
+  "_cmd": "wa v 7, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 7, wa w 9 1`] = `
+{
+  "_cmd": "wa v 7, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, wa w 10 1`] = `
+{
+  "_cmd": "wa v 7, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 1",
+  "attacker": 7,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 7, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 2",
+  "attacker": 7,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 7, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 3",
+  "attacker": 7,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 7, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 4",
+  "attacker": 1,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 7, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 5",
+  "attacker": 0,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 7, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 6",
+  "attacker": 0,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 7, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 7",
+  "attacker": 0,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 7, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 8",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 7, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 7, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 7, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 7, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 7, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 7, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 7, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 7, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 8, wa d 1 1`] = `
+{
+  "_cmd": "wa v 8, wa d 1",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 8, wa d 2 1`] = `
+{
+  "_cmd": "wa v 8, wa d 2",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, wa d 3 1`] = `
+{
+  "_cmd": "wa v 8, wa d 3",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, wa d 4 1`] = `
+{
+  "_cmd": "wa v 8, wa d 4",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, wa d 5 1`] = `
+{
+  "_cmd": "wa v 8, wa d 5",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, wa d 6 1`] = `
+{
+  "_cmd": "wa v 8, wa d 6",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, wa d 7 1`] = `
+{
+  "_cmd": "wa v 8, wa d 7",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa d 8 1`] = `
+{
+  "_cmd": "wa v 8, wa d 8",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, wa d 9 1`] = `
+{
+  "_cmd": "wa v 8, wa d 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa d 10 1`] = `
+{
+  "_cmd": "wa v 8, wa d 10",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 4",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 6",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 7",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 8",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 9",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 10",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 11",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 12",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 14",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 8, wa d v 15",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, wa p 1 1`] = `
+{
+  "_cmd": "wa v 8, wa p 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, wa p 2 1`] = `
+{
+  "_cmd": "wa v 8, wa p 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, wa p 3 1`] = `
+{
+  "_cmd": "wa v 8, wa p 3",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, wa p 4 1`] = `
+{
+  "_cmd": "wa v 8, wa p 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, wa p 5 1`] = `
+{
+  "_cmd": "wa v 8, wa p 5",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, wa p 6 1`] = `
+{
+  "_cmd": "wa v 8, wa p 6",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, wa p 7 1`] = `
+{
+  "_cmd": "wa v 8, wa p 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, wa p 8 1`] = `
+{
+  "_cmd": "wa v 8, wa p 8",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa p 9 1`] = `
+{
+  "_cmd": "wa v 8, wa p 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, wa p 10 1`] = `
+{
+  "_cmd": "wa v 8, wa p 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 2",
+  "attacker": 8,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 8, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 4",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 6",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 7",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 8",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 10",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 11",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 12",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 13",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 14",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 8, wa p v 15",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, wa v 1 1`] = `
+{
+  "_cmd": "wa v 8, wa v 1",
+  "attacker": 8,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 8, wa v 2 1`] = `
+{
+  "_cmd": "wa v 8, wa v 2",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, wa v 3 1`] = `
+{
+  "_cmd": "wa v 8, wa v 3",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, wa v 4 1`] = `
+{
+  "_cmd": "wa v 8, wa v 4",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, wa v 5 1`] = `
+{
+  "_cmd": "wa v 8, wa v 5",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, wa v 6 1`] = `
+{
+  "_cmd": "wa v 8, wa v 6",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, wa v 7 1`] = `
+{
+  "_cmd": "wa v 8, wa v 7",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, wa v 8 1`] = `
+{
+  "_cmd": "wa v 8, wa v 8",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, wa v 9 1`] = `
+{
+  "_cmd": "wa v 8, wa v 9",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, wa v 10 1`] = `
+{
+  "_cmd": "wa v 8, wa v 10",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa v 11 1`] = `
+{
+  "_cmd": "wa v 8, wa v 11",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, wa v 12 1`] = `
+{
+  "_cmd": "wa v 8, wa v 12",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa v 13 1`] = `
+{
+  "_cmd": "wa v 8, wa v 13",
+  "attacker": 2,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, wa v 14 1`] = `
+{
+  "_cmd": "wa v 8, wa v 14",
+  "attacker": 2,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, wa v 15 1`] = `
+{
+  "_cmd": "wa v 8, wa v 15",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, wa w 1 1`] = `
+{
+  "_cmd": "wa v 8, wa w 1",
+  "attacker": 8,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 8, wa w 2 1`] = `
+{
+  "_cmd": "wa v 8, wa w 2",
+  "attacker": 8,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 8, wa w 3 1`] = `
+{
+  "_cmd": "wa v 8, wa w 3",
+  "attacker": 8,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 8, wa w 4 1`] = `
+{
+  "_cmd": "wa v 8, wa w 4",
+  "attacker": 1,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, wa w 5 1`] = `
+{
+  "_cmd": "wa v 8, wa w 5",
+  "attacker": 1,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 8, wa w 6 1`] = `
+{
+  "_cmd": "wa v 8, wa w 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa w 7 1`] = `
+{
+  "_cmd": "wa v 8, wa w 7",
+  "attacker": 0,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa w 8 1`] = `
+{
+  "_cmd": "wa v 8, wa w 8",
+  "attacker": 0,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, wa w 9 1`] = `
+{
+  "_cmd": "wa v 8, wa w 9",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa w 10 1`] = `
+{
+  "_cmd": "wa v 8, wa w 10",
+  "attacker": 0,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 8, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 1",
+  "attacker": 8,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 8, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 2",
+  "attacker": 8,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 8, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 3",
+  "attacker": 8,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 8, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 4",
+  "attacker": 2,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 8, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 5",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 8, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 6",
+  "attacker": 1,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 8, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 7",
+  "attacker": 1,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 8, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 8",
+  "attacker": 1,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 8, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 9",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 8, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 10",
+  "attacker": 0,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 8, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 11",
+  "attacker": 0,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 8, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 12",
+  "attacker": 0,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 8, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 13",
+  "attacker": 0,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 8, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 14",
+  "attacker": 0,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 8, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 8, wa w v 15",
+  "attacker": 0,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 9, wa d 1 1`] = `
+{
+  "_cmd": "wa v 9, wa d 1",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 9, wa d 2 1`] = `
+{
+  "_cmd": "wa v 9, wa d 2",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, wa d 3 1`] = `
+{
+  "_cmd": "wa v 9, wa d 3",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, wa d 4 1`] = `
+{
+  "_cmd": "wa v 9, wa d 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa d 5 1`] = `
+{
+  "_cmd": "wa v 9, wa d 5",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa d 6 1`] = `
+{
+  "_cmd": "wa v 9, wa d 6",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa d 7 1`] = `
+{
+  "_cmd": "wa v 9, wa d 7",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa d 8 1`] = `
+{
+  "_cmd": "wa v 9, wa d 8",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa d 9 1`] = `
+{
+  "_cmd": "wa v 9, wa d 9",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, wa d 10 1`] = `
+{
+  "_cmd": "wa v 9, wa d 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 3",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 4",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 5",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 6",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 7",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 8",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 9",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 10",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 11",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 12",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 13",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 14",
+  "attacker": 3,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 9, wa d v 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, wa p 1 1`] = `
+{
+  "_cmd": "wa v 9, wa p 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, wa p 2 1`] = `
+{
+  "_cmd": "wa v 9, wa p 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, wa p 3 1`] = `
+{
+  "_cmd": "wa v 9, wa p 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, wa p 4 1`] = `
+{
+  "_cmd": "wa v 9, wa p 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, wa p 5 1`] = `
+{
+  "_cmd": "wa v 9, wa p 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa p 6 1`] = `
+{
+  "_cmd": "wa v 9, wa p 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa p 7 1`] = `
+{
+  "_cmd": "wa v 9, wa p 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa p 8 1`] = `
+{
+  "_cmd": "wa v 9, wa p 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, wa p 9 1`] = `
+{
+  "_cmd": "wa v 9, wa p 9",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa p 10 1`] = `
+{
+  "_cmd": "wa v 9, wa p 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 2",
+  "attacker": 9,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 9, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 4",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 6",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 7",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 8",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 9",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 11",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 12",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 13",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 9, wa p v 15",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, wa v 1 1`] = `
+{
+  "_cmd": "wa v 9, wa v 1",
+  "attacker": 9,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 9, wa v 2 1`] = `
+{
+  "_cmd": "wa v 9, wa v 2",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, wa v 3 1`] = `
+{
+  "_cmd": "wa v 9, wa v 3",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, wa v 4 1`] = `
+{
+  "_cmd": "wa v 9, wa v 4",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, wa v 5 1`] = `
+{
+  "_cmd": "wa v 9, wa v 5",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa v 6 1`] = `
+{
+  "_cmd": "wa v 9, wa v 6",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa v 7 1`] = `
+{
+  "_cmd": "wa v 9, wa v 7",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa v 8 1`] = `
+{
+  "_cmd": "wa v 9, wa v 8",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, wa v 9 1`] = `
+{
+  "_cmd": "wa v 9, wa v 9",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa v 10 1`] = `
+{
+  "_cmd": "wa v 9, wa v 10",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, wa v 11 1`] = `
+{
+  "_cmd": "wa v 9, wa v 11",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa v 12 1`] = `
+{
+  "_cmd": "wa v 9, wa v 12",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, wa v 13 1`] = `
+{
+  "_cmd": "wa v 9, wa v 13",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, wa v 14 1`] = `
+{
+  "_cmd": "wa v 9, wa v 14",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 9, wa v 15 1`] = `
+{
+  "_cmd": "wa v 9, wa v 15",
+  "attacker": 3,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, wa w 1 1`] = `
+{
+  "_cmd": "wa v 9, wa w 1",
+  "attacker": 9,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 9, wa w 2 1`] = `
+{
+  "_cmd": "wa v 9, wa w 2",
+  "attacker": 9,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 9, wa w 3 1`] = `
+{
+  "_cmd": "wa v 9, wa w 3",
+  "attacker": 9,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 9, wa w 4 1`] = `
+{
+  "_cmd": "wa v 9, wa w 4",
+  "attacker": 2,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa w 5 1`] = `
+{
+  "_cmd": "wa v 9, wa w 5",
+  "attacker": 2,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 9, wa w 6 1`] = `
+{
+  "_cmd": "wa v 9, wa w 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa w 7 1`] = `
+{
+  "_cmd": "wa v 9, wa w 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa w 8 1`] = `
+{
+  "_cmd": "wa v 9, wa w 8",
+  "attacker": 1,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa w 9 1`] = `
+{
+  "_cmd": "wa v 9, wa w 9",
+  "attacker": 1,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, wa w 10 1`] = `
+{
+  "_cmd": "wa v 9, wa w 10",
+  "attacker": 1,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 1",
+  "attacker": 9,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 9, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 2",
+  "attacker": 9,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 9, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 3",
+  "attacker": 9,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 9, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 4",
+  "attacker": 3,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 9, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 5",
+  "attacker": 3,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 9, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 6",
+  "attacker": 2,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 9, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 7",
+  "attacker": 2,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 9, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 8",
+  "attacker": 2,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 9, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 9",
+  "attacker": 2,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 9, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 10",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 9, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 11",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 9, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 12",
+  "attacker": 1,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 9, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 13",
+  "attacker": 1,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 9, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 14",
+  "attacker": 1,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 9, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 9, wa w v 15",
+  "attacker": 1,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 10, wa d 1 1`] = `
+{
+  "_cmd": "wa v 10, wa d 1",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 10, wa d 2 1`] = `
+{
+  "_cmd": "wa v 10, wa d 2",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, wa d 3 1`] = `
+{
+  "_cmd": "wa v 10, wa d 3",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa d 4 1`] = `
+{
+  "_cmd": "wa v 10, wa d 4",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, wa d 5 1`] = `
+{
+  "_cmd": "wa v 10, wa d 5",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, wa d 6 1`] = `
+{
+  "_cmd": "wa v 10, wa d 6",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, wa d 7 1`] = `
+{
+  "_cmd": "wa v 10, wa d 7",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, wa d 8 1`] = `
+{
+  "_cmd": "wa v 10, wa d 8",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa d 9 1`] = `
+{
+  "_cmd": "wa v 10, wa d 9",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa d 10 1`] = `
+{
+  "_cmd": "wa v 10, wa d 10",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 3",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 5",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 6",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 7",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 8",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 9",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 10",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 11",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 12",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 13",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 14",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 10, wa d v 15",
+  "attacker": 4,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, wa p 1 1`] = `
+{
+  "_cmd": "wa v 10, wa p 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, wa p 2 1`] = `
+{
+  "_cmd": "wa v 10, wa p 2",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, wa p 3 1`] = `
+{
+  "_cmd": "wa v 10, wa p 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, wa p 4 1`] = `
+{
+  "_cmd": "wa v 10, wa p 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa p 5 1`] = `
+{
+  "_cmd": "wa v 10, wa p 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, wa p 6 1`] = `
+{
+  "_cmd": "wa v 10, wa p 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, wa p 7 1`] = `
+{
+  "_cmd": "wa v 10, wa p 7",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, wa p 8 1`] = `
+{
+  "_cmd": "wa v 10, wa p 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa p 9 1`] = `
+{
+  "_cmd": "wa v 10, wa p 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, wa p 10 1`] = `
+{
+  "_cmd": "wa v 10, wa p 10",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 10, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 4",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 5",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 7",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 8",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 9",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 10",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 12",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 13",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 14",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 10, wa p v 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, wa v 1 1`] = `
+{
+  "_cmd": "wa v 10, wa v 1",
+  "attacker": 10,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 10, wa v 2 1`] = `
+{
+  "_cmd": "wa v 10, wa v 2",
+  "attacker": 10,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 10, wa v 3 1`] = `
+{
+  "_cmd": "wa v 10, wa v 3",
+  "attacker": 10,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 10, wa v 4 1`] = `
+{
+  "_cmd": "wa v 10, wa v 4",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa v 5 1`] = `
+{
+  "_cmd": "wa v 10, wa v 5",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, wa v 6 1`] = `
+{
+  "_cmd": "wa v 10, wa v 6",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, wa v 7 1`] = `
+{
+  "_cmd": "wa v 10, wa v 7",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, wa v 8 1`] = `
+{
+  "_cmd": "wa v 10, wa v 8",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa v 9 1`] = `
+{
+  "_cmd": "wa v 10, wa v 9",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, wa v 10 1`] = `
+{
+  "_cmd": "wa v 10, wa v 10",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa v 11 1`] = `
+{
+  "_cmd": "wa v 10, wa v 11",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, wa v 12 1`] = `
+{
+  "_cmd": "wa v 10, wa v 12",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, wa v 13 1`] = `
+{
+  "_cmd": "wa v 10, wa v 13",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, wa v 14 1`] = `
+{
+  "_cmd": "wa v 10, wa v 14",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, wa v 15 1`] = `
+{
+  "_cmd": "wa v 10, wa v 15",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 10, wa w 1 1`] = `
+{
+  "_cmd": "wa v 10, wa w 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, wa w 2 1`] = `
+{
+  "_cmd": "wa v 10, wa w 2",
+  "attacker": 10,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 10, wa w 3 1`] = `
+{
+  "_cmd": "wa v 10, wa w 3",
+  "attacker": 10,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 10, wa w 4 1`] = `
+{
+  "_cmd": "wa v 10, wa w 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, wa w 5 1`] = `
+{
+  "_cmd": "wa v 10, wa w 5",
+  "attacker": 3,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa w 6 1`] = `
+{
+  "_cmd": "wa v 10, wa w 6",
+  "attacker": 3,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 10, wa w 7 1`] = `
+{
+  "_cmd": "wa v 10, wa w 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa w 8 1`] = `
+{
+  "_cmd": "wa v 10, wa w 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa w 9 1`] = `
+{
+  "_cmd": "wa v 10, wa w 9",
+  "attacker": 2,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, wa w 10 1`] = `
+{
+  "_cmd": "wa v 10, wa w 10",
+  "attacker": 2,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 1",
+  "attacker": 10,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 10, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 2",
+  "attacker": 10,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 10, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 3",
+  "attacker": 10,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 10, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 4",
+  "attacker": 4,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 10, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 5",
+  "attacker": 4,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 10, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 6",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 10, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 7",
+  "attacker": 3,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 10, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 8",
+  "attacker": 3,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 10, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 9",
+  "attacker": 3,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 10, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 10",
+  "attacker": 3,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 10, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 11",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 10, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 12",
+  "attacker": 3,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 10, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 13",
+  "attacker": 2,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 10, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 14",
+  "attacker": 2,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 10, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 10, wa w v 15",
+  "attacker": 2,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 11, wa d 1 1`] = `
+{
+  "_cmd": "wa v 11, wa d 1",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, wa d 2 1`] = `
+{
+  "_cmd": "wa v 11, wa d 2",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, wa d 3 1`] = `
+{
+  "_cmd": "wa v 11, wa d 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa d 4 1`] = `
+{
+  "_cmd": "wa v 11, wa d 4",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, wa d 5 1`] = `
+{
+  "_cmd": "wa v 11, wa d 5",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, wa d 6 1`] = `
+{
+  "_cmd": "wa v 11, wa d 6",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, wa d 7 1`] = `
+{
+  "_cmd": "wa v 11, wa d 7",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa d 8 1`] = `
+{
+  "_cmd": "wa v 11, wa d 8",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, wa d 9 1`] = `
+{
+  "_cmd": "wa v 11, wa d 9",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa d 10 1`] = `
+{
+  "_cmd": "wa v 11, wa d 10",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 2",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 3",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 4",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 5",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 6",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 7",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 8",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 9",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 10",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 11",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 12",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 13",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 14",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 11, wa d v 15",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 11, wa p 1 1`] = `
+{
+  "_cmd": "wa v 11, wa p 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, wa p 2 1`] = `
+{
+  "_cmd": "wa v 11, wa p 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, wa p 3 1`] = `
+{
+  "_cmd": "wa v 11, wa p 3",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, wa p 4 1`] = `
+{
+  "_cmd": "wa v 11, wa p 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa p 5 1`] = `
+{
+  "_cmd": "wa v 11, wa p 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, wa p 6 1`] = `
+{
+  "_cmd": "wa v 11, wa p 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, wa p 7 1`] = `
+{
+  "_cmd": "wa v 11, wa p 7",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, wa p 8 1`] = `
+{
+  "_cmd": "wa v 11, wa p 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa p 9 1`] = `
+{
+  "_cmd": "wa v 11, wa p 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa p 10 1`] = `
+{
+  "_cmd": "wa v 11, wa p 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 3",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 5",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 6",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 7",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 8",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 9",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 10",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 11",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 13",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 14",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 11, wa p v 15",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, wa v 1 1`] = `
+{
+  "_cmd": "wa v 11, wa v 1",
+  "attacker": 11,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 11, wa v 2 1`] = `
+{
+  "_cmd": "wa v 11, wa v 2",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, wa v 3 1`] = `
+{
+  "_cmd": "wa v 11, wa v 3",
+  "attacker": 11,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 11, wa v 4 1`] = `
+{
+  "_cmd": "wa v 11, wa v 4",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa v 5 1`] = `
+{
+  "_cmd": "wa v 11, wa v 5",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, wa v 6 1`] = `
+{
+  "_cmd": "wa v 11, wa v 6",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, wa v 7 1`] = `
+{
+  "_cmd": "wa v 11, wa v 7",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, wa v 8 1`] = `
+{
+  "_cmd": "wa v 11, wa v 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa v 9 1`] = `
+{
+  "_cmd": "wa v 11, wa v 9",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa v 10 1`] = `
+{
+  "_cmd": "wa v 11, wa v 10",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, wa v 11 1`] = `
+{
+  "_cmd": "wa v 11, wa v 11",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa v 12 1`] = `
+{
+  "_cmd": "wa v 11, wa v 12",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, wa v 13 1`] = `
+{
+  "_cmd": "wa v 11, wa v 13",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, wa v 14 1`] = `
+{
+  "_cmd": "wa v 11, wa v 14",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, wa v 15 1`] = `
+{
+  "_cmd": "wa v 11, wa v 15",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, wa w 1 1`] = `
+{
+  "_cmd": "wa v 11, wa w 1",
+  "attacker": 11,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 11, wa w 2 1`] = `
+{
+  "_cmd": "wa v 11, wa w 2",
+  "attacker": 11,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 11, wa w 3 1`] = `
+{
+  "_cmd": "wa v 11, wa w 3",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, wa w 4 1`] = `
+{
+  "_cmd": "wa v 11, wa w 4",
+  "attacker": 5,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 11, wa w 5 1`] = `
+{
+  "_cmd": "wa v 11, wa w 5",
+  "attacker": 4,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa w 6 1`] = `
+{
+  "_cmd": "wa v 11, wa w 6",
+  "attacker": 4,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa w 7 1`] = `
+{
+  "_cmd": "wa v 11, wa w 7",
+  "attacker": 4,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 11, wa w 8 1`] = `
+{
+  "_cmd": "wa v 11, wa w 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa w 9 1`] = `
+{
+  "_cmd": "wa v 11, wa w 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, wa w 10 1`] = `
+{
+  "_cmd": "wa v 11, wa w 10",
+  "attacker": 3,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 1",
+  "attacker": 11,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 11, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 2",
+  "attacker": 11,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 11, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 3",
+  "attacker": 11,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 11, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 4",
+  "attacker": 11,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 11, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 5",
+  "attacker": 5,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 11, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 6",
+  "attacker": 5,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 11, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 7",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 11, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 8",
+  "attacker": 4,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 11, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 9",
+  "attacker": 4,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 11, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 11, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 11",
+  "attacker": 4,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 11, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 12",
+  "attacker": 4,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 11, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 13",
+  "attacker": 4,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 11, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 14",
+  "attacker": 3,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 11, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 11, wa w v 15",
+  "attacker": 3,
+  "defender": 14,
+}
+`;
+
+exports[`wa v 12, wa d 1 1`] = `
+{
+  "_cmd": "wa v 12, wa d 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, wa d 2 1`] = `
+{
+  "_cmd": "wa v 12, wa d 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, wa d 3 1`] = `
+{
+  "_cmd": "wa v 12, wa d 3",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa d 4 1`] = `
+{
+  "_cmd": "wa v 12, wa d 4",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa d 5 1`] = `
+{
+  "_cmd": "wa v 12, wa d 5",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, wa d 6 1`] = `
+{
+  "_cmd": "wa v 12, wa d 6",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, wa d 7 1`] = `
+{
+  "_cmd": "wa v 12, wa d 7",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa d 8 1`] = `
+{
+  "_cmd": "wa v 12, wa d 8",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa d 9 1`] = `
+{
+  "_cmd": "wa v 12, wa d 9",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa d 10 1`] = `
+{
+  "_cmd": "wa v 12, wa d 10",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 2",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 3",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 12, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 4",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 12, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 6",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 7",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 8",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 9",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 10",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 11",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 12",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 13",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 14",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 12, wa d v 15",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, wa p 1 1`] = `
+{
+  "_cmd": "wa v 12, wa p 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, wa p 2 1`] = `
+{
+  "_cmd": "wa v 12, wa p 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, wa p 3 1`] = `
+{
+  "_cmd": "wa v 12, wa p 3",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 12, wa p 4 1`] = `
+{
+  "_cmd": "wa v 12, wa p 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa p 5 1`] = `
+{
+  "_cmd": "wa v 12, wa p 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa p 6 1`] = `
+{
+  "_cmd": "wa v 12, wa p 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, wa p 7 1`] = `
+{
+  "_cmd": "wa v 12, wa p 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, wa p 8 1`] = `
+{
+  "_cmd": "wa v 12, wa p 8",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa p 9 1`] = `
+{
+  "_cmd": "wa v 12, wa p 9",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa p 10 1`] = `
+{
+  "_cmd": "wa v 12, wa p 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 1",
+  "attacker": 12,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 12, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 3",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 5",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 12, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 6",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 8",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 9",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 10",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 11",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 12",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 14",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 12, wa p v 15",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, wa v 1 1`] = `
+{
+  "_cmd": "wa v 12, wa v 1",
+  "attacker": 12,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 12, wa v 2 1`] = `
+{
+  "_cmd": "wa v 12, wa v 2",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, wa v 3 1`] = `
+{
+  "_cmd": "wa v 12, wa v 3",
+  "attacker": 12,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 12, wa v 4 1`] = `
+{
+  "_cmd": "wa v 12, wa v 4",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa v 5 1`] = `
+{
+  "_cmd": "wa v 12, wa v 5",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa v 6 1`] = `
+{
+  "_cmd": "wa v 12, wa v 6",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, wa v 7 1`] = `
+{
+  "_cmd": "wa v 12, wa v 7",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, wa v 8 1`] = `
+{
+  "_cmd": "wa v 12, wa v 8",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa v 9 1`] = `
+{
+  "_cmd": "wa v 12, wa v 9",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa v 10 1`] = `
+{
+  "_cmd": "wa v 12, wa v 10",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, wa v 11 1`] = `
+{
+  "_cmd": "wa v 12, wa v 11",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa v 12 1`] = `
+{
+  "_cmd": "wa v 12, wa v 12",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa v 13 1`] = `
+{
+  "_cmd": "wa v 12, wa v 13",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, wa v 14 1`] = `
+{
+  "_cmd": "wa v 12, wa v 14",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, wa v 15 1`] = `
+{
+  "_cmd": "wa v 12, wa v 15",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, wa w 1 1`] = `
+{
+  "_cmd": "wa v 12, wa w 1",
+  "attacker": 12,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 12, wa w 2 1`] = `
+{
+  "_cmd": "wa v 12, wa w 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa w 3 1`] = `
+{
+  "_cmd": "wa v 12, wa w 3",
+  "attacker": 12,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 12, wa w 4 1`] = `
+{
+  "_cmd": "wa v 12, wa w 4",
+  "attacker": 6,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 12, wa w 5 1`] = `
+{
+  "_cmd": "wa v 12, wa w 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, wa w 6 1`] = `
+{
+  "_cmd": "wa v 12, wa w 6",
+  "attacker": 5,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa w 7 1`] = `
+{
+  "_cmd": "wa v 12, wa w 7",
+  "attacker": 5,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 12, wa w 8 1`] = `
+{
+  "_cmd": "wa v 12, wa w 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa w 9 1`] = `
+{
+  "_cmd": "wa v 12, wa w 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa w 10 1`] = `
+{
+  "_cmd": "wa v 12, wa w 10",
+  "attacker": 4,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 1",
+  "attacker": 12,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 12, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 2",
+  "attacker": 12,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 12, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 3",
+  "attacker": 12,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 12, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 4",
+  "attacker": 12,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 12, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 5",
+  "attacker": 6,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 12, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 6",
+  "attacker": 6,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 12, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 7",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 12, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 8",
+  "attacker": 5,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 12, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 9",
+  "attacker": 5,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 12, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 10",
+  "attacker": 5,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 12, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 11",
+  "attacker": 5,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 12, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 12",
+  "attacker": 5,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 12, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 13",
+  "attacker": 5,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 12, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 14",
+  "attacker": 5,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 12, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 12, wa w v 15",
+  "attacker": 4,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 13, wa d 1 1`] = `
+{
+  "_cmd": "wa v 13, wa d 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, wa d 2 1`] = `
+{
+  "_cmd": "wa v 13, wa d 2",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, wa d 3 1`] = `
+{
+  "_cmd": "wa v 13, wa d 3",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, wa d 4 1`] = `
+{
+  "_cmd": "wa v 13, wa d 4",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, wa d 5 1`] = `
+{
+  "_cmd": "wa v 13, wa d 5",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, wa d 6 1`] = `
+{
+  "_cmd": "wa v 13, wa d 6",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, wa d 7 1`] = `
+{
+  "_cmd": "wa v 13, wa d 7",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, wa d 8 1`] = `
+{
+  "_cmd": "wa v 13, wa d 8",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa d 9 1`] = `
+{
+  "_cmd": "wa v 13, wa d 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa d 10 1`] = `
+{
+  "_cmd": "wa v 13, wa d 10",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 2",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 3",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 4",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 5",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 6",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 7",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 8",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 9",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 10",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 11",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 12",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 13",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 14",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 13, wa d v 15",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, wa p 1 1`] = `
+{
+  "_cmd": "wa v 13, wa p 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, wa p 2 1`] = `
+{
+  "_cmd": "wa v 13, wa p 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, wa p 3 1`] = `
+{
+  "_cmd": "wa v 13, wa p 3",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, wa p 4 1`] = `
+{
+  "_cmd": "wa v 13, wa p 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, wa p 5 1`] = `
+{
+  "_cmd": "wa v 13, wa p 5",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, wa p 6 1`] = `
+{
+  "_cmd": "wa v 13, wa p 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, wa p 7 1`] = `
+{
+  "_cmd": "wa v 13, wa p 7",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, wa p 8 1`] = `
+{
+  "_cmd": "wa v 13, wa p 8",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, wa p 9 1`] = `
+{
+  "_cmd": "wa v 13, wa p 9",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa p 10 1`] = `
+{
+  "_cmd": "wa v 13, wa p 10",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 1",
+  "attacker": 13,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 13, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 3",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 6",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 7",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 8",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 9",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 10",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 11",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 12",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 13",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 14",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 13, wa p v 15",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, wa v 1 1`] = `
+{
+  "_cmd": "wa v 13, wa v 1",
+  "attacker": 13,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 13, wa v 2 1`] = `
+{
+  "_cmd": "wa v 13, wa v 2",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, wa v 3 1`] = `
+{
+  "_cmd": "wa v 13, wa v 3",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, wa v 4 1`] = `
+{
+  "_cmd": "wa v 13, wa v 4",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, wa v 5 1`] = `
+{
+  "_cmd": "wa v 13, wa v 5",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, wa v 6 1`] = `
+{
+  "_cmd": "wa v 13, wa v 6",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, wa v 7 1`] = `
+{
+  "_cmd": "wa v 13, wa v 7",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, wa v 8 1`] = `
+{
+  "_cmd": "wa v 13, wa v 8",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, wa v 9 1`] = `
+{
+  "_cmd": "wa v 13, wa v 9",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa v 10 1`] = `
+{
+  "_cmd": "wa v 13, wa v 10",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa v 11 1`] = `
+{
+  "_cmd": "wa v 13, wa v 11",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, wa v 12 1`] = `
+{
+  "_cmd": "wa v 13, wa v 12",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa v 13 1`] = `
+{
+  "_cmd": "wa v 13, wa v 13",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, wa v 14 1`] = `
+{
+  "_cmd": "wa v 13, wa v 14",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, wa v 15 1`] = `
+{
+  "_cmd": "wa v 13, wa v 15",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, wa w 1 1`] = `
+{
+  "_cmd": "wa v 13, wa w 1",
+  "attacker": 13,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 13, wa w 2 1`] = `
+{
+  "_cmd": "wa v 13, wa w 2",
+  "attacker": 13,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 13, wa w 3 1`] = `
+{
+  "_cmd": "wa v 13, wa w 3",
+  "attacker": 13,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 13, wa w 4 1`] = `
+{
+  "_cmd": "wa v 13, wa w 4",
+  "attacker": 7,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, wa w 5 1`] = `
+{
+  "_cmd": "wa v 13, wa w 5",
+  "attacker": 7,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 13, wa w 6 1`] = `
+{
+  "_cmd": "wa v 13, wa w 6",
+  "attacker": 6,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa w 7 1`] = `
+{
+  "_cmd": "wa v 13, wa w 7",
+  "attacker": 6,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa w 8 1`] = `
+{
+  "_cmd": "wa v 13, wa w 8",
+  "attacker": 6,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 13, wa w 9 1`] = `
+{
+  "_cmd": "wa v 13, wa w 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa w 10 1`] = `
+{
+  "_cmd": "wa v 13, wa w 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 1",
+  "attacker": 13,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 13, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 2",
+  "attacker": 13,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 13, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 3",
+  "attacker": 13,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 13, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 4",
+  "attacker": 13,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 13, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 5",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 13, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 6",
+  "attacker": 7,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 13, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 7",
+  "attacker": 7,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 13, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 8",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 13, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 9",
+  "attacker": 6,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 13, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 10",
+  "attacker": 6,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 13, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 11",
+  "attacker": 6,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 13, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 12",
+  "attacker": 6,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 13, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 13",
+  "attacker": 6,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 13, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 14",
+  "attacker": 6,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 13, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 13, wa w v 15",
+  "attacker": 6,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 14, wa d 1 1`] = `
+{
+  "_cmd": "wa v 14, wa d 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, wa d 2 1`] = `
+{
+  "_cmd": "wa v 14, wa d 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, wa d 3 1`] = `
+{
+  "_cmd": "wa v 14, wa d 3",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, wa d 4 1`] = `
+{
+  "_cmd": "wa v 14, wa d 4",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, wa d 5 1`] = `
+{
+  "_cmd": "wa v 14, wa d 5",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, wa d 6 1`] = `
+{
+  "_cmd": "wa v 14, wa d 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa d 7 1`] = `
+{
+  "_cmd": "wa v 14, wa d 7",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, wa d 8 1`] = `
+{
+  "_cmd": "wa v 14, wa d 8",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa d 9 1`] = `
+{
+  "_cmd": "wa v 14, wa d 9",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa d 10 1`] = `
+{
+  "_cmd": "wa v 14, wa d 10",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 2",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 4",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 5",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 6",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 7",
+  "attacker": 10,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 8",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 9",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 10",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 11",
+  "attacker": 9,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 12",
+  "attacker": 9,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 13",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 14",
+  "attacker": 9,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 14, wa d v 15",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, wa p 1 1`] = `
+{
+  "_cmd": "wa v 14, wa p 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, wa p 2 1`] = `
+{
+  "_cmd": "wa v 14, wa p 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, wa p 3 1`] = `
+{
+  "_cmd": "wa v 14, wa p 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, wa p 4 1`] = `
+{
+  "_cmd": "wa v 14, wa p 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, wa p 5 1`] = `
+{
+  "_cmd": "wa v 14, wa p 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, wa p 6 1`] = `
+{
+  "_cmd": "wa v 14, wa p 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, wa p 7 1`] = `
+{
+  "_cmd": "wa v 14, wa p 7",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa p 8 1`] = `
+{
+  "_cmd": "wa v 14, wa p 8",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, wa p 9 1`] = `
+{
+  "_cmd": "wa v 14, wa p 9",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa p 10 1`] = `
+{
+  "_cmd": "wa v 14, wa p 10",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 1",
+  "attacker": 14,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 14, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 3",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 4",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 6",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 7",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 8",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 9",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 10",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 11",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 12",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 13",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 14",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 14, wa p v 15",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, wa v 1 1`] = `
+{
+  "_cmd": "wa v 14, wa v 1",
+  "attacker": 14,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 14, wa v 2 1`] = `
+{
+  "_cmd": "wa v 14, wa v 2",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, wa v 3 1`] = `
+{
+  "_cmd": "wa v 14, wa v 3",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, wa v 4 1`] = `
+{
+  "_cmd": "wa v 14, wa v 4",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, wa v 5 1`] = `
+{
+  "_cmd": "wa v 14, wa v 5",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, wa v 6 1`] = `
+{
+  "_cmd": "wa v 14, wa v 6",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, wa v 7 1`] = `
+{
+  "_cmd": "wa v 14, wa v 7",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa v 8 1`] = `
+{
+  "_cmd": "wa v 14, wa v 8",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, wa v 9 1`] = `
+{
+  "_cmd": "wa v 14, wa v 9",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa v 10 1`] = `
+{
+  "_cmd": "wa v 14, wa v 10",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa v 11 1`] = `
+{
+  "_cmd": "wa v 14, wa v 11",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, wa v 12 1`] = `
+{
+  "_cmd": "wa v 14, wa v 12",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, wa v 13 1`] = `
+{
+  "_cmd": "wa v 14, wa v 13",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, wa v 14 1`] = `
+{
+  "_cmd": "wa v 14, wa v 14",
+  "attacker": 9,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, wa v 15 1`] = `
+{
+  "_cmd": "wa v 14, wa v 15",
+  "attacker": 9,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, wa w 1 1`] = `
+{
+  "_cmd": "wa v 14, wa w 1",
+  "attacker": 14,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 14, wa w 2 1`] = `
+{
+  "_cmd": "wa v 14, wa w 2",
+  "attacker": 14,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 14, wa w 3 1`] = `
+{
+  "_cmd": "wa v 14, wa w 3",
+  "attacker": 14,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 14, wa w 4 1`] = `
+{
+  "_cmd": "wa v 14, wa w 4",
+  "attacker": 8,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa w 5 1`] = `
+{
+  "_cmd": "wa v 14, wa w 5",
+  "attacker": 8,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 14, wa w 6 1`] = `
+{
+  "_cmd": "wa v 14, wa w 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, wa w 7 1`] = `
+{
+  "_cmd": "wa v 14, wa w 7",
+  "attacker": 7,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa w 8 1`] = `
+{
+  "_cmd": "wa v 14, wa w 8",
+  "attacker": 7,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, wa w 9 1`] = `
+{
+  "_cmd": "wa v 14, wa w 9",
+  "attacker": 7,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 14, wa w 10 1`] = `
+{
+  "_cmd": "wa v 14, wa w 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 1",
+  "attacker": 14,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 14, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 2",
+  "attacker": 14,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 14, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 3",
+  "attacker": 14,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 14, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 4",
+  "attacker": 14,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 14, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 5",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 14, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 6",
+  "attacker": 8,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 14, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 7",
+  "attacker": 8,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 14, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 8",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 14, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 9",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 14, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 10",
+  "attacker": 7,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 14, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 11",
+  "attacker": 7,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 14, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 12",
+  "attacker": 7,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 14, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 13",
+  "attacker": 7,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 14, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 14",
+  "attacker": 7,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 14, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 14, wa w v 15",
+  "attacker": 7,
+  "defender": 13,
+}
+`;
+
+exports[`wa v 15, wa d 1 1`] = `
+{
+  "_cmd": "wa v 15, wa d 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, wa d 2 1`] = `
+{
+  "_cmd": "wa v 15, wa d 2",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, wa d 3 1`] = `
+{
+  "_cmd": "wa v 15, wa d 3",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, wa d 4 1`] = `
+{
+  "_cmd": "wa v 15, wa d 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa d 5 1`] = `
+{
+  "_cmd": "wa v 15, wa d 5",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa d 6 1`] = `
+{
+  "_cmd": "wa v 15, wa d 6",
+  "attacker": 11,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa d 7 1`] = `
+{
+  "_cmd": "wa v 15, wa d 7",
+  "attacker": 10,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa d 8 1`] = `
+{
+  "_cmd": "wa v 15, wa d 8",
+  "attacker": 10,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, wa d 9 1`] = `
+{
+  "_cmd": "wa v 15, wa d 9",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa d 10 1`] = `
+{
+  "_cmd": "wa v 15, wa d 10",
+  "attacker": 10,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, wa d v 1 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, wa d v 2 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, wa d v 3 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, wa d v 4 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 4",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa d v 5 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 5",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, wa d v 6 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 6",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa d v 7 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 7",
+  "attacker": 11,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, wa d v 8 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 8",
+  "attacker": 11,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa d v 9 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 9",
+  "attacker": 11,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, wa d v 10 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 10",
+  "attacker": 10,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa d v 11 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 11",
+  "attacker": 10,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, wa d v 12 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 12",
+  "attacker": 10,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, wa d v 13 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 13",
+  "attacker": 10,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, wa d v 14 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 14",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, wa d v 15 1`] = `
+{
+  "_cmd": "wa v 15, wa d v 15",
+  "attacker": 10,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, wa p 1 1`] = `
+{
+  "_cmd": "wa v 15, wa p 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, wa p 2 1`] = `
+{
+  "_cmd": "wa v 15, wa p 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, wa p 3 1`] = `
+{
+  "_cmd": "wa v 15, wa p 3",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, wa p 4 1`] = `
+{
+  "_cmd": "wa v 15, wa p 4",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, wa p 5 1`] = `
+{
+  "_cmd": "wa v 15, wa p 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa p 6 1`] = `
+{
+  "_cmd": "wa v 15, wa p 6",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa p 7 1`] = `
+{
+  "_cmd": "wa v 15, wa p 7",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa p 8 1`] = `
+{
+  "_cmd": "wa v 15, wa p 8",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, wa p 9 1`] = `
+{
+  "_cmd": "wa v 15, wa p 9",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa p 10 1`] = `
+{
+  "_cmd": "wa v 15, wa p 10",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa p v 1 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 1",
+  "attacker": 15,
+  "defender": -8,
+}
+`;
+
+exports[`wa v 15, wa p v 2 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, wa p v 3 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 3",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, wa p v 4 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 4",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, wa p v 5 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa p v 6 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 6",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, wa p v 7 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 7",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa p v 8 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 8",
+  "attacker": 13,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa p v 9 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 9",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa p v 10 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 10",
+  "attacker": 12,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, wa p v 11 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 11",
+  "attacker": 12,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa p v 12 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 12",
+  "attacker": 12,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, wa p v 13 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 13",
+  "attacker": 12,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, wa p v 14 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 14",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, wa p v 15 1`] = `
+{
+  "_cmd": "wa v 15, wa p v 15",
+  "attacker": 11,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, wa v 1 1`] = `
+{
+  "_cmd": "wa v 15, wa v 1",
+  "attacker": 15,
+  "defender": -7,
+}
+`;
+
+exports[`wa v 15, wa v 2 1`] = `
+{
+  "_cmd": "wa v 15, wa v 2",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, wa v 3 1`] = `
+{
+  "_cmd": "wa v 15, wa v 3",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, wa v 4 1`] = `
+{
+  "_cmd": "wa v 15, wa v 4",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, wa v 5 1`] = `
+{
+  "_cmd": "wa v 15, wa v 5",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa v 6 1`] = `
+{
+  "_cmd": "wa v 15, wa v 6",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa v 7 1`] = `
+{
+  "_cmd": "wa v 15, wa v 7",
+  "attacker": 12,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa v 8 1`] = `
+{
+  "_cmd": "wa v 15, wa v 8",
+  "attacker": 12,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, wa v 9 1`] = `
+{
+  "_cmd": "wa v 15, wa v 9",
+  "attacker": 12,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa v 10 1`] = `
+{
+  "_cmd": "wa v 15, wa v 10",
+  "attacker": 11,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa v 11 1`] = `
+{
+  "_cmd": "wa v 15, wa v 11",
+  "attacker": 11,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, wa v 12 1`] = `
+{
+  "_cmd": "wa v 15, wa v 12",
+  "attacker": 11,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, wa v 13 1`] = `
+{
+  "_cmd": "wa v 15, wa v 13",
+  "attacker": 11,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, wa v 14 1`] = `
+{
+  "_cmd": "wa v 15, wa v 14",
+  "attacker": 11,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, wa v 15 1`] = `
+{
+  "_cmd": "wa v 15, wa v 15",
+  "attacker": 10,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, wa w 1 1`] = `
+{
+  "_cmd": "wa v 15, wa w 1",
+  "attacker": 15,
+  "defender": -5,
+}
+`;
+
+exports[`wa v 15, wa w 2 1`] = `
+{
+  "_cmd": "wa v 15, wa w 2",
+  "attacker": 15,
+  "defender": -3,
+}
+`;
+
+exports[`wa v 15, wa w 3 1`] = `
+{
+  "_cmd": "wa v 15, wa w 3",
+  "attacker": 15,
+  "defender": -1,
+}
+`;
+
+exports[`wa v 15, wa w 4 1`] = `
+{
+  "_cmd": "wa v 15, wa w 4",
+  "attacker": 9,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa w 5 1`] = `
+{
+  "_cmd": "wa v 15, wa w 5",
+  "attacker": 9,
+  "defender": 2,
+}
+`;
+
+exports[`wa v 15, wa w 6 1`] = `
+{
+  "_cmd": "wa v 15, wa w 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa w 7 1`] = `
+{
+  "_cmd": "wa v 15, wa w 7",
+  "attacker": 8,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa w 8 1`] = `
+{
+  "_cmd": "wa v 15, wa w 8",
+  "attacker": 8,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, wa w 9 1`] = `
+{
+  "_cmd": "wa v 15, wa w 9",
+  "attacker": 8,
+  "defender": 7,
+}
+`;
+
+exports[`wa v 15, wa w 10 1`] = `
+{
+  "_cmd": "wa v 15, wa w 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, wa w v 1 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 1",
+  "attacker": 15,
+  "defender": -6,
+}
+`;
+
+exports[`wa v 15, wa w v 2 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 2",
+  "attacker": 15,
+  "defender": -4,
+}
+`;
+
+exports[`wa v 15, wa w v 3 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 3",
+  "attacker": 15,
+  "defender": -2,
+}
+`;
+
+exports[`wa v 15, wa w v 4 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 4",
+  "attacker": 15,
+  "defender": 0,
+}
+`;
+
+exports[`wa v 15, wa w v 5 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 5",
+  "attacker": 10,
+  "defender": 1,
+}
+`;
+
+exports[`wa v 15, wa w v 6 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 6",
+  "attacker": 9,
+  "defender": 3,
+}
+`;
+
+exports[`wa v 15, wa w v 7 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 7",
+  "attacker": 9,
+  "defender": 4,
+}
+`;
+
+exports[`wa v 15, wa w v 8 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 8",
+  "attacker": 9,
+  "defender": 5,
+}
+`;
+
+exports[`wa v 15, wa w v 9 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 9",
+  "attacker": 9,
+  "defender": 6,
+}
+`;
+
+exports[`wa v 15, wa w v 10 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 10",
+  "attacker": 8,
+  "defender": 8,
+}
+`;
+
+exports[`wa v 15, wa w v 11 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 11",
+  "attacker": 8,
+  "defender": 9,
+}
+`;
+
+exports[`wa v 15, wa w v 12 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 12",
+  "attacker": 8,
+  "defender": 10,
+}
+`;
+
+exports[`wa v 15, wa w v 13 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 13",
+  "attacker": 8,
+  "defender": 11,
+}
+`;
+
+exports[`wa v 15, wa w v 14 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 14",
+  "attacker": 8,
+  "defender": 12,
+}
+`;
+
+exports[`wa v 15, wa w v 15 1`] = `
+{
+  "_cmd": "wa v 15, wa w v 15",
+  "attacker": 8,
+  "defender": 13,
+}
+`;

--- a/bot/tests/simpleCalc/de-vs-de.test.js
+++ b/bot/tests/simpleCalc/de-vs-de.test.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@jest/globals');
+const { execute } = require('../../commands/calc.js');
+const { generateTestSuit, replyData } = require('./utils.js');
+
+const testData = () =>
+  generateTestSuit('de', ['b', 'v', 'b v'], 'de', [
+    'd',
+    'd v',
+    'p',
+    'p v',
+    'w',
+    'w v',
+    'v',
+  ]);
+
+testData().forEach((cmd) => {
+  test(cmd, () => {
+    const reply = replyData();
+    execute({}, cmd, reply, {});
+    const result = {
+      _cmd: cmd, // use underscore to put it on top of the snapshot
+      attacker: reply.outcome.attackers[0].afterhp,
+      defender: reply.outcome.defender.afterhp,
+    };
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/bot/tests/simpleCalc/de-vs-de.test.js
+++ b/bot/tests/simpleCalc/de-vs-de.test.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@jest/globals');
 const { execute } = require('../../commands/calc.js');
-const { generateTestSuit, replyData } = require('./utils.js');
+const { generateTestSuite, replyData } = require('./utils.js');
 
 const testData = () =>
-  generateTestSuit('de', ['b', 'v', 'b v'], 'de', [
+  generateTestSuite('de', ['b', 'v', 'b v'], 'de', [
     'd',
     'd v',
     'p',

--- a/bot/tests/simpleCalc/de-vs-wa.test.js
+++ b/bot/tests/simpleCalc/de-vs-wa.test.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@jest/globals');
+const { execute } = require('../../commands/calc.js');
+const { generateTestSuit, replyData } = require('./utils.js');
+
+const testData = () =>
+  generateTestSuit('de', ['b', 'v', 'b v'], 'wa', [
+    'd',
+    'd v',
+    'p',
+    'p v',
+    'w',
+    'w v',
+    'v',
+  ]);
+
+testData().forEach((cmd) => {
+  test(cmd, () => {
+    const reply = replyData();
+    execute({}, cmd, reply, {});
+    const result = {
+      _cmd: cmd, // use underscore to put it on top of the snapshot
+      attacker: reply.outcome.attackers[0].afterhp,
+      defender: reply.outcome.defender.afterhp,
+    };
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/bot/tests/simpleCalc/de-vs-wa.test.js
+++ b/bot/tests/simpleCalc/de-vs-wa.test.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@jest/globals');
 const { execute } = require('../../commands/calc.js');
-const { generateTestSuit, replyData } = require('./utils.js');
+const { generateTestSuite, replyData } = require('./utils.js');
 
 const testData = () =>
-  generateTestSuit('de', ['b', 'v', 'b v'], 'wa', [
+  generateTestSuite('de', ['b', 'v', 'b v'], 'wa', [
     'd',
     'd v',
     'p',

--- a/bot/tests/simpleCalc/utils.js
+++ b/bot/tests/simpleCalc/utils.js
@@ -1,0 +1,65 @@
+const { getUnit } = require('../../commands/units.js');
+
+const getTestUnit = (code, modifier) => {
+  const unit = getUnit(code);
+  unit.code = code;
+  if (modifier) {
+    unit.modifiers = ' ' + modifier;
+  } else {
+    unit.modifiers = '';
+  }
+  return unit;
+};
+
+const getMaxHp = (unit) => {
+  if (unit.modifiers.includes('v')) {
+    return unit.maxhp + 5;
+  }
+  return unit.maxhp;
+};
+
+const generateTests = (attacker, defender) => {
+  const tests = [];
+  for (let a = 1; a <= getMaxHp(attacker); a++) {
+    for (let d = 1; d <= getMaxHp(defender); d++) {
+      tests.push(
+        `${attacker.code}${attacker.modifiers} ${a}, ${defender.code}${defender.modifiers} ${d}`,
+      );
+    }
+  }
+  return tests;
+};
+
+const generateTestSuit = (
+  attCode,
+  attModifierList,
+  defCode,
+  defModifierList,
+) => {
+  const result = [];
+  attModifierList.forEach((attModifier) => {
+    defModifierList.forEach((defModifier) => {
+      const att = getTestUnit(attCode, attModifier);
+      const def = getTestUnit(defCode, defModifier);
+      result.push(...generateTests(att, def));
+    });
+  });
+  return result;
+};
+
+const replyData = () => ({
+  content: [],
+  deleteContent: false,
+  discord: {
+    title: undefined,
+    description: undefined,
+    fields: [],
+    footer: undefined,
+  },
+  outcome: {
+    attackers: [],
+    defender: {},
+  },
+});
+
+module.exports = { generateTests, getTestUnit, generateTestSuit, replyData };

--- a/bot/tests/simpleCalc/utils.js
+++ b/bot/tests/simpleCalc/utils.js
@@ -30,7 +30,7 @@ const generateTests = (attacker, defender) => {
   return tests;
 };
 
-const generateTestSuit = (
+const generateTestSuite = (
   attCode,
   attModifierList,
   defCode,
@@ -62,4 +62,4 @@ const replyData = () => ({
   },
 });
 
-module.exports = { generateTests, getTestUnit, generateTestSuit, replyData };
+module.exports = { generateTests, getTestUnit, generateTestSuite, replyData };

--- a/bot/tests/simpleCalc/wa-vs-de.test.js
+++ b/bot/tests/simpleCalc/wa-vs-de.test.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@jest/globals');
 const { execute } = require('../../commands/calc.js');
-const { generateTestSuit, replyData } = require('./utils.js');
+const { generateTestSuite, replyData } = require('./utils.js');
 
 const testData = () =>
-  generateTestSuit('wa', ['b', 'v', 'b v'], 'de', [
+  generateTestSuite('wa', ['b', 'v', 'b v'], 'de', [
     'd',
     'd v',
     'p',

--- a/bot/tests/simpleCalc/wa-vs-de.test.js
+++ b/bot/tests/simpleCalc/wa-vs-de.test.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@jest/globals');
+const { execute } = require('../../commands/calc.js');
+const { generateTestSuit, replyData } = require('./utils.js');
+
+const testData = () =>
+  generateTestSuit('wa', ['b', 'v', 'b v'], 'de', [
+    'd',
+    'd v',
+    'p',
+    'p v',
+    'w',
+    'w v',
+    'v',
+  ]);
+
+testData().forEach((cmd) => {
+  test(cmd, () => {
+    const reply = replyData();
+    execute({}, cmd, reply, {});
+    const result = {
+      _cmd: cmd, // use underscore to put it on top of the snapshot
+      attacker: reply.outcome.attackers[0].afterhp,
+      defender: reply.outcome.defender.afterhp,
+    };
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/bot/tests/simpleCalc/wa-vs-wa.test.js
+++ b/bot/tests/simpleCalc/wa-vs-wa.test.js
@@ -1,9 +1,9 @@
 const { test, expect } = require('@jest/globals');
 const { execute } = require('../../commands/calc.js');
-const { generateTestSuit, replyData } = require('./utils.js');
+const { generateTestSuite, replyData } = require('./utils.js');
 
 const testData = () =>
-  generateTestSuit('wa', ['b', 'v', 'b v'], 'wa', [
+  generateTestSuite('wa', ['b', 'v', 'b v'], 'wa', [
     'd',
     'd v',
     'p',

--- a/bot/tests/simpleCalc/wa-vs-wa.test.js
+++ b/bot/tests/simpleCalc/wa-vs-wa.test.js
@@ -1,0 +1,28 @@
+const { test, expect } = require('@jest/globals');
+const { execute } = require('../../commands/calc.js');
+const { generateTestSuit, replyData } = require('./utils.js');
+
+const testData = () =>
+  generateTestSuit('wa', ['b', 'v', 'b v'], 'wa', [
+    'd',
+    'd v',
+    'p',
+    'p v',
+    'w',
+    'w v',
+    'v',
+  ]);
+
+testData().forEach((cmd) => {
+  test(cmd, () => {
+    const reply = replyData();
+    execute({}, cmd, reply, {});
+    const result = {
+      _cmd: cmd, // use underscore to put it on top of the snapshot
+      attacker: reply.outcome.attackers[0].afterhp,
+      defender: reply.outcome.defender.afterhp,
+    };
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,44 +17,526 @@
         "discord-api-types": "0.24.0",
         "discord.js": "13.5.0",
         "dotenv": "8.0.0",
-        "eslint": "6.8.0",
         "express": "4.17.3",
         "helmet": "3.21.3",
         "nodemon": "^2.0.20",
         "pg": "8.5.1"
+      },
+      "devDependencies": {
+        "eslint": "6.8.0",
+        "jest": "29.7.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
+      "integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.6",
+        "@babel/parser": "^7.23.6",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.23.6",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
+      "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.6",
+        "@babel/types": "^7.23.6"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
+      "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@discordjs/builders": {
       "version": "0.8.1",
@@ -126,6 +608,626 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@jest/types/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/types/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
@@ -145,6 +1247,12 @@
         "npm": ">=6"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
@@ -154,6 +1262,98 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
+      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
+      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
       }
     },
     "node_modules/@types/node": {
@@ -170,6 +1370,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
     "node_modules/@types/ws": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
@@ -177,6 +1383,21 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -210,6 +1431,7 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
       "peer": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -222,6 +1444,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -230,6 +1453,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -245,6 +1469,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -259,14 +1484,40 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
@@ -280,6 +1531,174 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/babel-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -364,6 +1783,64 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "node_modules/buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -400,15 +1877,45 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001570",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
+      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -422,6 +1929,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -433,6 +1941,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -440,12 +1949,23 @@
     "node_modules/chalk/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -473,44 +1993,10 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/chokidar/node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
       "engines": {
         "node": ">=8"
       }
@@ -526,14 +2012,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar/node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/chokidar/node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -545,21 +2023,32 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/chokidar/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
       "engines": {
-        "node": ">=8.0"
+        "node": ">=8"
       }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -571,14 +2060,46 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true,
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -589,7 +2110,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -653,6 +2175,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "node_modules/cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -678,10 +2206,84 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/create-jest/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/create-jest/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -707,6 +2309,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -722,12 +2325,37 @@
     "node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -749,6 +2377,24 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/discord-api-types": {
       "version": "0.24.0",
@@ -827,6 +2473,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -869,10 +2516,29 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.611",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.611.tgz",
+      "integrity": "sha512-ZtRpDxrjHapOwxtv+nuth5ByB8clyn8crVynmRNGO3wG3LOp8RTcyZDqwaI6Ng6y8FCK2hVZmJoqwCskKbNMaw==",
+      "dev": true
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -880,6 +2546,24 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -891,6 +2575,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -899,6 +2584,7 @@
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -952,6 +2638,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -964,6 +2651,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -975,6 +2663,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -983,6 +2672,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -991,6 +2681,7 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
       "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
       "dependencies": {
         "type-fest": "^0.8.1"
       },
@@ -1005,6 +2696,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1013,6 +2705,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -1024,6 +2717,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1032,6 +2726,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
       "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
@@ -1045,6 +2740,7 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1056,6 +2752,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -1068,6 +2765,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -1079,6 +2777,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
       "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1087,6 +2786,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1098,6 +2798,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
       "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1106,6 +2807,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -1114,6 +2816,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1132,6 +2835,113 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/expect-ct": {
@@ -1278,6 +3088,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -1290,17 +3101,29 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "dependencies": {
+        "bser": "2.1.1"
+      }
     },
     "node_modules/feature-policy": {
       "version": "0.3.0",
@@ -1314,6 +3137,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -1328,11 +3152,23 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
       "dependencies": {
         "flat-cache": "^2.0.1"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -1365,10 +3201,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
       "dependencies": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
@@ -1382,6 +3232,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -1392,7 +3243,8 @@
     "node_modules/flatted": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -1434,7 +3286,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -1450,14 +3303,36 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-intrinsic": {
       "version": "1.1.1",
@@ -1472,10 +3347,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1501,6 +3398,21 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1530,6 +3442,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/helmet": {
@@ -1619,6 +3543,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1650,6 +3580,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1673,6 +3612,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -1681,6 +3621,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1692,10 +3633,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "dev": true,
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -1704,6 +3665,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1718,6 +3680,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
       "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
@@ -1741,6 +3704,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1755,6 +3719,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -1770,6 +3735,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1778,6 +3744,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -1793,6 +3760,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "dependencies": {
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1805,8 +3790,18 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-glob": {
@@ -1820,6 +3815,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -1828,20 +3831,1480 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-circus/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-cli/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-cli/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-cli/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-diff/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-each/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-resolve/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runner/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-util/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-util/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-validate/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-validate/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1850,20 +5313,71 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -1872,15 +5386,100 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-dir/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -1895,12 +5494,31 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -1948,6 +5566,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
       "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1956,6 +5575,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -1971,12 +5591,14 @@
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -1989,7 +5611,8 @@
     "node_modules/nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node_modules/nocache": {
       "version": "2.1.0",
@@ -2017,6 +5640,18 @@
           "optional": true
         }
       }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/nodemon": {
       "version": "2.0.20",
@@ -2080,6 +5715,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2111,6 +5767,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2119,6 +5776,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -2133,6 +5791,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2141,6 +5800,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -2157,6 +5817,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2191,6 +5852,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/packet-reader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
@@ -2200,11 +5912,30 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -2215,10 +5946,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2227,9 +5968,16 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
@@ -2310,6 +6058,12 @@
         "split2": "^3.1.1"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2319,6 +6073,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/postgres-array": {
@@ -2360,16 +6135,45 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/proxy-addr": {
@@ -2393,9 +6197,26 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/qs": {
       "version": "6.11.0",
@@ -2433,6 +6254,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -2458,22 +6285,81 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true,
       "engines": {
         "node": ">=6.5.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -2486,6 +6372,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -2494,6 +6381,7 @@
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -2504,7 +6392,8 @@
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -2593,6 +6482,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
       },
@@ -2604,6 +6494,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2624,7 +6515,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/simple-update-notifier": {
       "version": "1.0.7",
@@ -2645,6 +6537,40 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -2656,7 +6582,29 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -2693,10 +6641,24 @@
         }
       ]
     },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2706,10 +6668,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2717,21 +6680,29 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -2750,10 +6721,23 @@
         "node": ">=4"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
       "dependencies": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -2768,6 +6752,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
       "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2776,6 +6761,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2787,6 +6773,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2795,6 +6782,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -2802,17 +6790,20 @@
     "node_modules/table/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "node_modules/table/node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
     },
     "node_modules/table/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2821,6 +6812,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
@@ -2834,6 +6826,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -2847,6 +6840,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -2854,25 +6848,68 @@
         "node": ">=6"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -2913,6 +6950,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -2920,10 +6958,20 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2956,10 +7004,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -2980,7 +7059,22 @@
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/vali-date": {
       "version": "1.0.0",
@@ -2996,6 +7090,15 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "dependencies": {
+        "makeerror": "1.0.12"
       }
     },
     "node_modules/webidl-conversions": {
@@ -3016,6 +7119,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -3027,24 +7131,72 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
       "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/write": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
       "dependencies": {
         "mkdirp": "^0.5.1"
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/ws": {
@@ -3083,6 +7235,60 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "3.11.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
@@ -3093,28 +7299,384 @@
     }
   },
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+    "@ampproject/remapping": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
+      "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+      "dev": true,
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@babel/code-frame": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.23.4",
+        "chalk": "^2.4.2"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
+      "integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-compilation-targets": "^7.23.6",
+        "@babel/helper-module-transforms": "^7.23.3",
+        "@babel/helpers": "^7.23.6",
+        "@babel/parser": "^7.23.6",
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.23.6",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.23.5",
+        "@babel/helper-validator-option": "^7.23.5",
+        "browserslist": "^4.22.2",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
+      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.15"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-module-imports": "^7.22.15",
+        "@babel/helper-simple-access": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/helper-validator-identifier": "^7.22.20"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+      "dev": true
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.22.5"
+      }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
+      "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
+      "integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.22.15",
+        "@babel/traverse": "^7.23.6",
+        "@babel/types": "^7.23.6"
+      }
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
+      "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@babel/parser": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.22.5"
+      }
+    },
+    "@babel/template": {
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
+      "integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@discordjs/builders": {
       "version": "0.8.1",
@@ -3170,6 +7732,472 @@
         }
       }
     },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      }
+    },
+    "@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "dev": true,
+      "requires": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.6.3"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.27.8"
+      }
+    },
+    "@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      }
+    },
+    "@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.20",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "@sapphire/async-queue": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
@@ -3180,10 +8208,108 @@
       "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-1.3.6.tgz",
       "integrity": "sha512-QnzuLp+p9D7agynVub/zqlDVriDza9y3STArBhNiNBUgIX8+GL5FpQxstRfw1jDr5jkZUjcuKYAHxjIuXKdJAg=="
     },
+    "@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
       "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+    },
+    "@sinonjs/commons": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.0.tgz",
+      "integrity": "sha512-jXBtWAF4vmdNmZgD5FoKsVLv3rPgDnLgPbU84LIJ3otV44vJlDRokVng5v8NFJdCf/da9legHcKaRuZs4L7faA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.7",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
+      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.20.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
+      "integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
     },
     "@types/node": {
       "version": "16.11.6",
@@ -3199,6 +8325,12 @@
         "form-data": "^3.0.0"
       }
     },
+    "@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
@@ -3206,6 +8338,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/yargs": {
+      "version": "17.0.32",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
@@ -3233,18 +8380,21 @@
       "version": "8.8.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
       "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
       "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
       "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3256,6 +8406,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
       "requires": {
         "type-fest": "^0.21.3"
       }
@@ -3263,12 +8414,29 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -3282,6 +8450,133 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "dependencies": {
+        "istanbul-lib-instrument": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+          "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.12.3",
+            "@babel/parser": "^7.14.7",
+            "@istanbuljs/schema": "^0.1.2",
+            "istanbul-lib-coverage": "^3.2.0",
+            "semver": "^6.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
+      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -3354,6 +8649,41 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001565",
+        "electron-to-chromium": "^1.4.601",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
+      "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "buffer-writer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
@@ -3378,15 +8708,28 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
       "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
+    "caniuse-lite": {
+      "version": "1.0.30001570",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
+      "integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3397,6 +8740,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -3405,6 +8749,7 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -3412,14 +8757,22 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         }
       }
+    },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
     },
     "chokidar": {
       "version": "3.5.3",
@@ -3436,35 +8789,10 @@
         "readdirp": "~3.6.0"
       },
       "dependencies": {
-        "anymatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-          "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
         "binary-extensions": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
           "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-        },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
         },
         "is-binary-path": {
           "version": "2.1.0",
@@ -3474,11 +8802,6 @@
             "binary-extensions": "^2.0.0"
           }
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
         "readdirp": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3486,21 +8809,26 @@
           "requires": {
             "picomatch": "^2.2.1"
           }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
         }
       }
+    },
+    "ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
@@ -3508,12 +8836,37 @@
     "cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+      "dev": true
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "dev": true
     },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -3521,7 +8874,8 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3561,6 +8915,12 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
+    "convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
     "cookie": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
@@ -3580,10 +8940,62 @@
         "vary": "^1"
       }
     },
+    "create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -3606,6 +9018,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       },
@@ -3613,14 +9026,29 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "requires": {}
     },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -3636,6 +9064,18 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg=="
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true
     },
     "discord-api-types": {
       "version": "0.24.0",
@@ -3696,6 +9136,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
       "requires": {
         "esutils": "^2.0.2"
       }
@@ -3723,15 +9164,43 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "electron-to-chromium": {
+      "version": "1.4.611",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.611.tgz",
+      "integrity": "sha512-ZtRpDxrjHapOwxtv+nuth5ByB8clyn8crVynmRNGO3wG3LOp8RTcyZDqwaI6Ng6y8FCK2hVZmJoqwCskKbNMaw==",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3741,12 +9210,14 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
       "integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",
@@ -3790,12 +9261,14 @@
         "ansi-regex": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
         },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
           "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
           }
@@ -3803,12 +9276,14 @@
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -3816,7 +9291,8 @@
         "type-fest": {
           "version": "0.8.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
         }
       }
     },
@@ -3824,6 +9300,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -3833,6 +9310,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -3840,12 +9318,14 @@
     "eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+      "dev": true
     },
     "espree": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
       "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
+      "dev": true,
       "requires": {
         "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
@@ -3855,19 +9335,22 @@
         "acorn": {
           "version": "7.4.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
         }
       }
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
       "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
       },
@@ -3875,7 +9358,8 @@
         "estraverse": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
         }
       }
     },
@@ -3883,6 +9367,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
       "requires": {
         "estraverse": "^5.2.0"
       },
@@ -3890,19 +9375,22 @@
         "estraverse": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
         }
       }
     },
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -3913,6 +9401,85 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true
+    },
+    "expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
+      "requires": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
     },
     "expect-ct": {
       "version": "0.2.0",
@@ -4025,6 +9592,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
       "requires": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -4034,17 +9602,29 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fb-watchman": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
+      "integrity": "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
     },
     "feature-policy": {
       "version": "0.3.0",
@@ -4055,6 +9635,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -4063,8 +9644,17 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
       }
     },
     "finalhandler": {
@@ -4096,10 +9686,21 @@
         }
       }
     },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
       "requires": {
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
@@ -4110,6 +9711,7 @@
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -4119,7 +9721,8 @@
     "flatted": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
+      "dev": true
     },
     "form-data": {
       "version": "3.0.1",
@@ -4149,7 +9752,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
@@ -4158,14 +9762,27 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -4177,10 +9794,23 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true
+    },
     "glob": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4197,6 +9827,18 @@
       "requires": {
         "is-glob": "^4.0.1"
       }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -4215,6 +9857,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
       "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "helmet": {
       "version": "3.21.3",
@@ -4286,6 +9937,12 @@
         }
       }
     },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4310,6 +9967,12 @@
         }
       }
     },
+    "human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4326,26 +9989,40 @@
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
       }
     },
+    "import-local": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4360,6 +10037,7 @@
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
       "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+      "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.0",
@@ -4380,6 +10058,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -4388,6 +10067,7 @@
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -4396,12 +10076,14 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -4413,6 +10095,21 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
+      "dev": true,
+      "requires": {
+        "hasown": "^2.0.0"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4421,7 +10118,14 @@
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -4431,58 +10135,1226 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      }
+    },
+    "jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      }
+    },
+    "jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "dev": true,
+      "requires": {}
+    },
+    "jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      }
+    },
+    "jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "jest-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
     },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
+    "makeerror": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
+      "integrity": "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.5"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -4494,10 +11366,26 @@
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -4528,12 +11416,14 @@
     "minimist": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -4546,12 +11436,14 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.3",
@@ -4561,7 +11453,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "nocache": {
       "version": "2.1.0",
@@ -4575,6 +11468,18 @@
       "requires": {
         "whatwg-url": "^5.0.0"
       }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "nodemon": {
       "version": "2.0.20",
@@ -4621,6 +11526,23 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        }
+      }
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4643,6 +11565,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4651,6 +11574,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       },
@@ -4658,7 +11582,8 @@
         "mimic-fn": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
         }
       }
     },
@@ -4666,6 +11591,7 @@
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -4678,7 +11604,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "ow": {
       "version": "0.28.1",
@@ -4700,6 +11627,41 @@
         }
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
     "packet-reader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
@@ -4709,8 +11671,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
       "requires": {
         "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parseurl": {
@@ -4718,15 +11693,29 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
@@ -4790,10 +11779,31 @@
         "split2": "^3.1.1"
       }
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
     },
     "postgres-array": {
       "version": "2.0.0",
@@ -4821,12 +11831,35 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      }
     },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -4845,7 +11878,14 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
+      "dev": true
     },
     "qs": {
       "version": "6.11.0",
@@ -4871,6 +11911,12 @@
         "unpipe": "1.0.0"
       }
     },
+    "react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
+      "dev": true
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -4889,17 +11935,60 @@
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
-      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true
     },
     "restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -4908,12 +11997,14 @@
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       },
@@ -4921,7 +12012,8 @@
         "tslib": {
           "version": "1.14.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
         }
       }
     },
@@ -5004,6 +12096,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -5011,7 +12104,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "side-channel": {
       "version": "1.0.4",
@@ -5026,7 +12120,8 @@
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "simple-update-notifier": {
       "version": "1.0.7",
@@ -5043,6 +12138,34 @@
         }
       }
     },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "split2": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
@@ -5054,7 +12177,25 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        }
+      }
     },
     "statuses": {
       "version": "1.5.0",
@@ -5076,38 +12217,53 @@
         }
       }
     },
+    "string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
@@ -5117,10 +12273,17 @@
         "has-flag": "^3.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "table": {
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
       "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "dev": true,
       "requires": {
         "ajv": "^6.10.2",
         "lodash": "^4.17.14",
@@ -5131,12 +12294,14 @@
         "ansi-regex": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g=="
+          "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -5144,12 +12309,14 @@
         "astral-regex": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
+          "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+          "dev": true
         },
         "color-convert": {
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -5157,22 +12324,26 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "slice-ansi": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
           "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "astral-regex": "^1.0.0",
@@ -5183,6 +12354,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -5193,28 +12365,63 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
         }
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmpl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
@@ -5249,14 +12456,22 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -5277,10 +12492,21 @@
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
+    "update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -5298,7 +12524,19 @@
     "v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA=="
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+      "dev": true
+    },
+    "v8-to-istanbul": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      }
     },
     "vali-date": {
       "version": "1.0.0",
@@ -5309,6 +12547,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "walker": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
+      "integrity": "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.12"
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",
@@ -5328,6 +12575,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5335,19 +12583,54 @@
     "word-wrap": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
-      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA=="
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
       "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
       }
     },
     "ws": {
@@ -5365,6 +12648,45 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "zod": {
       "version": "3.11.6",

--- a/package.json
+++ b/package.json
@@ -12,16 +12,22 @@
     "discord-api-types": "0.24.0",
     "discord.js": "13.5.0",
     "dotenv": "8.0.0",
-    "eslint": "6.8.0",
     "express": "4.17.3",
     "helmet": "3.21.3",
     "nodemon": "^2.0.20",
     "pg": "8.5.1"
   },
+  "devDependencies": {
+    "eslint": "6.8.0",
+    "jest": "29.7.0"
+  },
   "scripts": {
     "start": "node server/index.js",
     "api": "nodemon server/index.js",
-    "bot": "nodemon bot/index.js"
+    "bot": "nodemon bot/index.js",
+    "test": "jest",
+    "test:updateSnapshots": "jest --updateSnapshot",
+    "test:watch": "jest --watch"
   },
   "keywords": [],
   "author": "jd (alphaSeahorse)",


### PR DESCRIPTION
Cover all possible fight scenarios with WA and DE. My end goal with the simpleCalc tests is to cover all scenarios between units with different attack and defense.

You can read more about snapshot testing with Jest here: https://jestjs.io/docs/snapshot-testing Snapshot testing is a good way to detect changes to calculator results when the code is changed.