### PR TITLE
Fix calculations with more than 1 attacker

### DIFF
--- a/bot/tests/calcRegressions.test.js
+++ b/bot/tests/calcRegressions.test.js
@@ -2,34 +2,41 @@ const { expect, test } = require('@jest/globals');
 const { execute } = require('../commands/calc.js');
 const { replyData } = require('./simpleCalc/utils.js');
 
-test('de 1, v ri 2', () => {
+test('de 1, v ri 2', async () => {
   const reply = replyData();
-  execute({}, 'de 1, v ri 2', reply, {});
+  await execute({}, 'de 1, v ri 2', reply, {});
   expect(reply.outcome.attackers[0].afterhp).toBe(0);
   expect(reply.outcome.defender.afterhp).toBe(1);
 });
 
-test('de 6, ri 8', () => {
+test('de 6, ri 8', async () => {
   const reply = replyData();
-  execute({}, 'de 6, ri 8', reply, {});
+  await execute({}, 'de 6, ri 8', reply, {});
   expect(reply.outcome.attackers[0].afterhp).toBe(3);
   expect(reply.outcome.defender.afterhp).toBe(6);
 });
 
-// TODO: fix this
-test.skip('dr s, ri 8', () => {
+test('wa, wa, wa', async () => {
   const reply = replyData();
-  execute({}, 'dr s, ri 8', reply, {});
-  expect(reply.outcome.attackers[0].afterhp).toBe(20);
-  expect(reply.outcome.defender.afterhp).toBe(0);
+  await execute({}, 'wa, wa, wa', reply, {});
+  expect(reply.outcome.attackers[0].afterhp).toBe(5);
+  expect(reply.outcome.attackers[1].afterhp).toBe(10);
+  expect(reply.outcome.defender.afterhp).toBe(-1);
 });
 
-test('ca, de, wa, de d', () => {
+test('ca, de, wa, de d', async () => {
   const reply = replyData();
-  execute({}, 'ca, de, wa, de d', reply, {});
+  await execute({}, 'ca, de, wa, de d', reply, {});
   expect(reply.outcome.attackers[0].afterhp).toBe(10);
-  expect(reply.outcome.attackers[1].afterhp).toBe(4);
-  expect(reply.outcome.attackers[2].afterhp).toBe(1);
-  expect(reply.outcome.defender.afterhp).toBe(3);
+  expect(reply.outcome.attackers[1].afterhp).toBe(6);
+  expect(reply.outcome.attackers[2].afterhp).toBe(4);
+  expect(reply.outcome.defender.afterhp).toBe(1);
 });
 
+test('gi 31, wa 10, gi 40', async () => {
+  const reply = replyData();
+  await execute({}, 'gi 31, wa 10, gi 40', reply, {});
+  expect(reply.outcome.attackers[0].afterhp).toBe(22);
+  expect(reply.outcome.attackers[1].afterhp).toBe(0);
+  expect(reply.outcome.defender.afterhp).toBe(25);
+});

--- a/bot/tests/optim.test.js
+++ b/bot/tests/optim.test.js
@@ -1,6 +1,10 @@
 const { expect, test } = require('@jest/globals');
 const { execute } = require('../commands/optim.js');
 const { replyData } = require('./commandUtils.js');
+const deadTexts = require('../util/deadtexts.js');
+
+deadTexts.length = 1;
+deadTexts[0] = 'DEAD';
 
 test('/o attackers: ca, de, wa defender: de d', () => {
   const reply = replyData();
@@ -15,14 +19,14 @@ test('/o attackers: ca, de, wa defender: de d', () => {
         {
           name: 'Attacker: startHP ➔ endHP (enemyHP)',
           value: [
-            'Catapult: 10 ➔ 10 (**7**)',
-            'Defender: 15 ➔ 4 (**6**)',
-            'Warrior: 10 ➔ 1 (**3**)',
+            'Defender: 15 ➔ 4 (**14**)',
+            'Catapult: 10 ➔ 10 (**5**)',
+            'Warrior: 10 ➔ 10 (**0**)',
           ],
         },
         {
           name: '**Defender (protected)**:',
-          value: '15 ➔ 3',
+          value: '15 ➔ DEAD',
         },
       ],
       footer: undefined,
@@ -30,35 +34,35 @@ test('/o attackers: ca, de, wa defender: de d', () => {
     outcome: {
       attackers: [
         {
-          name: 'Catapult',
-          afterhp: 10,
-          beforehp: 10,
-          hpdefender: 7,
-          hplost: 0,
-          maxhp: 10,
-        },
-        {
           name: 'Defender',
           afterhp: 4,
           beforehp: 15,
-          hpdefender: 6,
+          hpdefender: 14,
           hplost: 11,
           maxhp: 15,
         },
         {
-          name: 'Warrior',
-          afterhp: 1,
+          name: 'Catapult',
+          afterhp: 10,
           beforehp: 10,
-          hpdefender: 3,
-          hplost: 9,
+          hpdefender: 5,
+          hplost: 0,
+          maxhp: 10,
+        },
+        {
+          name: 'Warrior',
+          afterhp: 10,
+          beforehp: 10,
+          hpdefender: 0,
+          hplost: 0,
           maxhp: 10,
         },
       ],
       defender: {
         name: 'Defender (protected)',
-        afterhp: 3,
+        afterhp: 0,
         currenthp: 15,
-        hplost: 12,
+        hplost: 15,
         maxhp: 15,
       },
     },
@@ -80,12 +84,12 @@ test('/o attackers: ca f, de, wa defender: de d', () => {
           value: [
             'Defender: 15 ➔ 4 (**14**)',
             'Warrior: 10 ➔ 1 (**11**)',
-            'Catapult: 10 ➔ 10 (**3**)',
+            'Catapult: 10 ➔ 10 (**1**)',
           ],
         },
         {
           name: '**Defender (protected)**:',
-          value: '15 ➔ 3',
+          value: '15 ➔ 1',
         },
       ],
       footer: undefined,
@@ -112,16 +116,16 @@ test('/o attackers: ca f, de, wa defender: de d', () => {
           name: 'Catapult',
           afterhp: 10,
           beforehp: 10,
-          hpdefender: 3,
+          hpdefender: 1,
           hplost: 0,
           maxhp: 10,
         },
       ],
       defender: {
         name: 'Defender (protected)',
-        afterhp: 3,
+        afterhp: 1,
         currenthp: 15,
-        hplost: 12,
+        hplost: 14,
         maxhp: 15,
       },
     },

--- a/bot/tests/simpleCalc/utils.js
+++ b/bot/tests/simpleCalc/utils.js
@@ -89,9 +89,9 @@ const defenders = ['ca', 'de', 'dr', 'ga', 'gi', 'po', 'ri', 'wa'];
 const runTestSuite = (attacker) => {
   defenders.forEach((defender) => {
     generateTestSuite(attacker, defender).forEach((cmd) => {
-      test(cmd, () => {
+      test(cmd, async () => {
         const reply = replyData();
-        execute({}, cmd, reply, {});
+        await execute({}, cmd, reply, {});
         const result = {
           _cmd: cmd, // use underscore to put it on top of the snapshot
           attacker: Math.max(reply.outcome.attackers[0].afterhp, 0),

--- a/bot/util/sequencer.js
+++ b/bot/util/sequencer.js
@@ -107,7 +107,7 @@ module.exports.multicombat = function (attackers, defender, sequence) {
 
 function combat(attacker, defender, solution) {
   const aforce = attacker.iAtt * attacker.iCurrentHp * 100n / attacker.iMaxHp;
-  const dforce = defender.iDef * defender.iCurrentHp * 100n / defender.iMaxHp;
+  const dforce = defender.iDef * BigInt(solution.defenderHP * 10) * 100n / defender.iMaxHp;
 
   const totaldam = aforce + dforce;
   let defdiff = Number(attackerCalc(aforce, totaldam, attacker));


### PR DESCRIPTION
Fix a regression caused by previous changes. We were not properly taking into account damage to defenders by previous attackers.
Made `calc` tests async as execute returns a `Promise`.