### PR TITLE
Fix multi-axi HP tracking and floor poisoned defense bonus

### DIFF
--- a/bot/unit/unit.js
+++ b/bot/unit/unit.js
@@ -125,7 +125,7 @@ module.exports = function buildMakeUnit() {
             poisonexplosion: poisonexplosion,
             selfPoison: function () {
                 if (!this.poisoned) {
-                    this.bonus *= 0.5
+                    this.bonus = Math.floor(this.bonus * 5) / 10
                     this.poisoned = true
                 }
             },
@@ -135,7 +135,7 @@ module.exports = function buildMakeUnit() {
                     (this.poisonexplosion && this.exploding)
                 ) {
                     if (!defender.poisoned) {
-                        defender.bonus *= 0.5
+                        defender.bonus = Math.floor(defender.bonus * 5) / 10
                         defender.poisoned = true
                     }
                 } else

--- a/bot/util/fightEngine.js
+++ b/bot/util/fightEngine.js
@@ -10,9 +10,10 @@ const {
 } = require('./sequencer')
 
 function getDefenderBonusLabel(defender) {
-    const baseBonus = defender.poisoned ? defender.bonus * 2 : defender.bonus
-    const baseLabel =
-        { 1: '', 1.5: ' (protected)', 4: ' (walled)' }[baseBonus] || ''
+    const labels = defender.poisoned
+        ? { 0.5: '', 0.7: ' (protected)', 2: ' (walled)' }
+        : { 1: '', 1.5: ' (protected)', 4: ' (walled)' }
+    const baseLabel = labels[defender.bonus] || ''
     return baseLabel + (defender.poisoned ? ' (poisoned)' : '')
 }
 
@@ -159,7 +160,7 @@ module.exports.optim = function (attackers, defender, replyData, target) {
     }
 
     if (bestSolution.wasPoisoned && !defender.poisoned) {
-        defender.bonus *= 0.5
+        defender.bonus = Math.floor(defender.bonus * 5) / 10
         defender.poisoned = true
     }
 
@@ -284,7 +285,7 @@ module.exports.calc = function (attackers, defender, replyData) {
     const solution = multicombat(attackersSorted, defender, sequence)
 
     if (solution.wasPoisoned && !defender.poisoned) {
-        defender.bonus *= 0.5
+        defender.bonus = Math.floor(defender.bonus * 5) / 10
         defender.poisoned = true
     }
 
@@ -392,7 +393,7 @@ module.exports.bulk = function (attacker, defender, replyData) {
             (attacker.poisonexplosion && attacker.exploding)
         ) {
             if (!defender.poisoned) {
-                defender.bonus *= 0.5
+                defender.bonus = Math.floor(defender.bonus * 5) / 10
                 defender.poisoned = true
             }
         }

--- a/bot/util/fightEngine.js
+++ b/bot/util/fightEngine.js
@@ -264,7 +264,7 @@ module.exports.calc = function (attackers, defender, replyData) {
             clone.attackExplode = false
             clone.instantExplode = false
             clone.description = `${clone.description} 💥`
-            clone._hitPairIndex = i
+            clone._hitPairIndex = expandedAttackers.length - 1
             expandedAttackers.push(clone)
         }
     }

--- a/bot/util/util.js
+++ b/bot/util/util.js
@@ -42,7 +42,7 @@ module.exports.buildEmbed = function (data) {
 
 module.exports.poison = function (unit) {
     if (!unit.poisoned) {
-        unit.bonus *= 0.5
+        unit.bonus = Math.floor(unit.bonus * 5) / 10
         unit.poisoned = true
     }
 }


### PR DESCRIPTION
## Summary
- Fix `_hitPairIndex` in `calc()`: explode clones inserted inline were indexing the original attackers array, so scenarios with multiple `ax`/`axi` attackers used the wrong hit's retaliation damage to compute the clone's effective HP. This affected both the display and the simulation.
- Floor poisoned defense bonus to 1 decimal to match in-game rounding: protected `1.5 → 0.7` (was `0.75`), walled `4 → 2`, unfortified `1 → 0.5`.

## Repro for the axi bug
`.c bm x, do axi, do axi, gi 34.5 d`

Before: second Doomux 💥 displayed as `7 → 0` and simulated with 7 HP, despite the hit ending at 15 HP.
After: second Doomux 💥 displays and simulates with the correct 15 HP.

## Repro for the poison rounding
Same scenario matches in-game outcome (Giant dies) only when poisoned bonus is floored to 0.7. With the prior `0.75`, the calc left the Giant at 1 HP.

## Test plan
- [x] `npx jest` — all 1,656,025 tests pass locally
- [ ] Verify `/c` and `/o` outputs in Discord
- [ ] Verify poisoned `Warrior d` scenario (1.5 → 0.7) matches game
- [ ] Verify non-poisoned and walled outputs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)