### PR TITLE
Fix Ice Archer freeze: prevent retaliation and duplicate label

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 /server/public
+.claude/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 package-lock.json
 /server/public
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,35 @@
+# PolyCalculator
+
+Discord bot and CLI calculator for The Battle of Polytopia combat.
+
+## Commands
+
+- `.c` (calc) — fixed-order combat calculation. Attackers fight in the order given.
+- `.o` (optim) — optimizer. Tries all attacker permutations to find the best sequence.
+- `.b` (bulk) — how many hits of one unit to kill another.
+- `.e` (elim) — minimum attacker HP to kill, or max defender HP that dies.
+
+## Architecture
+
+- `bot/util/sequencer.js` — core `multicombat()` loop. Runs combat for each attacker in sequence, applies effects (poison, freeze, convert), then **resets defender state** so the next sequence evaluation starts clean.
+- `bot/util/fightEngine.js` — `calc()` (single sequence) and `optim()` (all permutations). After finding the best solution, re-applies effects (poison, freeze) to the defender for display.
+- `bot/util/util.js` — effect functions: `poison()`, `freeze()`, `convert()`, `boost()`. Each uses a guard flag (`poisoned`, `frozen`, `converted`) to prevent duplicate application within a single sequence.
+- `bot/unit/unit.js` — unit factory with stats, modifiers, and methods.
+
+## Testing changes
+
+When modifying combat logic (sequencer, fightEngine, util), always verify against **both** `.c` and `.o` paths:
+
+- `.c` calls `multicombat()` once with a fixed sequence
+- `.o` calls `multicombat()` many times across all permutations with the same defender object — state leaks between calls will cause bugs (duplicate labels, wrong retaliation, corrupted bonuses)
+
+Run the full test suite: `npm test`
+
+Snapshot tests in `bot/tests/simpleCalc/` cover all unit matchups at every HP via `.c`.
+Integration tests in `bot/tests/optim.test.js` cover `.o` scenarios.
+
+To run locally: `npm run bot` (requires `.env` with bot token).
+
+## Key invariant
+
+In `multicombat()`, any defender state mutated during the attacker loop **must** be saved before the loop and restored after it. Currently saved/restored: `bonus`, `poisoned`, `retaliation`, `frozen`, `description`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,24 +4,31 @@ Discord bot and CLI calculator for The Battle of Polytopia combat.
 
 ## Commands
 
-- `.c` (calc) — fixed-order combat calculation. Attackers fight in the order given.
-- `.o` (optim) — optimizer. Tries all attacker permutations to find the best sequence.
-- `.b` (bulk) — how many hits of one unit to kill another.
-- `.e` (elim) — minimum attacker HP to kill, or max defender HP that dies.
+-   `.c` (calc) — fixed-order combat calculation. Attackers fight in the order given.
+-   `.o` (optim) — optimizer. Tries all attacker permutations to find the best sequence.
+-   `.b` (bulk) — how many hits of one unit to kill another.
+-   `.e` (elim) — minimum attacker HP to kill, or max defender HP that dies.
 
 ## Architecture
 
-- `bot/util/sequencer.js` — core `multicombat()` loop. Runs combat for each attacker in sequence, applies effects (poison, freeze, convert), then **resets defender state** so the next sequence evaluation starts clean.
-- `bot/util/fightEngine.js` — `calc()` (single sequence) and `optim()` (all permutations). After finding the best solution, re-applies effects (poison, freeze) to the defender for display.
-- `bot/util/util.js` — effect functions: `poison()`, `freeze()`, `convert()`, `boost()`. Each uses a guard flag (`poisoned`, `frozen`, `converted`) to prevent duplicate application within a single sequence.
-- `bot/unit/unit.js` — unit factory with stats, modifiers, and methods.
+-   `bot/util/sequencer.js` — core `multicombat()` loop. Runs combat for each attacker in sequence, applies effects (poison, freeze, convert), then **resets defender state** so the next sequence evaluation starts clean.
+-   `bot/util/fightEngine.js` — `calc()` (single sequence) and `optim()` (all permutations). After finding the best solution, re-applies effects (poison, freeze) to the defender for display.
+-   `bot/util/util.js` — effect functions: `poison()`, `freeze()`, `convert()`, `boost()`. Each uses a guard flag (`poisoned`, `frozen`, `converted`) to prevent duplicate application within a single sequence.
+-   `bot/unit/unit.js` — unit factory with stats, modifiers, and methods.
+
+## Linting
+
+Run `npm run lint` before opening a PR. This runs ESLint then Prettier.
+To auto-fix formatting: `npx prettier --write .`
+
+After pushing a PR, **always verify GitHub CI passes** — local lint passing is not enough. Check with `gh pr checks <PR#>`. CI runs lint on shard 1; if lint fails, all other test shards are canceled. If checks fail, inspect with `gh run view <run-id> --log-failed`, fix, commit, and push again until CI is green.
 
 ## Testing changes
 
 When modifying combat logic (sequencer, fightEngine, util), always verify against **both** `.c` and `.o` paths:
 
-- `.c` calls `multicombat()` once with a fixed sequence
-- `.o` calls `multicombat()` many times across all permutations with the same defender object — state leaks between calls will cause bugs (duplicate labels, wrong retaliation, corrupted bonuses)
+-   `.c` calls `multicombat()` once with a fixed sequence
+-   `.o` calls `multicombat()` many times across all permutations with the same defender object — state leaks between calls will cause bugs (duplicate labels, wrong retaliation, corrupted bonuses)
 
 Run the full test suite: `npm test`
 

--- a/bot/util/fightEngine.js
+++ b/bot/util/fightEngine.js
@@ -164,6 +164,12 @@ module.exports.optim = function (attackers, defender, replyData, target) {
         defender.poisoned = true
     }
 
+    if (bestSolution.wasFrozen && !defender.frozen) {
+        defender.description = `${defender.description} (frozen)`
+        defender.retaliation = false
+        defender.frozen = true
+    }
+
     // if (bestSolution.defenderHP === defender.currenthp)
     //   throw `No unit can make a dent in this ${defender.name}${defender.description}...`
 
@@ -287,6 +293,12 @@ module.exports.calc = function (attackers, defender, replyData) {
     if (solution.wasPoisoned && !defender.poisoned) {
         defender.bonus = Math.floor(defender.bonus * 5) / 10
         defender.poisoned = true
+    }
+
+    if (solution.wasFrozen && !defender.frozen) {
+        defender.description = `${defender.description} (frozen)`
+        defender.retaliation = false
+        defender.frozen = true
     }
 
     // if (solution.defenderHP === defender.currenthp)

--- a/bot/util/sequencer.js
+++ b/bot/util/sequencer.js
@@ -66,10 +66,14 @@ module.exports.multicombat = function (attackers, defender, sequence) {
         sequence: sequence,
         finalSequence: [],
         wasPoisoned: false,
+        wasFrozen: false,
     }
 
     const initialBonus = defender.bonus
     const initialPoisoned = defender.poisoned || false
+    const initialRetaliation = defender.retaliation
+    const initialFrozen = defender.frozen || false
+    const initialDescription = defender.description
 
     for (const attacker of attackers) {
         if (attacker.convert) convert(defender)
@@ -114,11 +118,17 @@ module.exports.multicombat = function (attackers, defender, sequence) {
             solution.wasPoisoned = true
         }
 
-        if (attacker.freeze) freeze(defender)
+        if (attacker.freeze) {
+            freeze(defender)
+            solution.wasFrozen = true
+        }
     }
 
     defender.bonus = initialBonus
     defender.poisoned = initialPoisoned
+    defender.retaliation = initialRetaliation
+    defender.frozen = initialFrozen
+    defender.description = initialDescription
 
     return solution
 }

--- a/bot/util/util.js
+++ b/bot/util/util.js
@@ -48,8 +48,11 @@ module.exports.poison = function (unit) {
 }
 
 module.exports.freeze = function (unit) {
-    unit.description = `${unit.description} (frozen)`
-    unit.retaliation = false
+    if (!unit.frozen) {
+        unit.description = `${unit.description} (frozen)`
+        unit.retaliation = false
+        unit.frozen = true
+    }
 }
 
 module.exports.boost = function (unit) {


### PR DESCRIPTION
## Summary
- Frozen units no longer retaliate, and the `(frozen)` label appears only once on the defender
- Root cause: `multicombat()` reset `bonus` and `poisoned` between sequence evaluations but not `retaliation`, `frozen`, or `description` — so freeze state leaked across all permutations in `.o`
- `freeze()` now guards on `unit.frozen` (mirrors the `poisoned` guard in `poison()`); `multicombat()` saves/restores the full freeze-related state; `calc()` and `optim()` re-apply freeze post-evaluation for display, matching the existing `wasPoisoned` pattern
- Adds a CLAUDE.md noting that combat-engine changes must be verified against both `.c` and `.o` paths

## Test plan
- [x] `npm test` — all 76 suites / 2,577,657 tests pass
- [ ] `.c ia, wa` — defender shows `(frozen)` once
- [ ] `.o ia, wa, wa` — frozen defender doesn't retaliate against later attackers; `(frozen)` appears once
- [ ] `.o` with multiple Ice Archers — single `(frozen)` label